### PR TITLE
Add config for running with Docker Compose and on Docker Swarm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+*.swp
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ ENV NODE_ENV production
 ENV NODE_CONFIG_DIR ./docker
 
 CMD ["npm", "start"]
-VOLUME ["/data"]
+VOLUME ["/usr/src/app/data"]
 EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:8
+
+# install yarn
+RUN apt-get update && apt-get install -y apt-transport-https \
+ && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+ && apt-get update && apt-get install -y yarn \
+ && rm /var/lib/apt/lists/* -fR
+
+# install ffmpeg
+RUN echo "deb http://ftp.uk.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list \
+ && apt-get update \
+ && apt-get -y install ffmpeg \
+ && rm /var/lib/apt/lists/* -fR
+
+WORKDIR /usr/src/app
+
+COPY package.json yarn.lock ./
+COPY client/package.json client/yarn.lock client/
+RUN yarn install --pure-lockfile
+
+COPY . ./
+
+RUN npm run build
+
+ENV NODE_ENV production
+ENV NODE_CONFIG_DIR ./docker
+
+CMD ["npm", "start"]
+VOLUME ["/data"]
+EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
-FROM node:8
-
-# install yarn
-RUN apt-get update && apt-get install -y apt-transport-https \
- && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
- && apt-get update && apt-get install -y yarn \
- && rm /var/lib/apt/lists/* -fR
+FROM node:8-stretch
 
 # install ffmpeg
-RUN echo "deb http://ftp.uk.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list \
- && apt-get update \
+RUN apt-get update \
  && apt-get -y install ffmpeg \
  && rm /var/lib/apt/lists/* -fR
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ BitTorrent) inside the web browser, as of today.
 
 You can quickly get a server running using Docker. You need to have [docker](https://www.docker.com/community-edition) and [docker-compose](https://docs.docker.com/compose/install/) installed.
 
-Also, you need to run a Traefik loadbalancer using Docker Compose. You can start one locally with this [example compose config](https://gist.github.com/djmaze/72f0565715c59712ce191b41d3c377da).
+For this example configuration, you also need to run a Traefik loadbalancer using Docker Compose. You can start one locally with this [example compose config](https://gist.github.com/djmaze/72f0565715c59712ce191b41d3c377da).
 
 Example for running a peertube server locally:
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ BitTorrent) inside the web browser, as of today.
   * OpenSSL (cli)
   * FFmpeg
 
+## Run using Docker
+
+You can quickly get a server running using Docker. You need to have [docker](https://www.docker.com/community-edition) and [docker-compose](https://docs.docker.com/compose/install/) installed.
+
+Example for running a server locally:
+
+```bash
+sudo \
+  PEERTUBE_HOSTNAME=peertube.lvh.me \
+  PEERTUBE_ADMIN_EMAIL=test@example.com \
+  PEERTUBE_TRANSCODING_ENABLED=true \
+  docker-compose up app
+```
+
+(Get the initial root user password from the program output.)
+
 ## Production
 
 See the [production guide](support/doc/production.md).

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ BitTorrent) inside the web browser, as of today.
 
 You can quickly get a server running using Docker. You need to have [docker](https://www.docker.com/community-edition) and [docker-compose](https://docs.docker.com/compose/install/) installed.
 
-Example for running a server locally:
+Also, you need to run a Traefik loadbalancer using Docker Compose. You can start one locally with this [example compose config](https://gist.github.com/djmaze/72f0565715c59712ce191b41d3c377da).
+
+Example for running a peertube server locally:
 
 ```bash
 sudo \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.3"
+
+services:
+  app:
+    build: .
+    image: decentralize/peertube
+    environment:
+      NODE_CONFIG: '{"webserver": {"https": false, "port": 80}}'
+      PEERTUBE_HOSTNAME:
+      PEERTUBE_ADMIN_EMAIL:
+      PEERTUBE_SIGNUP_ENABLED:
+      PEERTUBE_TRANSCODING_ENABLED:
+    labels:
+      traefik.enable: "true"
+      traefik.frontend.rule: "Host:${PEERTUBE_HOSTNAME}"
+      traefik.docker.network: traefik_traefik
+      traefik.port: "9000"
+    volumes:
+      - app_data:/usr/src/app/data
+    networks:
+      - traefik
+      - backend
+    depends_on:
+      - db
+
+  db:
+    image: postgres:10
+    environment:
+      POSTGRES_DB: peertube_prod
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    networks:
+      - backend
+
+volumes:
+  app_data:
+  db_data:
+
+networks:
+  backend:
+  traefik:
+    external:
+      name: traefik_traefik

--- a/docker/custom-environment-variables.yaml
+++ b/docker/custom-environment-variables.yaml
@@ -1,0 +1,15 @@
+webserver:
+  hostname: "PEERTUBE_HOSTNAME"
+
+admin:
+  email: "PEERTUBE_ADMIN_EMAIL"
+
+signup:
+  enabled:
+    __name: "PEERTUBE_SIGNUP_ENABLED"
+    __format: "json"
+
+transcoding:
+  enabled:
+    __name: "PEERTUBE_TRANSCODING_ENABLED"
+    __format: "json"

--- a/docker/production.yaml
+++ b/docker/production.yaml
@@ -1,0 +1,55 @@
+listen:
+  port: 9000
+
+# Correspond to your reverse proxy "listen" configuration
+webserver:
+  https: true
+  hostname: undefined
+  port: 443
+
+# Your database name will be "peertube"+database.suffix
+database:
+  hostname: 'db'
+  port: 5432
+  suffix: '_prod'
+  username: 'postgres'
+  password: 'postgres'
+
+# From the project root directory
+storage:
+  avatars: 'data/avatars/'
+  certs: 'data/certs/'
+  videos: 'data/videos/'
+  logs: 'data/logs/'
+  previews: 'data/previews/'
+  thumbnails: 'data/thumbnails/'
+  torrents: 'data/torrents/'
+  cache: 'data/cache/'
+
+cache:
+  previews:
+    size: 100 # Max number of previews you want to cache
+
+admin:
+  email: undefined
+
+signup:
+  enabled: false
+  limit: 10 # When the limit is reached, registrations are disabled. -1 == unlimited
+
+user:
+  # Default value of maximum video BYTES the user can upload (does not take into account transcoded files).
+  # -1 == unlimited
+  video_quota: -1
+
+# If enabled, the video will be transcoded to mp4 (x264) with "faststart" flag
+# Uses a lot of CPU!
+transcoding:
+  enabled: false
+  threads: 2
+  resolutions: # Only created if the original video has a higher resolution
+    240p: true
+    360p: true
+    480p: true
+    720p: true
+    1080p: true

--- a/docker/swarm-stack.sample.yml
+++ b/docker/swarm-stack.sample.yml
@@ -1,0 +1,48 @@
+version: "3.3"
+
+services:
+  app:
+    image: decentralize/peertube
+    environment:
+      PEERTUBE_HOSTNAME: peertube.example.com
+      PEERTUBE_ADMIN_EMAIL: admin@example.com
+      PEERTUBE_SIGNUP_ENABLED: "false"
+      PEERTUBE_TRANSCODING_ENABLED: "true"
+    labels: &labels
+      traefik.frontend.rule: "Host:peertube.example.com"
+      traefik.docker.network: traefik
+      traefik.port: "9000"
+    volumes:
+      - app_data:/usr/src/app/data
+    networks:
+      - traefik
+      - backend
+    depends_on:
+      - db
+    deploy:
+      labels: *labels
+      placement:
+        constraints:
+        - node.labels.peertube == 1
+
+  db:
+    image: postgres:10
+    environment:
+      POSTGRES_DB: peertube_prod
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    networks:
+      - backend
+    deploy:
+      placement:
+        constraints:
+        - node.labels.peertube == 1
+
+volumes:
+  app_data:
+  db_data:
+
+networks:
+  backend:
+  traefik:
+    external: true

--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -225,3 +225,21 @@ branch), upgrade node modules and rebuild client application:
 $ npm run upgrade-peertube
 # systemctl start peertube
 ```
+
+## Installation on Docker Swarm
+
+There is an example configuration for deploying peertube and a postgres database as a Docker swarm stack. It works like this:
+
+(_Note_: You need to make sure to set `traefik` and `peertube` labels on the target node(s) for this configuration to work.)
+
+1. Install a traefik loadbalancer stack (including Let's Encrypt) on your docker swarm. [Here](https://gist.github.com/djmaze/2684fbf147d775c8ee441b4302554823) is an example configuration.
+
+2. Copy the [example stack file](docker/docker-stack.example.yml) for peertube:
+
+        scp docker/docker-stack.example.yml root@your-server:/path/to/your/swarm-config/peertube.yml
+
+2. Have a look at the file and adjust the variables to your need.
+
+3. Deploy the stack:
+
+        docker stack deploy -c peertube.yml peertube


### PR DESCRIPTION
This allows running a local or production server, either with Docker Compose or on a Docker Swarm cluster. I think this makes deployment (and also development) much easier, so I hope this is deemed valuable.

I have the swarm stack successfully working on a cluster (currently without federation though). 

I made some of the main settings configurable via environment variables on the way. This can of course been expanded upon.

nginx is notably missing from this setup and I am not sure if the default settings of the traefik loadbalancer are enough for this to work reliably as a webseed / webtorrent tracker. Any advice welcome. (Also, practice will show.)