### PR TITLE
Remove one pod

### DIFF
--- a/client/src/app/+admin/friends/friend-list/friend-list.component.html
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.html
@@ -2,7 +2,7 @@
   <div class="content-padding">
     <h3>Friends list</h3>
 
-    <ng2-smart-table [settings]="tableSettings" [source]="friendsSource"></ng2-smart-table>
+    <ng2-smart-table [settings]="tableSettings" [source]="friendsSource" (delete)="removeFriend($event)"></ng2-smart-table>
 
     <a *ngIf="hasFriends()" class="btn btn-danger pull-left" (click)="quitFriends()">
       Quit friends

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -71,8 +71,7 @@ export class FriendListComponent {
 
         this.friendService.quitFriends().subscribe(
           status => {
-            this.notificationsService.success('Sucess', 'Friends left!')
-
+            this.notificationsService.success('Success', 'Friends left!');
             this.friendsSource.refresh()
           },
 

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -68,15 +68,15 @@ export class FriendListComponent {
     return this.friendsSource.count() !== 0
   }
 
-  quitFriends() {
-    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.';
+  quitFriends () {
+    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.'
     this.confirmService.confirm(confirmMessage, 'Quit friends').subscribe(
       res => {
         if (res === false) return
 
         this.friendService.quitFriends().subscribe(
           status => {
-            this.notificationsService.success('Success', 'Friends left!');
+            this.notificationsService.success('Success', 'Friends left!')
             this.friendsSource.refresh()
           },
 
@@ -86,24 +86,24 @@ export class FriendListComponent {
     )
   }
 
-  removeFriend({ data }) {
-    const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.';
-    const friend: Pod = data;
+  removeFriend ({ data }) {
+    const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.'
+    const friend: Pod = data
 
     this.confirmService.confirm(confirmMessage, 'Remove').subscribe(
       res => {
-	if (res === false) return;
+        if (res === false) return
 
-	this.friendService.removeFriend(friend).subscribe(
+        this.friendService.removeFriend(friend).subscribe(
 	  status => {
-	    this.notificationsService.success('Success', 'Friend removed');
+	    this.notificationsService.success('Success', 'Friend removed')
 
-	    this.friendsSource.refresh();
+	    this.friendsSource.refresh()
 	  },
 
 	  err => this.notificationsService.error('Error', err.text)
-	);
+	)
       }
-    );
+    )
   }
 }

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -15,6 +15,7 @@ import { FriendService } from '../shared'
 export class FriendListComponent {
   friendsSource = null
   tableSettings = {
+    mode: 'external',
     attr: {
       class: 'table-hover'
     },
@@ -23,7 +24,10 @@ export class FriendListComponent {
       position: 'right',
       add: false,
       edit: false,
-      delete: false
+      delete: true
+    },
+    delete: {
+      deleteButtonContent: Utils.getRowDeleteButton()
     },
     columns: {
       id: {
@@ -63,8 +67,8 @@ export class FriendListComponent {
     return this.friendsSource.count() !== 0
   }
 
-  quitFriends () {
-    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.'
+  quitFriends() {
+    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.';
     this.confirmService.confirm(confirmMessage, 'Quit friends').subscribe(
       res => {
         if (res === false) return
@@ -79,5 +83,26 @@ export class FriendListComponent {
         )
       }
     )
+  }
+
+  removeFriend({ data }) {
+    const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.';
+    const friend: Friend = data;
+
+    this.confirmService.confirm(confirmMessage, 'Remove').subscribe(
+      res => {
+	if (res === false) return;
+
+	this.friendService.removeFriend(friend).subscribe(
+	  status => {
+	    this.notificationsService.success('Success', 'Friend removed');
+
+	    this.friendsSource.refresh();
+	  },
+
+	  err => this.notificationsService.error('Error', err.text)
+	);
+      }
+    );
   }
 }

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -6,6 +6,7 @@ import { ServerDataSource } from 'ng2-smart-table'
 import { ConfirmService } from '../../../core'
 import { Utils } from '../../../shared'
 import { FriendService } from '../shared'
+import { Pod } from '../../../../../../shared'
 
 @Component({
   selector: 'my-friend-list',
@@ -87,7 +88,7 @@ export class FriendListComponent {
 
   removeFriend({ data }) {
     const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.';
-    const friend: Friend = data;
+    const friend: Pod = data;
 
     this.confirmService.confirm(confirmMessage, 'Remove').subscribe(
       res => {

--- a/client/src/app/+admin/friends/shared/friend.service.ts
+++ b/client/src/app/+admin/friends/shared/friend.service.ts
@@ -31,15 +31,15 @@ export class FriendService {
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  quitFriends() {
+  quitFriends () {
     return this.authHttp.get(FriendService.BASE_FRIEND_URL + 'quitfriends')
                         .map(res => res.status)
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  removeFriend(friend: Pod) {
+  removeFriend (friend: Pod) {
     return this.authHttp.delete(FriendService.BASE_FRIEND_URL + friend.id)
                         .map(this.restExtractor.extractDataBool)
-                        .catch((res) => this.restExtractor.handleError(res));
+                        .catch((res) => this.restExtractor.handleError(res))
   }
 }

--- a/client/src/app/+admin/friends/shared/friend.service.ts
+++ b/client/src/app/+admin/friends/shared/friend.service.ts
@@ -30,9 +30,15 @@ export class FriendService {
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  quitFriends () {
+  quitFriends() {
     return this.authHttp.get(FriendService.BASE_FRIEND_URL + 'quitfriends')
                         .map(res => res.status)
                         .catch((res) => this.restExtractor.handleError(res))
+  }
+
+  removeFriend(friend: Friend) {
+    return this.authHttp.delete(FriendService.BASE_FRIEND_URL + friend.id)
+                        .map(this.restExtractor.extractDataBool)
+                        .catch((res) => this.restExtractor.handleError(res));
   }
 }

--- a/client/src/app/+admin/friends/shared/friend.service.ts
+++ b/client/src/app/+admin/friends/shared/friend.service.ts
@@ -6,6 +6,7 @@ import 'rxjs/add/operator/map'
 import { ServerDataSource } from 'ng2-smart-table'
 
 import { AuthHttp, RestExtractor, RestDataSource, ResultList } from '../../../shared'
+import { Pod } from '../../../../../../shared'
 
 @Injectable()
 export class FriendService {
@@ -20,7 +21,7 @@ export class FriendService {
     return new RestDataSource(this.authHttp, FriendService.BASE_FRIEND_URL)
   }
 
-  makeFriends (notEmptyHosts) {
+  makeFriends (notEmptyHosts: String[]) {
     const body = {
       hosts: notEmptyHosts
     }
@@ -36,7 +37,7 @@ export class FriendService {
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  removeFriend(friend: Friend) {
+  removeFriend(friend: Pod) {
     return this.authHttp.delete(FriendService.BASE_FRIEND_URL + friend.id)
                         .map(this.restExtractor.extractDataBool)
                         .catch((res) => this.restExtractor.handleError(res));

--- a/server/controllers/api/pods.ts
+++ b/server/controllers/api/pods.ts
@@ -20,7 +20,8 @@ import {
   ensureIsAdmin,
   makeFriendsValidator,
   setBodyHostPort,
-  setBodyHostsPort
+  setBodyHostsPort,
+  podRemoveValidator
 } from '../../middlewares'
 import {
   PodInstance
@@ -49,6 +50,7 @@ podsRouter.get('/quitfriends',
 podsRouter.delete('/:id',
   authenticate,
   ensureIsAdmin,
+  podRemoveValidator,
   removeFriendController
 )
 
@@ -127,7 +129,7 @@ function quitFriendsController (req: express.Request, res: express.Response, nex
 }
 
 function removeFriendController (req: express.Request, res: express.Response, next: express.NextFunction) {
-  removeFriend(req.params.id, function (err) {
+  removeFriend(res.locals.pod, function (err) {
     if (err) return next(err)
 
     res.type('json').status(204).end()

--- a/server/controllers/api/pods.ts
+++ b/server/controllers/api/pods.ts
@@ -119,3 +119,11 @@ function quitFriendsController (req: express.Request, res: express.Response, nex
     res.type('json').status(204).end()
   })
 }
+
+function removeFriend (req, res, next) {
+  friends.removeFriend(req.params.id, function (err) {
+    if (err) return next(err)
+
+    res.type('json').status(204).end()
+  })
+}

--- a/server/controllers/api/pods.ts
+++ b/server/controllers/api/pods.ts
@@ -11,7 +11,8 @@ import {
 import {
   sendOwnedVideosToPod,
   makeFriends,
-  quitFriends
+  quitFriends,
+  removeFriend
 } from '../../lib'
 import {
   podsAddValidator,
@@ -44,6 +45,11 @@ podsRouter.get('/quitfriends',
   authenticate,
   ensureIsAdmin,
   quitFriendsController
+)
+podsRouter.delete('/:id',
+  authenticate,
+  ensureIsAdmin,
+  removeFriendController
 )
 
 // ---------------------------------------------------------------------------
@@ -120,8 +126,8 @@ function quitFriendsController (req: express.Request, res: express.Response, nex
   })
 }
 
-function removeFriend (req, res, next) {
-  friends.removeFriend(req.params.id, function (err) {
+function removeFriendController (req: express.Request, res: express.Response, next: express.NextFunction) {
+  removeFriend(req.params.id, function (err) {
     if (err) return next(err)
 
     res.type('json').status(204).end()

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -243,19 +243,19 @@ function removeFriend (pod: PodInstance, callback: (err: Error) => void) {
 
     function announceIQuitThisFriend (pod, callbackAsync) {
       const requestParams = {
-	method: 'POST' as 'POST',
-	path: '/api/' + API_VERSION + '/remote/pods/remove',
-	sign: true,
-	toPod: pod
+        method: 'POST' as 'POST',
+        path: '/api/' + API_VERSION + '/remote/pods/remove',
+        sign: true,
+        toPod: pod
       }
 
       makeSecureRequest(requestParams, function (err) {
-	if (err) {
+        if (err) {
           logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, { err: err })
           // Continue anyway
-	}
+        }
 
-	return callbackAsync(null, pod)
+        return callbackAsync(null, pod)
       })
     },
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -234,7 +234,7 @@ function quitFriends (callback: (err: Error) => void) {
   })
 }
 
-function removeFriend (pod, callback: (err: Error) => void) {
+function removeFriend (pod: PodInstance, callback: (err: Error) => void) {
   // Stop pool requests
   requestScheduler.deactivate()
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -234,7 +234,56 @@ function quitFriends (callback: (err: Error) => void) {
   })
 }
 
-function sendOwnedVideosToPod (podId: number) {
+function removeFriend (podId, callback) {
+  // Stop pool requests
+  requestScheduler.deactivate()
+
+  waterfall([
+    function flushRequests (callbackAsync) {
+      requestScheduler.flush(err => callbackAsync(err))
+    },
+
+    function flushVideoQaduRequests (callbackAsync) {
+      requestVideoQaduScheduler.flush(err => callbackAsync(err))
+    },
+
+    function getPod (callbackAsync) {
+      return db.Pod.load(podId, callbackAsync)
+    },
+
+    function announceIQuitMyFriends (pod, callbackAsync) {
+      const requestParams = {
+        method: 'POST',
+        path: '/api/' + constants.API_VERSION + '/remote/pods/remove',
+        sign: true
+      }
+
+      requestParams.toPod = pod
+      requests.makeSecureRequest(requestParams, function (err) {
+        if (err) {
+          logger.error('Some errors while quitting friend.', { err: err })
+          // Continue anyway
+        }
+
+        return callbackAsync(null, pod)
+      })
+    },
+
+    function removePodFromDB (pod, callbackAsync) {
+      pod.destroy().asCallback(callbackAsync)
+    }
+  ], function (err) {
+    // Don't forget to re activate the scheduler, even if there was an error
+    requestScheduler.activate()
+
+    if (err) return callback(err)
+
+    logger.info('Removed friend.')
+    return callback(null)
+  })
+}
+
+function sendOwnedVideosToPod (podId) {
   db.Video.listOwnedAndPopulateAuthorAndTags(function (err, videosList) {
     if (err) {
       logger.error('Cannot get the list of videos we own.')

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -1,4 +1,4 @@
-import { each, eachLimit, eachSeries, series, waterfall } from 'async'
+import { constant, each, eachLimit, eachSeries, series, waterfall } from 'async'
 import * as request from 'request'
 import * as Sequelize from 'sequelize'
 
@@ -234,30 +234,28 @@ function quitFriends (callback: (err: Error) => void) {
   })
 }
 
-function removeFriend (podId: number, callback: (err: Error) => void) {
+function removeFriend (pod, callback: (err: Error) => void) {
   // Stop pool requests
   requestScheduler.deactivate()
 
   waterfall([
-    function getPod (callbackAsync) {
-      return db.Pod.load(podId, callbackAsync)
-    },
+    constant(pod),
 
     function announceIQuitThisFriend (pod, callbackAsync) {
       const requestParams = {
-        method: 'POST' as 'POST',
-        path: '/api/' + API_VERSION + '/remote/pods/remove',
-        sign: true,
-        toPod: pod
+	method: 'POST' as 'POST',
+	path: '/api/' + API_VERSION + '/remote/pods/remove',
+	sign: true,
+	toPod: pod
       }
 
       makeSecureRequest(requestParams, function (err) {
-        if (err) {
+	if (err) {
           logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, { err: err })
           // Continue anyway
-        }
+	}
 
-        return callbackAsync(null, pod)
+	return callbackAsync(null, pod)
       })
     },
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -251,7 +251,7 @@ function removeFriend (podId, callback) {
       return db.Pod.load(podId, callbackAsync)
     },
 
-    function announceIQuitMyFriends (pod, callbackAsync) {
+    function announceIQuitThisFriend (pod, callbackAsync) {
       const requestParams = {
         method: 'POST',
         path: '/api/' + constants.API_VERSION + '/remote/pods/remove',

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -261,7 +261,7 @@ function removeFriend (podId: number, callback: (err: Error) => void) {
 
       makeSecureRequest(requestParams, function (err) {
         if (err) {
-          logger.error('Some errors while quitting friend.', { err: err })
+          logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, { err: err })
           // Continue anyway
         }
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -234,7 +234,7 @@ function quitFriends (callback: (err: Error) => void) {
   })
 }
 
-function removeFriend (podId, callback) {
+function removeFriend (podId: number, callback: (err: Error) => void) {
   // Stop pool requests
   requestScheduler.deactivate()
 
@@ -253,13 +253,13 @@ function removeFriend (podId, callback) {
 
     function announceIQuitThisFriend (pod, callbackAsync) {
       const requestParams = {
-        method: 'POST',
-        path: '/api/' + constants.API_VERSION + '/remote/pods/remove',
-        sign: true
+        method: 'POST' as 'POST',
+        path: '/api/' + API_VERSION + '/remote/pods/remove',
+        sign: true,
+        toPod: pod
       }
 
-      requestParams.toPod = pod
-      requests.makeSecureRequest(requestParams, function (err) {
+      makeSecureRequest(requestParams, function (err) {
         if (err) {
           logger.error('Some errors while quitting friend.', { err: err })
           // Continue anyway
@@ -272,7 +272,7 @@ function removeFriend (podId, callback) {
     function removePodFromDB (pod, callbackAsync) {
       pod.destroy().asCallback(callbackAsync)
     }
-  ], function (err) {
+  ], function (err: Error) {
     // Don't forget to re activate the scheduler, even if there was an error
     requestScheduler.activate()
 
@@ -337,6 +337,7 @@ export {
   hasFriends,
   makeFriends,
   quitFriends,
+  removeFriend,
   removeVideoToFriends,
   sendOwnedVideosToPod,
   getRequestScheduler,

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -239,14 +239,6 @@ function removeFriend (podId: number, callback: (err: Error) => void) {
   requestScheduler.deactivate()
 
   waterfall([
-    function flushRequests (callbackAsync) {
-      requestScheduler.flush(err => callbackAsync(err))
-    },
-
-    function flushVideoQaduRequests (callbackAsync) {
-      requestVideoQaduScheduler.flush(err => callbackAsync(err))
-    },
-
     function getPod (callbackAsync) {
       return db.Pod.load(podId, callbackAsync)
     },

--- a/server/middlewares/validators/pods.ts
+++ b/server/middlewares/validators/pods.ts
@@ -58,9 +58,33 @@ function podsAddValidator (req: express.Request, res: express.Response, next: ex
   })
 }
 
+function podRemoveValidator (req: express.Request, res: express.Response, next: express.NextFunction) {
+  req.checkParams('id', 'Should have a valid id').notEmpty().isNumeric()
+
+  logger.debug('Checking podRemoveValidator parameters', { parameters: req.params })
+
+  checkErrors(req, res, function () {
+    db.Pod.load(req.params.id, function (err, pod) {
+      if (err) {
+	logger.error('Cannot load pod %d.', req.params.id, { error: err })
+	res.sendStatus(500)
+      }
+
+      if (!pod) {
+	logger.error('Cannot find pod %d.', req.params.id, { error: err })
+	return res.sendStatus(404)
+      }
+
+      res.locals.pod = pod
+      return next()
+    })
+  })
+}
+
 // ---------------------------------------------------------------------------
 
 export {
   makeFriendsValidator,
-  podsAddValidator
+  podsAddValidator,
+  podRemoveValidator
 }


### PR DESCRIPTION
Should close issue #20.

I've just used the `quitFriends` method and adapt it to remove one friend.

I can see one problem with this method, though : It's not really DRY. Maybe we should add one method in the `server/lib/friends.js` to remove just one friend and call it 
- in the removeFriend method
- while iterating over the friend list in quitFriends 
?