### PR TITLE
dependencies.md : Update g++ needed version

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -21,6 +21,7 @@
 $ sudo apt update
 $ sudo apt install nginx ffmpeg postgresql openssl g++ make redis-server git
 $ ffmpeg -version # Should be >= 3.x 
+$ g++ -v # Should be >= 5.x
 ```
 
 ## Arch Linux


### PR DESCRIPTION
In order to build properly rdf-canonize node nativ module gcc > 5 is needed. Tested on Ubuntu 14.04 with gcc 4.8, it didn't work. I had to install a newer gcc version and it was OK.