### PR TITLE
Remove one pod

### DIFF
--- a/client/src/app/+admin/friends/friend-list/friend-list.component.html
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.html
@@ -2,7 +2,7 @@
   <div class="content-padding">
     <h3>Friends list</h3>
 
-    <ng2-smart-table [settings]="tableSettings" [source]="friendsSource"></ng2-smart-table>
+    <ng2-smart-table [settings]="tableSettings" [source]="friendsSource" (delete)="removeFriend($event)"></ng2-smart-table>
 
     <a *ngIf="hasFriends()" class="btn btn-danger pull-left" (click)="quitFriends()">
       Quit friends

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -71,8 +71,7 @@ export class FriendListComponent {
 
         this.friendService.quitFriends().subscribe(
           status => {
-            this.notificationsService.success('Sucess', 'Friends left!')
-
+            this.notificationsService.success('Success', 'Friends left!');
             this.friendsSource.refresh()
           },
 

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -68,15 +68,15 @@ export class FriendListComponent {
     return this.friendsSource.count() !== 0
   }
 
-  quitFriends() {
-    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.';
+  quitFriends () {
+    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.'
     this.confirmService.confirm(confirmMessage, 'Quit friends').subscribe(
       res => {
         if (res === false) return
 
         this.friendService.quitFriends().subscribe(
           status => {
-            this.notificationsService.success('Success', 'Friends left!');
+            this.notificationsService.success('Success', 'Friends left!')
             this.friendsSource.refresh()
           },
 
@@ -86,24 +86,24 @@ export class FriendListComponent {
     )
   }
 
-  removeFriend({ data }) {
-    const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.';
-    const friend: Pod = data;
+  removeFriend ({ data }) {
+    const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.'
+    const friend: Pod = data
 
     this.confirmService.confirm(confirmMessage, 'Remove').subscribe(
       res => {
-	if (res === false) return;
+        if (res === false) return
 
-	this.friendService.removeFriend(friend).subscribe(
+        this.friendService.removeFriend(friend).subscribe(
 	  status => {
-	    this.notificationsService.success('Success', 'Friend removed');
+	    this.notificationsService.success('Success', 'Friend removed')
 
-	    this.friendsSource.refresh();
+	    this.friendsSource.refresh()
 	  },
 
 	  err => this.notificationsService.error('Error', err.text)
-	);
+	)
       }
-    );
+    )
   }
 }

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -15,6 +15,7 @@ import { FriendService } from '../shared'
 export class FriendListComponent {
   friendsSource = null
   tableSettings = {
+    mode: 'external',
     attr: {
       class: 'table-hover'
     },
@@ -23,7 +24,10 @@ export class FriendListComponent {
       position: 'right',
       add: false,
       edit: false,
-      delete: false
+      delete: true
+    },
+    delete: {
+      deleteButtonContent: Utils.getRowDeleteButton()
     },
     columns: {
       id: {
@@ -63,8 +67,8 @@ export class FriendListComponent {
     return this.friendsSource.count() !== 0
   }
 
-  quitFriends () {
-    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.'
+  quitFriends() {
+    const confirmMessage = 'Do you really want to quit your friends? All their videos will be deleted.';
     this.confirmService.confirm(confirmMessage, 'Quit friends').subscribe(
       res => {
         if (res === false) return
@@ -79,5 +83,26 @@ export class FriendListComponent {
         )
       }
     )
+  }
+
+  removeFriend({ data }) {
+    const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.';
+    const friend: Friend = data;
+
+    this.confirmService.confirm(confirmMessage, 'Remove').subscribe(
+      res => {
+	if (res === false) return;
+
+	this.friendService.removeFriend(friend).subscribe(
+	  status => {
+	    this.notificationsService.success('Success', 'Friend removed');
+
+	    this.friendsSource.refresh();
+	  },
+
+	  err => this.notificationsService.error('Error', err.text)
+	);
+      }
+    );
   }
 }

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -97,7 +97,6 @@ export class FriendListComponent {
         this.friendService.removeFriend(friend).subscribe(
 	  status => {
 	    this.notificationsService.success('Success', 'Friend removed')
-
 	    this.friendsSource.refresh()
 	  },
 

--- a/client/src/app/+admin/friends/friend-list/friend-list.component.ts
+++ b/client/src/app/+admin/friends/friend-list/friend-list.component.ts
@@ -6,6 +6,7 @@ import { ServerDataSource } from 'ng2-smart-table'
 import { ConfirmService } from '../../../core'
 import { Utils } from '../../../shared'
 import { FriendService } from '../shared'
+import { Pod } from '../../../../../../shared'
 
 @Component({
   selector: 'my-friend-list',
@@ -87,7 +88,7 @@ export class FriendListComponent {
 
   removeFriend({ data }) {
     const confirmMessage = 'Do you really want to remove this friend ? All its videos will be deleted.';
-    const friend: Friend = data;
+    const friend: Pod = data;
 
     this.confirmService.confirm(confirmMessage, 'Remove').subscribe(
       res => {

--- a/client/src/app/+admin/friends/shared/friend.service.ts
+++ b/client/src/app/+admin/friends/shared/friend.service.ts
@@ -31,15 +31,15 @@ export class FriendService {
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  quitFriends() {
+  quitFriends () {
     return this.authHttp.get(FriendService.BASE_FRIEND_URL + 'quitfriends')
                         .map(res => res.status)
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  removeFriend(friend: Pod) {
+  removeFriend (friend: Pod) {
     return this.authHttp.delete(FriendService.BASE_FRIEND_URL + friend.id)
                         .map(this.restExtractor.extractDataBool)
-                        .catch((res) => this.restExtractor.handleError(res));
+                        .catch((res) => this.restExtractor.handleError(res))
   }
 }

--- a/client/src/app/+admin/friends/shared/friend.service.ts
+++ b/client/src/app/+admin/friends/shared/friend.service.ts
@@ -30,9 +30,15 @@ export class FriendService {
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  quitFriends () {
+  quitFriends() {
     return this.authHttp.get(FriendService.BASE_FRIEND_URL + 'quitfriends')
                         .map(res => res.status)
                         .catch((res) => this.restExtractor.handleError(res))
+  }
+
+  removeFriend(friend: Friend) {
+    return this.authHttp.delete(FriendService.BASE_FRIEND_URL + friend.id)
+                        .map(this.restExtractor.extractDataBool)
+                        .catch((res) => this.restExtractor.handleError(res));
   }
 }

--- a/client/src/app/+admin/friends/shared/friend.service.ts
+++ b/client/src/app/+admin/friends/shared/friend.service.ts
@@ -6,6 +6,7 @@ import 'rxjs/add/operator/map'
 import { ServerDataSource } from 'ng2-smart-table'
 
 import { AuthHttp, RestExtractor, RestDataSource, ResultList } from '../../../shared'
+import { Pod } from '../../../../../../shared'
 
 @Injectable()
 export class FriendService {
@@ -20,7 +21,7 @@ export class FriendService {
     return new RestDataSource(this.authHttp, FriendService.BASE_FRIEND_URL)
   }
 
-  makeFriends (notEmptyHosts) {
+  makeFriends (notEmptyHosts: String[]) {
     const body = {
       hosts: notEmptyHosts
     }
@@ -36,7 +37,7 @@ export class FriendService {
                         .catch((res) => this.restExtractor.handleError(res))
   }
 
-  removeFriend(friend: Friend) {
+  removeFriend(friend: Pod) {
     return this.authHttp.delete(FriendService.BASE_FRIEND_URL + friend.id)
                         .map(this.restExtractor.extractDataBool)
                         .catch((res) => this.restExtractor.handleError(res));

--- a/server/controllers/api/pods.ts
+++ b/server/controllers/api/pods.ts
@@ -19,7 +19,8 @@ import {
   ensureIsAdmin,
   makeFriendsValidator,
   setBodyHostPort,
-  setBodyHostsPort
+  setBodyHostsPort,
+  podRemoveValidator
 } from '../../middlewares'
 import {
   PodInstance
@@ -49,6 +50,7 @@ podsRouter.get('/quitfriends',
 podsRouter.delete('/:id',
   authenticate,
   ensureIsAdmin,
+  podRemoveValidator,
   removeFriendController
 )
 
@@ -101,7 +103,7 @@ function quitFriendsController (req: express.Request, res: express.Response, nex
 }
 
 function removeFriendController (req: express.Request, res: express.Response, next: express.NextFunction) {
-  removeFriend(req.params.id, function (err) {
+  removeFriend(res.locals.pod, function (err) {
     if (err) return next(err)
 
     res.type('json').status(204).end()

--- a/server/controllers/api/pods.ts
+++ b/server/controllers/api/pods.ts
@@ -103,9 +103,9 @@ function quitFriendsController (req: express.Request, res: express.Response, nex
 }
 
 function removeFriendController (req: express.Request, res: express.Response, next: express.NextFunction) {
-  removeFriend(res.locals.pod, function (err) {
-    if (err) return next(err)
+  const pod = res.locals.pod as PodInstance
 
-    res.type('json').status(204).end()
-  })
+  removeFriend(pod)
+    .then(() => (res.type('json').status(204).end()))
+    .catch(err => next(err))
 }

--- a/server/controllers/api/pods.ts
+++ b/server/controllers/api/pods.ts
@@ -10,7 +10,8 @@ import {
 import {
   sendOwnedVideosToPod,
   makeFriends,
-  quitFriends
+  quitFriends,
+  removeFriend
 } from '../../lib'
 import {
   podsAddValidator,
@@ -44,6 +45,11 @@ podsRouter.get('/quitfriends',
   authenticate,
   ensureIsAdmin,
   quitFriendsController
+)
+podsRouter.delete('/:id',
+  authenticate,
+  ensureIsAdmin,
+  removeFriendController
 )
 
 // ---------------------------------------------------------------------------
@@ -94,8 +100,8 @@ function quitFriendsController (req: express.Request, res: express.Response, nex
     .catch(err => next(err))
 }
 
-function removeFriend (req, res, next) {
-  friends.removeFriend(req.params.id, function (err) {
+function removeFriendController (req: express.Request, res: express.Response, next: express.NextFunction) {
+  removeFriend(req.params.id, function (err) {
     if (err) return next(err)
 
     res.type('json').status(204).end()

--- a/server/controllers/api/pods.ts
+++ b/server/controllers/api/pods.ts
@@ -93,3 +93,11 @@ function quitFriendsController (req: express.Request, res: express.Response, nex
     .then(() => res.type('json').status(204).end())
     .catch(err => next(err))
 }
+
+function removeFriend (req, res, next) {
+  friends.removeFriend(req.params.id, function (err) {
+    if (err) return next(err)
+
+    res.type('json').status(204).end()
+  })
+}

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -242,7 +242,7 @@ function fetchRemotePreview (pod: PodInstance, video: VideoInstance) {
   return request.get(REMOTE_SCHEME.HTTP + '://' + host + path)
 }
 
-function removeFriend (podId, callback) {
+function removeFriend (podId: number, callback: (err: Error) => void) {
   // Stop pool requests
   requestScheduler.deactivate()
 
@@ -261,13 +261,13 @@ function removeFriend (podId, callback) {
 
     function announceIQuitThisFriend (pod, callbackAsync) {
       const requestParams = {
-        method: 'POST',
-        path: '/api/' + constants.API_VERSION + '/remote/pods/remove',
-        sign: true
+        method: 'POST' as 'POST',
+        path: '/api/' + API_VERSION + '/remote/pods/remove',
+        sign: true,
+        toPod: pod
       }
 
-      requestParams.toPod = pod
-      requests.makeSecureRequest(requestParams, function (err) {
+      makeSecureRequest(requestParams, function (err) {
         if (err) {
           logger.error('Some errors while quitting friend.', { err: err })
           // Continue anyway
@@ -280,7 +280,7 @@ function removeFriend (podId, callback) {
     function removePodFromDB (pod, callbackAsync) {
       pod.destroy().asCallback(callbackAsync)
     }
-  ], function (err) {
+  ], function (err: Error) {
     // Don't forget to re activate the scheduler, even if there was an error
     requestScheduler.activate()
 
@@ -317,6 +317,7 @@ export {
   hasFriends,
   makeFriends,
   quitFriends,
+  removeFriend,
   removeVideoToFriends,
   sendOwnedVideosToPod,
   getRequestScheduler,

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -243,9 +243,6 @@ function fetchRemotePreview (pod: PodInstance, video: VideoInstance) {
 }
 
 function removeFriend (pod: PodInstance) {
-  // Stop pool requests
-  requestScheduler.deactivate()
-
   const requestParams = {
     method: 'POST' as 'POST',
     path: '/api/' + API_VERSION + '/remote/pods/remove',
@@ -261,7 +258,6 @@ function removeFriend (pod: PodInstance) {
     .catch(err => {
       logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, { err: err })
     })
-    .finally(() => requestScheduler.activate())
 }
 
 function getRequestScheduler () {

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -246,7 +246,6 @@ function removeFriend (pod: PodInstance) {
   const requestParams = {
     method: 'POST' as 'POST',
     path: '/api/' + API_VERSION + '/remote/pods/remove',
-    sign: true,
     toPod: pod
   }
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -259,7 +259,7 @@ function removeFriend (podId, callback) {
       return db.Pod.load(podId, callbackAsync)
     },
 
-    function announceIQuitMyFriends (pod, callbackAsync) {
+    function announceIQuitThisFriend (pod, callbackAsync) {
       const requestParams = {
         method: 'POST',
         path: '/api/' + constants.API_VERSION + '/remote/pods/remove',

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -247,14 +247,6 @@ function removeFriend (podId: number, callback: (err: Error) => void) {
   requestScheduler.deactivate()
 
   waterfall([
-    function flushRequests (callbackAsync) {
-      requestScheduler.flush(err => callbackAsync(err))
-    },
-
-    function flushVideoQaduRequests (callbackAsync) {
-      requestVideoQaduScheduler.flush(err => callbackAsync(err))
-    },
-
     function getPod (callbackAsync) {
       return db.Pod.load(podId, callbackAsync)
     },

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -244,7 +244,7 @@ function fetchRemotePreview (pod: PodInstance, video: VideoInstance) {
   return request.get(REMOTE_SCHEME.HTTP + '://' + host + path)
 }
 
-function removeFriend (pod, callback: (err: Error) => void) {
+function removeFriend (pod: PodInstance, callback: (err: Error) => void) {
   // Stop pool requests
   requestScheduler.deactivate()
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -269,7 +269,7 @@ function removeFriend (podId: number, callback: (err: Error) => void) {
 
       makeSecureRequest(requestParams, function (err) {
         if (err) {
-          logger.error('Some errors while quitting friend.', { err: err })
+          logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, { err: err })
           // Continue anyway
         }
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -256,7 +256,7 @@ function removeFriend (pod: PodInstance) {
       logger.info('Removed friend.')
     })
     .catch(err => {
-      logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, { err: err })
+      logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, err)
     })
 }
 

--- a/server/lib/friends.ts
+++ b/server/lib/friends.ts
@@ -253,19 +253,19 @@ function removeFriend (pod: PodInstance, callback: (err: Error) => void) {
 
     function announceIQuitThisFriend (pod, callbackAsync) {
       const requestParams = {
-	method: 'POST' as 'POST',
-	path: '/api/' + API_VERSION + '/remote/pods/remove',
-	sign: true,
-	toPod: pod
+        method: 'POST' as 'POST',
+        path: '/api/' + API_VERSION + '/remote/pods/remove',
+        sign: true,
+        toPod: pod
       }
 
       makeSecureRequest(requestParams, function (err) {
-	if (err) {
+        if (err) {
           logger.error('Some errors while quitting friend %s (id: %d).', pod.host, pod.id, { err: err })
           // Continue anyway
-	}
+        }
 
-	return callbackAsync(null, pod)
+        return callbackAsync(null, pod)
       })
     },
 

--- a/server/middlewares/validators/pods.ts
+++ b/server/middlewares/validators/pods.ts
@@ -58,9 +58,33 @@ function podsAddValidator (req: express.Request, res: express.Response, next: ex
   })
 }
 
+function podRemoveValidator (req: express.Request, res: express.Response, next: express.NextFunction) {
+  req.checkParams('id', 'Should have a valid id').notEmpty().isNumeric()
+
+  logger.debug('Checking podRemoveValidator parameters', { parameters: req.params })
+
+  checkErrors(req, res, function () {
+    db.Pod.load(req.params.id, function (err, pod) {
+      if (err) {
+	logger.error('Cannot load pod %d.', req.params.id, { error: err })
+	res.sendStatus(500)
+      }
+
+      if (!pod) {
+	logger.error('Cannot find pod %d.', req.params.id, { error: err })
+	return res.sendStatus(404)
+      }
+
+      res.locals.pod = pod
+      return next()
+    })
+  })
+}
+
 // ---------------------------------------------------------------------------
 
 export {
   makeFriendsValidator,
-  podsAddValidator
+  podsAddValidator,
+  podRemoveValidator
 }

--- a/server/middlewares/validators/pods.ts
+++ b/server/middlewares/validators/pods.ts
@@ -64,20 +64,20 @@ function podRemoveValidator (req: express.Request, res: express.Response, next: 
   logger.debug('Checking podRemoveValidator parameters', { parameters: req.params })
 
   checkErrors(req, res, function () {
-    db.Pod.load(req.params.id, function (err, pod) {
-      if (err) {
-	logger.error('Cannot load pod %d.', req.params.id, { error: err })
-	res.sendStatus(500)
-      }
+    db.Pod.load(req.params.id)
+      .then(pod => {
+        if (!pod) {
+          logger.error('Cannot find pod %d.', req.params.id)
+          return res.sendStatus(404)
+        }
 
-      if (!pod) {
-	logger.error('Cannot find pod %d.', req.params.id, { error: err })
-	return res.sendStatus(404)
-      }
-
-      res.locals.pod = pod
-      return next()
-    })
+        res.locals.pod = pod
+        return next()
+      })
+      .catch(err => {
+        logger.error('Cannot load pod %d.', req.params.id, { error: err })
+        res.sendStatus(500)
+      })
   })
 }
 

--- a/server/middlewares/validators/pods.ts
+++ b/server/middlewares/validators/pods.ts
@@ -75,7 +75,7 @@ function podRemoveValidator (req: express.Request, res: express.Response, next: 
         return next()
       })
       .catch(err => {
-        logger.error('Cannot load pod %d.', req.params.id, { error: err })
+        logger.error('Cannot load pod %d.', req.params.id, err)
         res.sendStatus(500)
       })
   })

--- a/server/tests/api/check-params/pods.js
+++ b/server/tests/api/check-params/pods.js
@@ -110,7 +110,7 @@ describe('Test pods API validators', function () {
           .expect(400, done)
       })
 
-      it('Should fail with a invalid token', function (done) {
+      it('Should fail with an invalid token', function (done) {
         request(server.url)
           .post(path + '/makefriends')
           .send(body)
@@ -130,7 +130,7 @@ describe('Test pods API validators', function () {
     })
 
     describe('When quitting friends', function () {
-      it('Should fail with a invalid token', function (done) {
+      it('Should fail with an invalid token', function (done) {
         request(server.url)
           .get(path + '/quitfriends')
           .query({ start: 'hello' })
@@ -150,7 +150,7 @@ describe('Test pods API validators', function () {
     })
 
     describe('When removing one friend', function () {
-      it('Should fail with a invalid token', function (done) {
+      it('Should fail with an invalid token', function (done) {
 	request(server.url)
           .delete(path + '/1')
           .set('Authorization', 'Bearer faketoken')
@@ -217,7 +217,7 @@ describe('Test pods API validators', function () {
       requestsUtils.makePostBodyRequest(server.url, path, null, data, done)
     })
 
-    it('Should fail without an host', function (done) {
+    it('Should fail without a host', function (done) {
       const data = {
         email: 'testexample.com',
         publicKey: 'mysuperpublickey'

--- a/server/tests/api/check-params/pods.js
+++ b/server/tests/api/check-params/pods.js
@@ -17,7 +17,7 @@ describe('Test pods API validators', function () {
   // ---------------------------------------------------------------
 
   before(function (done) {
-    this.timeout(20000)
+    this.timeout(45000)
 
     series([
       function (next) {
@@ -147,6 +147,42 @@ describe('Test pods API validators', function () {
           .set('Accept', 'application/json')
           .expect(403, done)
       })
+    })
+
+    describe('When removing one friend', function () {
+      it('Should fail with a invalid token', function (done) {
+	request(server.url)
+          .delete(path + '/1')
+          .set('Authorization', 'Bearer faketoken')
+          .set('Accept', 'application/json')
+          .expect(401, done)
+      })
+
+      it('Should fail if the user is not an administrator', function (done) {
+	request(server.url)
+          .delete(path + '/1')
+          .set('Authorization', 'Bearer ' + userAccessToken)
+          .set('Accept', 'application/json')
+          .expect(403, done)
+      })
+
+      it('Should fail with an invalid id', function (done) {
+	request(server.url)
+          .delete(path + '/foobar')
+          .set('Authorization', 'Bearer ' + server.accessToken)
+          .set('Accept', 'application/json')
+          .expect(400, done)
+      })
+
+      it('Should fail if the pod is not a friend', function (done) {
+	request(server.url)
+          .delete(path + '/-1')
+          .set('Authorization', 'Bearer ' + server.accessToken)
+          .set('Accept', 'application/json')
+          .expect(404, done)
+      })
+
+      it('Should succeed with the correct parameters')
     })
   })
 

--- a/server/tests/api/check-params/pods.js
+++ b/server/tests/api/check-params/pods.js
@@ -166,6 +166,14 @@ describe('Test pods API validators', function () {
           .expect(403, done)
       })
 
+      it('Should fail with an undefined id', function (done) {
+        request(server.url)
+          .delete(path + '/' + undefined)
+          .set('Authorization', 'Bearer ' + server.accessToken)
+          .set('Accept', 'application/json')
+          .expect(400, done)
+      })
+
       it('Should fail with an invalid id', function (done) {
 	request(server.url)
           .delete(path + '/foobar')

--- a/server/tests/api/friends-advanced.js
+++ b/server/tests/api/friends-advanced.js
@@ -33,16 +33,9 @@ describe('Test advanced friends', function () {
       if (err) throw err
 
       let friendsList = res.body.data
-      let podIdToRemove = -1
+      let podToRemove = friendsList.find((friend) => (friend.host === serverToRemove.host))
 
-      for (let i = 0; i < friendsList.length; i++) {
-        if (serverToRemove.host === friendsList[i].host) {
-          podIdToRemove = friendsList[i].id
-          break
-        }
-      }
-
-      return podsUtils.quitOneFriend(server.url, server.accessToken, podIdToRemove, callback)
+      return podsUtils.quitOneFriend(server.url, server.accessToken, podToRemove.id, callback)
     })
   }
 

--- a/server/tests/api/friends-basic.js
+++ b/server/tests/api/friends-basic.js
@@ -209,17 +209,10 @@ describe('Test basic friends', function () {
           if (err) throw err
 
           const result = res.body.data
-          let podId
-
-          for (let i = 0; i < result.length; i++) {
-            if (result[i].host === servers[1].host) {
-              podId = result[i].id
-              break
-            }
-          }
+          let pod = result.find((friend) => (friend.host === servers[1].host))
 
           // Remove it from the friends list
-          podsUtils.quitOneFriend(server.url, server.accessToken, podId, next)
+          podsUtils.quitOneFriend(server.url, server.accessToken, pod.id, next)
         })
       },
 

--- a/server/tests/utils/pods.js
+++ b/server/tests/utils/pods.js
@@ -107,8 +107,7 @@ function quitOneFriend (url, accessToken, friendId, expectedStatus, end) {
     .end(function (err, res) {
       if (err) throw err
 
-      // Wait for the request between pods
-      setTimeout(end, 1000)
+      end()
     })
 }
 

--- a/server/tests/utils/pods.js
+++ b/server/tests/utils/pods.js
@@ -5,7 +5,8 @@ const request = require('supertest')
 const podsUtils = {
   getFriendsList,
   makeFriends,
-  quitFriends
+  quitFriends,
+  quitOneFriend
 }
 
 // ---------------------- Export functions --------------------
@@ -79,6 +80,27 @@ function quitFriends (url, accessToken, expectedStatus, end) {
   // The first pod make friend with the third
   request(url)
     .get(path)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + accessToken)
+    .expect(expectedStatus)
+    .end(function (err, res) {
+      if (err) throw err
+
+      // Wait for the request between pods
+      setTimeout(end, 1000)
+    })
+}
+
+function quitOneFriend (url, accessToken, friendId, expectedStatus, end) {
+  if (!end) {
+    end = expectedStatus
+    expectedStatus = 204
+  }
+
+  const path = '/api/v1/pods/' + friendId
+
+  request(url)
+    .delete(path)
     .set('Accept', 'application/json')
     .set('Authorization', 'Bearer ' + accessToken)
     .expect(expectedStatus)


### PR DESCRIPTION
Should close issue #20.

I've just used the `quitFriends` method and adapt it to remove one friend.

I can see one problem with this method, though : It's not really DRY. Maybe we should add one method in the `server/lib/friends.js` to remove just one friend and call it 
- in the removeFriend method
- while iterating over the friend list in quitFriends 
?