### PR TITLE
change nginx config to fix deprecation of a old module

### DIFF
--- a/support/nginx/peertube-https
+++ b/support/nginx/peertube-https
@@ -6,7 +6,7 @@ server {
 }
 
 server {
-  listen 443 ssl spdy; # or http2
+  listen 443 ssl http2; # spdy is deprecated on nginx
   # listen [::]:443 ssl spdy;
   server_name domain.tld;
 


### PR DESCRIPTION
just a small change, so it does not byte people when they actually stop showing a warning and instead just fails