### PR TITLE
Pre-build PeerTube again in dev Dockerfile.

### DIFF
--- a/scripts/watch/client.sh
+++ b/scripts/watch/client.sh
@@ -2,4 +2,4 @@
 
 cd client || exit -1
 
-npm run ng -- server --hmr --host 0.0.0.0 --port 3000
+npm run ng -- server --hmr --host 0.0.0.0 --disable-host-check --port 3000

--- a/support/docker/dev/Dockerfile
+++ b/support/docker/dev/Dockerfile
@@ -24,8 +24,9 @@ RUN sudo chown user:user /home/user/janitor.json
 
 # Configure and build PeerTube.
 ADD create_user.sql /tmp/
-RUN sudo service postgresql start && \
-    sudo -u postgres psql --file=/tmp/create_user.sql
+RUN sudo service postgresql start \
+ && sudo -u postgres psql --file=/tmp/create_user.sql \
+ && npm run build
 
 ADD supervisord.conf /tmp/supervisord-extra.conf
 RUN cat /tmp/supervisord-extra.conf | sudo tee -a /etc/supervisord.conf


### PR DESCRIPTION
PeerTube pre-build was removed in #207 because `npm run dev` already builds it on-the-fly (see [this comment](https://github.com/Chocobozzz/PeerTube/pull/207/files#r161971735)).

However, I find that `npm run dev` takes too long to produce an initial build, causing [errors](https://irccloud.mozilla.com/pastebin/11Vv9PoA/ENOENT.txt) when you try to use PeerTube right after starting `npm run dev`.

I feel like including a pre-built PeerTube in dev images is valuable and convenient. @Chocobozzz please have a look when you have time.