### PR TITLE
Precisions and security enhancements to the production guide

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -1,10 +1,10 @@
 server {
   listen 80;
-  # listen [::]:80;
-  server_name domain.tld;
+  listen [::]:80;
+  server_name peertube.example.com;
 
-  access_log /var/log/nginx/peertube_access.log;
-  error_log /var/log/nginx/peertube_error.log;
+  access_log /var/log/nginx/peertube.example.com.access.log;
+  error_log /var/log/nginx/peertube.example.com.error.log;
 
   location /.well-known/acme-challenge/ { allow all; }
   location / { return 301 https://$host$request_uri; }
@@ -12,16 +12,38 @@ server {
 
 server {
   listen 443 ssl http2;
-  # listen [::]:443 ssl http2;
-  server_name domain.tld;
+  listen [::]:443 ssl http2;
+  server_name peertube.example.com;
 
-  access_log /var/log/nginx/peertube_access.log;
-  error_log /var/log/nginx/peertube_error.log;
+  # For example with Let's Encrypt (you need a certificate to run https)
+  ssl_certificate      /etc/letsencrypt/live/peertube.example.com/fullchain.pem;
+  ssl_certificate_key  /etc/letsencrypt/live/peertube.example.com/privkey.pem;
+  
+  # Security hardening (as of 11/02/2018)
+  ssl_protocols TLSv1.3, TLSv1.2;# TLSv1.3 requires nginx >= 1.13.0 else use only TLSv1.2
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+  ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
+  ssl_session_timeout  10m;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off; # Requires nginx >= 1.5.9
+  ssl_stapling on; # Requires nginx >= 1.3.7
+  ssl_stapling_verify on; # Requires nginx => 1.3.7
+  resolver $DNS-IP-1 $DNS-IP-2 valid=300s;
+  resolver_timeout 5s;
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+  add_header X-Frame-Options DENY;
+  add_header X-Content-Type-Options nosniff;
+  add_header X-XSS-Protection "1; mode=block";
+  add_header X-Robots-Tag none;
+  
+  access_log /var/log/nginx/peertube.example.com.access.log;
+  error_log /var/log/nginx/peertube.example.com.error.log;
 
-  # For example with Let's Encrypt
-  ssl_certificate      /etc/letsencrypt/live/domain.tld/fullchain.pem;
-  ssl_certificate_key  /etc/letsencrypt/live/domain.tld/privkey.pem;
-  ssl_trusted_certificate /etc/letsencrypt/live/domain.tld/chain.pem;
+  location ^~ '/.well-known/acme-challenge' {
+    default_type "text/plain";
+    root /var/www/certbot;
+  }
 
   location ~ ^/client/(.*\.(js|css|woff2|otf|ttf|woff|eot))$ {
     add_header Cache-Control "public, max-age=31536000, immutable";
@@ -46,6 +68,7 @@ server {
     proxy_connect_timeout       600;
     proxy_send_timeout          600;
     proxy_read_timeout          600;
+    send_timeout                600;
   }
 
   # Bypass PeerTube webseed route for better performances


### PR DESCRIPTION
- added precisions and suggestions about how to generate Let's Encrypt certificates. Users have reported their installations didn't work when the problem came from missing certificates (false positives).
- security defaults of Nginx follow the basic robustness principle "be conservative in what you send, be liberal in what you accept", which isn't enough with modern security standards, so we should be picky with the cipher suites we use, among other things. Extra comments (especially for the TLS1.3 protocol support parameter) make the requirement of a recent Nginx installation obvious, and the downgrade alternative remains clear to the system administrator.

All in all, we should aknowledge users will most often copy and paste the configuration files. Making them secure by default may force a few users to read their configuration, but on the long run we are making the fediverse more secure.

Since I've come to modify a bit the Nginx config in `support/doc/production.md`, I've merged it with the template so that they stay consistent.