### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+In order to create an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of:
+
+* age
+* body size
+* disability
+* ethnicity
+* gender identity and expression
+* level of experience
+* education
+* socio-economic status
+* nationality
+* personal appearance
+* ethnicity
+* religion
+* sexual identity and orientation
+
+## Our standards
+
+A supplemental goal of this Code of Conduct is to increase open source and culture citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, please recognize their efforts.
+
+You can contribute to creating a positive environment in many ways. For example you can:
+
+* use welcoming and inclusive language
+* be respectful of differing viewpoints and experiences
+* accept constructive criticism gracefully
+* focus on what is best for the community
+* show empathy towards other community members
+
+You should not:
+
+* use sexualised language or imagery
+* make unwelcome sexual advances
+* troll, and make insulting or derogatory comments
+* make personal or political attacks
+* harass others, in public or private
+* publish others' private information, such as a physical or electronic address, without explicit permission
+* engage in any other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our responsibilities
+
+As project maintainers, we are responsible for clarifying the standards of acceptable behaviour and we are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.
+
+We have the right and responsibility to remove, edit, or reject:
+
+* comments
+* commits
+* code
+* wiki edits
+* issues
+* other contributions that are not aligned to this code of conduct
+
+We also reserve the right to temporarily or permanently ban any contributor for other behaviours we deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This code of conduct applies whenever you are representing the project or community. For example you may be:
+
+* working in a project space online or in the public (i.e.: github.com, framacolibri.org, IRC)
+* using an official project email address
+* posting via an official social media account
+* participating in an online or offline event
+
+Project maintainers may further define and clarify representation of a project.
+
+## Enforcement
+
+You should report any instances of abusive, harassing, or otherwise unacceptable behaviour to the project team at me@florianbigard.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain the anonymity of the reporter of an incident. We may post further details of specific enforcement policies separately.
+
+Project maintainers who do not follow or enforce this code of conduct in good faith may face temporary or permanent consequences. These will be determined by members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
We want to be inclusive to the largest number of participants, with the most varied and diverse backgrounds possible. As such, we should take position as to how we will defend our contributors. Better settle on how we handle dire situations before they happen.

I saw some projects of Framasoft already used the Contributor Covenant CoC, and it's apparently used by a large number of projects, so I figured out we could use something of the like. Again, it's not just a text. We should be ready to enforce it too, so better agree on it :-)

Nota: the code of conduct isn't clear on the disclosure of an incident per se. That should be investigated further.
Nota bis: maybe we should leave the PR open some time and call for discussion over it?