### PR TITLE
Show a message on client when JavaScript is disabled

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -20,6 +20,15 @@
   <!-- 3. Display the application -->
   <body>
 
+    <noscript>
+      <p>You are blocking Javascript, and we totally get that. However this endpoint uses Angular, so the front end is in full JavaScript and won't work without it.
+      </br></br>
+      There will be other non JS-based clients to access PeerTube, but for now none is available as this is still alpha software. Be sure we will update this page with a list once alternative clients are developped. You can certainly develop you own in the meantime as our code is open source and libre software under GNU AGPLv3.0.
+      </br></br>
+      There might be numerous reasons you refuse to use JavaScript. If it has just to do with security (or lack thereof) of JavaScript-based webapps, then depending on your threat menace you might want to go through the code running on the node you are trying to access, and look for security audits.
+      </p>
+    </noscript>
+
     <my-app>
     </my-app>
 


### PR DESCRIPTION
Following with #194, that's a (for now text-only) message to explain:
- the need for JS
- the alternatives existing (none for now)
- the extent to which our code can be trusted

Maybe we should stick with something simpler?