### PR TITLE
update yarn installation command

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -52,7 +52,7 @@ $ sudo -u peertube unzip peertube-${VERSION}.zip && sudo -u peertube rm peertube
 Install Peertube
 ```
 $ cd ../ && sudo -u peertube ln -s versions/peertube-${VERSION} ./peertube-latest
-$ cd ./peertube-latest && sudo -u peertube yarn install --production --pure-lockfile
+$ cd ./peertube-latest && sudo -H -u peertube yarn install --production --pure-lockfile
 ```
 
 ### PeerTube configuration


### PR DESCRIPTION
on ubuntu `sudo -u` doesn't set homedirectory of the targeted user althought debian does. it requires the option `-H`. I think with this option it works in both case.