### PR TITLE
Add production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,7 @@ RUN groupadd -g 991 peertube && useradd -u 991 -g 991  --create-home peertube \
 COPY ./ /
 WORKDIR /PeerTube/
 
-RUN echo "****** Clone Peertube ******" \
-	&& git clone --branch develop https://github.com/Chocobozzz/PeerTube /PeerTube \
-	&& echo "****** chown ******" \
+RUN echo "****** chown ******" \
 	&& chown -R peertube:peertube PeerTube \
         && cd /PeerTube \
 	&& echo "****** run npm install as user ******" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+FROM debian:jessie-slim
+
+ENV UID=991 GID=991 \
+	HTTPS=false \
+	HOSTNAME=peertube.localhost \
+	PORT=80 \
+	DATABASE_HOST=localhost \
+	DATABASE_PORT=5432 \
+	DATABASE_USERNAME=peertube \
+	DATABASE_PASSWORD=peertube \
+	ADMIN_EMAIL=admin@domain.local \
+	SIGNUP_ENABLE=false \
+	TRANSCODING_ENABLE=false \
+	TRANSCODING_THREADS=2 \
+	BODY_SIZE=100M \
+	CACHE_SIZE=100 \
+	SIGNUP_LIMIT=10 \
+	VIDEO_QUOTA=-1 \
+	RESOLUTION_280=true \
+	RESOLUTION_360=true \
+	RESOLUTION_480=true \
+	RESOLUTION_720=true \
+	RESOLUTION_1080=true \
+	DEBIAN_FRONTEND=noninteractive
+
+RUN groupadd -g 991 peertube && useradd -u 991 -g 991  --create-home peertube \
+	&& echo "deb http://ftp.debian.org/debian jessie-backports main contrib non-free" >> /etc/apt/sources.list \
+	&& apt-get update \
+	&& apt-get -y install curl \
+	&& apt-get -y --no-install-recommends  install ffmpeg openssl git build-essential nginx-light \
+	&& apt-get clean \
+	&& curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+	&& echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+	&& apt-get update \
+	&& apt-get -y install -y nodejs yarn --no-install-recommends \
+	&& mkdir /PeerTube && cd /PeerTube
+
+COPY ./ /
+WORKDIR /PeerTube/
+
+RUN echo "****** Clone Peertube ******" \
+	&& git clone --branch develop https://github.com/Chocobozzz/PeerTube /PeerTube \
+	&& echo "****** chown ******" \
+	&& chown -R peertube:peertube PeerTube \
+        && cd /PeerTube \
+	&& echo "****** run npm install as user ******" \
+	&& su - peertube -c "cd /PeerTube && npm install" \
+        && echo "****** run yarn install as user ******" \
+	&& su - peertube -c "cd /PeerTube && yarn install" \
+        && echo "****** run npm run build as user ******" \
+	&& su - peertube -c "cd /PeerTube && npm run build" \
+	&& mv docker/rootfs / \
+	&& apt-get remove --purge --yes build-essential curl git  \
+	&& apt-get autoremove -y \
+	&& apt-get clean \
+	&& rm -rf /PeerTube/.git /PeerTube/Dockerfile /PeerTube/docker \
+	&& rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/debconf/*-old \
+	&& rm -rf /usr/share/man/?? \
+	&& rm -rf /usr/share/man/??_* 
+
+EXPOSE 8080
+
+RUN chmod +x /usr/local/bin/startup
+
+VOLUME ["/PeerTube/certs", "/PeerTube/videos", "/PeerTube/logs", "/PeerTube/previews", "/PeerTube/thumbnails", "/PeerTube/torrents"]
+
+ENTRYPOINT ["/usr/local/bin/startup"]

--- a/docker.README.md
+++ b/docker.README.md
@@ -1,0 +1,75 @@
+# PeerTube Docker ([hub image](https://hub.docker.com/r/dryusdan/peertube/))
+
+[![Build Status](https://drone.dryusdan.fr/api/badges/Dryusdan/docker-peertube/status.svg)](https://drone.dryusdan.fr/Dryusdan/docker-peertube)
+
+#### What is this?
+
+A docker image for [PeerTube](https://github.com/Chocobozzz/PeerTube/) the federated (ActivityPub) video streaming platform using P2P (BitTorrent) directly in the web browser with WebTorrent.
+
+#### Features
+- Based on a Debian Jessie (slim image base of 80MB)
+
+#### Build-time variables
+- **PEERTUBE_VER** : version of PeerTube.
+
+#### Environment variables
+- **GID** : peertube group id *(default : 991)*
+- **UID** : peertube user id *(default : 991)*
+
+#### Volumes
+- **/PeerTube/avatars** : location of users avatars.
+- **/PeerTube/certs** : location of certs.
+- **/PeerTube/videos** : location of videos.
+- **/PeerTube/logs** : location of logs.
+- **/PeerTube/previews** : location of video preview image.
+- **/PeerTube/thumbnails** : location of thumbnails.
+- **/PeerTube/torrents** : location of torrents.
+
+#### Example of simple configuration
+
+Since PeerTube requires a database and for now only supports [PostgreSQL](https://github.com/Chocobozzz/PeerTube/#dependencies), here is an example (running docker-compose for convenience) that links to the official PostgreSQL docker image. You can of course adapt to use your favorite PostgreSQL image. Just be sure to follow the [production guide](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/production.md) and properly configure your reverse proxy.
+
+```yaml
+version: "3"
+
+services:
+  peertube:
+    image: index.docker.io/dryusdan/peertube:latest
+    container_name: peertube
+    restart: always
+    environment:
+      - HTTPS=true
+      - HOSTNAME=peertube.tld
+      - PORT=443
+      - DATABASE_HOST=db
+      - DATABASE_USERNAME=peertube
+      - DATABASE_PASSWORD=
+      - ADMIN_EMAIL=admin@peertube.tld
+      - SIGNUP_ENABLE=true
+      - TRANSCODING_THREADS=2
+      - BODY_SIZE=1G
+      - SIGNUP_LIMIT=-1
+      - CACHE_SIZE=100
+      - VIDEO_QUOTA=104857600
+    external_links:
+      - peertube-db:db
+    volumes:
+      - /home/docker/services/web/peertube/avatars:/PeerTube/avatars
+      - /home/docker/services/web/peertube/certs:/PeerTube/certs
+      - /home/docker/services/web/peertube/videos:/PeerTube/videos
+      - /home/docker/services/web/peertube/logs:/PeerTube/logs
+      - /home/docker/services/web/peertube/previews:/PeerTube/previews
+      - /home/docker/services/web/peertube/thumbnails:/PeerTube/thumbnails
+      - /home/docker/services/web/peertube/torrents:/PeerTube/torrents
+
+  peertube-db:
+    restart: always
+    container_name: peertube-postgresql
+    image: index.docker.io/postgres:9.6.5-alpine
+    environment:
+      - POSTGRES_USER=peertube
+      - POSTGRES_PASSWORD=peertube
+      - POSTGRES_DB=peertube_prod
+    volumes:
+      - /home/docker/db/peertube/postgresql/data:/var/lib/postgresql/data
+```

--- a/docker.README.md
+++ b/docker.README.md
@@ -9,9 +9,6 @@ A docker image for [PeerTube](https://github.com/Chocobozzz/PeerTube/) the feder
 #### Features
 - Based on a Debian Jessie (slim image base of 80MB)
 
-#### Build-time variables
-- **PEERTUBE_VER** : version of PeerTube.
-
 #### Environment variables
 - **GID** : peertube group id *(default : 991)*
 - **UID** : peertube user id *(default : 991)*

--- a/docker/rootfs/PeerTube/config/production.yaml
+++ b/docker/rootfs/PeerTube/config/production.yaml
@@ -1,0 +1,55 @@
+listen:
+  port: 9000
+
+# Correspond to your reverse proxy "listen" configuration
+webserver:
+  https: <https>
+  hostname: '<hostname>'
+  port: <port>
+
+# Your database name will be "peertube"+database.suffix
+database:
+  hostname: '<database_host>'
+  port: <database_port>
+  suffix: '_prod'
+  username: '<database_username>'
+  password: '<database_password>'
+
+# From the project root directory
+storage:
+  avatars: 'avatars/'
+  certs: 'certs/'
+  videos: 'videos/'
+  logs: 'logs/'
+  previews: 'previews/'
+  thumbnails: 'thumbnails/'
+  torrents: 'torrents/'
+  
+cache:
+  previews:
+    size: <cache_size>
+
+admin:
+  email: '<admin_email>'
+
+signup:
+  enabled: <signup_enabled>
+  limit: <signup_limit> # When the limit is reached, registrations are disabled. -1 == unlimited
+
+user:
+  # Default value of maximum video BYTES the user can upload (does not take into account transcoded files).
+  # -1 == unlimited
+  video_quota: <video_quota>
+
+# If enabled, the video will be transcoded to mp4 (x264) with "faststart" flag
+# Uses a lot of CPU!
+transcoding:
+  enabled: <transcoding_enable>
+  threads: <transcoding_threads>
+  resolutions: # Only created if the original video has a higher resolution
+    240p: <resolution_280>
+    360p: <resolution_360>
+    480p: <resolution_480>
+    720p: <resolution_720>
+    1080p: <resolution_1080>
+

--- a/docker/rootfs/etc/nginx/sites-enabled/peertube.conf
+++ b/docker/rootfs/etc/nginx/sites-enabled/peertube.conf
@@ -1,0 +1,47 @@
+server {
+  listen 8080;
+
+  location / {
+    proxy_pass http://localhost:9000;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    # For the video upload
+    client_max_body_size <body_size>;
+  }
+
+  # Bypass PeerTube webseed route for better performances
+  location /static/webseed {
+    if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+      add_header 'Access-Control-Allow-Headers' 'Range,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Content-Type' 'text/plain charset=UTF-8';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
+
+    if ($request_method = 'GET') {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+      add_header 'Access-Control-Allow-Headers' 'Range,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+    }
+
+    alias /PeerTube/videos;
+  }
+
+  # Websocket tracker
+  location /tracker/socket {
+    # Peers send a message to the tracker every 15 minutes
+    # Don't close the websocket before this time
+    proxy_read_timeout 1200s;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_pass http://localhost:9000;
+  }
+}

--- a/docker/rootfs/usr/local/bin/startup
+++ b/docker/rootfs/usr/local/bin/startup
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+#groupadd -g ${GID} peertube && useradd -u ${UID} -M -g ${GID} peertube
+
+usermod -u ${GID} peertube
+groupmod -g ${UID} peertube
+
+sed -i -e 's|<https>|'${HTTPS}'|' \
+		-e 's|<hostname>|'${HOSTNAME}'|' \
+		-e 's|<port>|'${PORT}'|' \
+		-e 's|<database_host>|'${DATABASE_HOST}'|' \
+		-e 's|<database_port>|'${DATABASE_PORT}'|' \
+		-e 's|<database_username>|'${DATABASE_USERNAME}'|' \
+		-e 's|<database_password>|'${DATABASE_PASSWORD}'|' \
+		-e 's|<admin_email>|'${ADMIN_EMAIL}'|' \
+		-e 's|<signup_enabled>|'${SIGNUP_ENABLE}'|' \
+		-e 's|<transcoding_enable>|'${TRANSCODING_ENABLE}'|' \
+		-e 's|<transcoding_threads>|'${TRANSCODING_THREADS}'|' \
+  		-e 's|<cache_size>|'${CACHE_SIZE}'|' \
+  		-e 's|<signup_limit>|'${SIGNUP_LIMIT}'|' \
+		-e 's|<video_quota>|'${VIDEO_QUOTA}'|' \
+  		-e 's|<resolution_280>|'${RESOLUTION_280}'|' \
+  		-e 's|<resolution_360>|'${RESOLUTION_360}'|' \
+  		-e 's|<resolution_480>|'${RESOLUTION_480}'|' \
+  		-e 's|<resolution_720>|'${RESOLUTION_720}'|' \
+  		-e 's|<resolution_1080>|'${RESOLUTION_1080}'|' /PeerTube/config/production.yaml
+
+sed -i -e 's|<body_size>|'${BODY_SIZE}'|' /etc/nginx/sites-enabled/peertube.conf
+
+chown -R $UID:$GID /home/peertube
+chown -R $UID:$GID /PeerTube
+
+nginx
+if [ $# -eq 0 ]; then
+   su - peertube -c "cd /PeerTube && NODE_ENV=production npm start"
+else
+   su - peertube -c "cd /PeerTube && NODE_ENV=production npm $#"
+fi


### PR DESCRIPTION
I create a production image on Debian slim. The build time is long (20 minutes), but I use last version of node 8, I not use the image node:8 because is heavy and not updated every time.

@rigelk make a docker README for my own peertube image, i copy it here :)