### PR TITLE
Add a PeerTube development environment Dockerfile compatible with Janitor.

### DIFF
--- a/support/docker/dev/Dockerfile
+++ b/support/docker/dev/Dockerfile
@@ -1,0 +1,20 @@
+FROM janx/ubuntu-dev
+MAINTAINER Jan Keromnes <janx@linux.com>
+
+# Install PeerTube's dependencies.
+# Packages are from https://github.com/Chocobozzz/PeerTube#dependencies
+RUN sudo apt-get update -q && sudo apt-get install -qy \
+ ffmpeg \
+ postgresql \
+ openssl
+
+# Download PeerTube's source code.
+RUN git clone -b master https://github.com/Chocobozzz/PeerTube /home/user/PeerTube
+WORKDIR /home/user/PeerTube
+
+# Configure Cloud9 IDE to use PeerTube's source directory as workspace (-w).
+RUN sudo sed -i "s/-w \/home\/user/-w \/home\/user\/PeerTube/" /etc/supervisord.conf
+
+# Configure and build PeerTube.
+RUN yarn install \
+ && npm run build

--- a/support/docker/dev/Dockerfile
+++ b/support/docker/dev/Dockerfile
@@ -9,7 +9,7 @@ RUN sudo apt-get update -q && sudo apt-get install -qy \
  openssl
 
 # Download PeerTube's source code.
-RUN git clone -b master https://github.com/Chocobozzz/PeerTube /home/user/PeerTube
+RUN git clone -b develop https://github.com/Chocobozzz/PeerTube /home/user/PeerTube
 WORKDIR /home/user/PeerTube
 
 # Configure Cloud9 IDE to use PeerTube's source directory as workspace (-w).


### PR DESCRIPTION
This should allow us to set up a Docker Hub automated build containing an up-to-date PeerTube development environment.

This image is based on [ubuntu-dev](https://github.com/JanitorTechnology/dockerfiles#ubuntu-dev), so it should be really convenient and efficient to use for developers, and it's also compatible with the https://janitor.technology service.