### PR TITLE
Client: Fix Javascript OOM error during webpack compilation

### DIFF
--- a/client/config/webpack.prod.js
+++ b/client/config/webpack.prod.js
@@ -15,7 +15,6 @@ const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin')
 const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin')
 const OptimizeJsPlugin = require('optimize-js-plugin')
 const HashedModuleIdsPlugin = require('webpack/lib/HashedModuleIdsPlugin')
-const ModuleConcatenationPlugin = require('webpack/lib/optimize/ModuleConcatenationPlugin')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 /**
  * Webpack Constants
@@ -108,7 +107,6 @@ module.exports = function (env) {
        * See: http://webpack.github.io/docs/configuration.html#plugins
        */
       plugins: [
-        new ModuleConcatenationPlugin(),
 
         /**
          * Webpack plugin to optimize a JavaScript file for faster initial load


### PR DESCRIPTION
Linked to issue #88.

Javascript running OOM during webpack compilation seem to be an known issue :
https://github.com/webpack/webpack/issues/1914

The last comment of this issue (https://github.com/webpack/webpack/issues/1914#issuecomment-326937497) fixed it by disabling the ModuleConcatenationPlugin. I did the same on PeerTube and the client part compiles on my PC 🎉