### PR TITLE
Remove X-Frame options in nginx config

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -38,7 +38,6 @@ server {
   # resolver_timeout 5s;
 
   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-  add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection "1; mode=block";
   add_header X-Robots-Tag none;


### PR DESCRIPTION
`X-Frame-Options DENY;` doesn't permit sharing using iframe

if present we get the following message in browser : 
`
Load denied by X-Frame-Options: https://peertube.valvin.fr/videos/embed/b2cc97ef-dc05-400b-94f8-43ea61237718 does not permit framing.`