### PR TITLE
Replace Diaspora reference with Patchwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Want to see in action?
 
 We can't build a FOSS video streaming alternatives to YouTube, Dailymotion, Vimeo... with a centralized software. One organization alone cannot have enought money to pay bandwith and video storage of its server.
 
-So we need to have a decentralized network (as [Diaspora](https://github.com/diaspora/diaspora) for example).
-But it's not enought because one video could become famous and overload the server.
+So we need to have a decentralized network (as [Patchwork](https://github.com/ssbc/patchwork) for example).
+But it's not enough because one video could become famous and overload the server.
 It's the reason why we need to use a P2P protocol to limit the server load.
 Thanks to [WebTorrent](https://github.com/feross/webtorrent), we can make P2P (thus bittorrent) inside the web browser right now.
 


### PR DESCRIPTION
Diaspora is not decentralized. It is federated (AKA distributed). Patchwork (on the Secure Scuttlebutt protocol) is a lot closer to the social media version of PeerTube.

Was just bugging me a bit :)

Thoughts?