### PR TITLE
 Issue #168: youtube-like marking of comments

### DIFF
--- a/client/src/app/videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.html
@@ -2,6 +2,7 @@
   <img [src]="getAvatarUrl(comment.account)" alt="Avatar" />
 
   <div class="comment">
+    <span class="marked-comment" *ngIf="comment.marked">Marked comment</span>
     <div class="comment-account-date">
       <a target="_blank" [href]="comment.account.url" class="comment-account">{{ comment.by }}</a>
       <div class="comment-date">{{ comment.createdAt | myFromNow }}</div>
@@ -9,6 +10,7 @@
     <div class="comment-html" [innerHTML]="sanitizedCommentHTML"></div>
 
     <div class="comment-actions">
+      <a [href]="getCommentUrl(comment.id)" class="comment-action-link">Link</a>
       <div *ngIf="isUserLoggedIn()" (click)="onWantToReply()" class="comment-action-reply">Reply</div>
       <div *ngIf="isRemovableByUser()" (click)="onWantToDelete()" class="comment-action-delete">Delete</div>
     </div>

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.html
@@ -5,7 +5,7 @@
     <span class="marked-comment" *ngIf="comment.marked">Marked comment</span>
     <div class="comment-account-date">
       <a target="_blank" [href]="comment.account.url" class="comment-account">{{ comment.by }}</a>
-      <a [href]="getCommentUrl(comment.id)" class="comment-date">{{ comment.createdAt | myFromNow }}</a>
+      <a [routerLink]="['/videos/watch', video.uuid, 'comment', comment.id]" class="comment-date">{{ comment.createdAt | myFromNow }}</a>
     </div>
     <div class="comment-html" [innerHTML]="sanitizedCommentHTML"></div>
 

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.html
@@ -5,12 +5,11 @@
     <span class="marked-comment" *ngIf="comment.marked">Marked comment</span>
     <div class="comment-account-date">
       <a target="_blank" [href]="comment.account.url" class="comment-account">{{ comment.by }}</a>
-      <div class="comment-date">{{ comment.createdAt | myFromNow }}</div>
+      <a [href]="getCommentUrl(comment.id)" class="comment-date">{{ comment.createdAt | myFromNow }}</a>
     </div>
     <div class="comment-html" [innerHTML]="sanitizedCommentHTML"></div>
 
     <div class="comment-actions">
-      <a [href]="getCommentUrl(comment.id)" class="comment-action-link">Link</a>
       <div *ngIf="isUserLoggedIn()" (click)="onWantToReply()" class="comment-action-reply">Reply</div>
       <div *ngIf="isRemovableByUser()" (click)="onWantToDelete()" class="comment-action-delete">Delete</div>
     </div>

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.scss
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.scss
@@ -51,7 +51,7 @@
       margin: 10px 0;
       display: flex;
 
-      .comment-action-reply, .comment-action-delete, .comment-action-link {
+      .comment-action-reply, .comment-action-delete {
         color: #585858;
         cursor: pointer;
         margin-right: 10px;

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.scss
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.scss
@@ -32,6 +32,13 @@
       }
     }
 
+    .marked-comment {
+      background-color: #F5F5F5;
+      padding-left: 3px;
+      padding-right: 3px;
+      font-size: 12px;
+    }
+
     .comment-html {
       a {
         @include disable-default-a-behaviour;
@@ -44,7 +51,7 @@
       margin: 10px 0;
       display: flex;
 
-      .comment-action-reply, .comment-action-delete {
+      .comment-action-reply, .comment-action-delete, .comment-action-link {
         color: #585858;
         cursor: pointer;
         margin-right: 10px;

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.ts
@@ -86,8 +86,4 @@ export class VideoCommentComponent implements OnInit {
         this.user.hasRight(UserRight.REMOVE_ANY_VIDEO_COMMENT)
       )
   }
-
-  getCommentUrl (commentId) {
-    return '/videos/watch/' + this.video.uuid + '?markedcomment=' + commentId
-  }
 }

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.ts
@@ -86,4 +86,8 @@ export class VideoCommentComponent implements OnInit {
         this.user.hasRight(UserRight.REMOVE_ANY_VIDEO_COMMENT)
       )
   }
+
+  getCommentUrl (commentId) {
+    return '/videos/watch/' + this.video.uuid + '?markedcomment=' + commentId
+  }
 }

--- a/client/src/app/videos/+video-watch/comment/video-comment.model.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comment.model.ts
@@ -13,8 +13,8 @@ export class VideoComment implements VideoCommentServerModel {
   updatedAt: Date | string
   account: AccountInterface
   totalReplies: number
-
   by: string
+  marked = false
 
   constructor (hash: VideoCommentServerModel) {
     this.id = hash.id

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -178,11 +178,11 @@ export class VideoCommentsComponent implements OnChanges {
       this.componentPagination.currentPage = 1
       this.componentPagination.totalItems = null
 
-      // Find marked comment in GET params
-      this.activatedRoute.queryParams.forEach(
-        value => {
-          if (value.markedcomment) {
-            this.markedCommentID = Number(value.markedcomment)
+      // Find marked comment in params
+      this.activatedRoute.params.subscribe(
+        params => {
+          if (params['commentId']) {
+            this.markedCommentID = +params['commentId']
           }
         }
       )

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -9,6 +9,7 @@ import { SortField } from '../../../shared/video/sort-field.type'
 import { VideoDetails } from '../../../shared/video/video-details.model'
 import { VideoComment } from './video-comment.model'
 import { VideoCommentService } from './video-comment.service'
+import { ActivatedRoute } from '@angular/router'
 
 @Component({
   selector: 'my-video-comments',
@@ -29,12 +30,14 @@ export class VideoCommentsComponent implements OnChanges {
   inReplyToCommentId: number
   threadComments: { [ id: number ]: VideoCommentThreadTree } = {}
   threadLoading: { [ id: number ]: boolean } = {}
+  markedCommentID: number
 
   constructor (
     private authService: AuthService,
     private notificationsService: NotificationsService,
     private confirmService: ConfirmService,
-    private videoCommentService: VideoCommentService
+    private videoCommentService: VideoCommentService,
+    private activatedRoute: ActivatedRoute
   ) {}
 
   ngOnChanges (changes: SimpleChanges) {
@@ -63,6 +66,18 @@ export class VideoCommentsComponent implements OnChanges {
         res => {
           this.comments = this.comments.concat(res.comments)
           this.componentPagination.totalItems = res.totalComments
+
+          if (this.markedCommentID) {
+            // If there is a marked comment, retrieve it separately as it may not be on this page, filter to prevent duplicate
+            this.comments = this.comments.filter(value => value.id !== this.markedCommentID)
+            this.videoCommentService.getVideoThreadComments(this.video.id, this.markedCommentID).subscribe(
+              res => {
+                let comment = new VideoComment(res.comment)
+                comment.marked = true
+                this.comments.unshift(comment) // Insert marked comment at the beginning
+              }
+            )
+          }
         },
 
         err => this.notificationsService.error('Error', err.message)
@@ -162,6 +177,15 @@ export class VideoCommentsComponent implements OnChanges {
       this.inReplyToCommentId = undefined
       this.componentPagination.currentPage = 1
       this.componentPagination.totalItems = null
+
+      // Find marked comment in GET params
+      this.activatedRoute.queryParams.forEach(
+        value => {
+          if (value.markedcomment) {
+            this.markedCommentID = Number(value.markedcomment)
+          }
+        }
+      )
 
       this.loadMoreComments()
     }

--- a/client/src/app/videos/+video-watch/video-watch-routing.module.ts
+++ b/client/src/app/videos/+video-watch/video-watch-routing.module.ts
@@ -10,6 +10,11 @@ const videoWatchRoutes: Routes = [
     path: '',
     component: VideoWatchComponent,
     canActivate: [ MetaGuard ]
+  },
+  {
+    path: 'comment/:commentId',
+    component: VideoWatchComponent,
+    canActivate: [ MetaGuard ]
   }
 ]
 


### PR DESCRIPTION
Uses GET parameters to mark comments similar to youtube, allowing to send a comment link to someone else.
I agree with Aluriak that the « x min ago » text is not a logical place to provide the link, even though this is the case in youtube. (#168)
Right now I included a link next to the `Delete` and `Reply` links, but i'm open to changing that.
