### PR TITLE
[docker] Update production guidelines and docker-compose file

### DIFF
--- a/support/doc/docker.md
+++ b/support/doc/docker.md
@@ -1,26 +1,61 @@
 # Docker guide
 
-## Test/Development 
-
-You can quickly get a server running using Docker. You need to have [docker](https://www.docker.com/community-edition) and [docker-compose](https://docs.docker.com/compose/install/) installed.
-
-For this example configuration, you should also run a reverse proxy. The example
-Docker Compose file provides example labels for the Traefik load balancer,
-though any HTTP reverse proxy is compatible.
-
-Example for running a PeerTube server locally:
-
-```bash
-$ wget https://github.com/chocobozzz/PeerTube/raw/develop/support/docker/production/docker-compose.yml
-$ sudo \
-    PEERTUBE_HOSTNAME=peertube.lvh.me \
-    PEERTUBE_ADMIN_EMAIL=test@example.com \
-    PEERTUBE_TRANSCODING_ENABLED=true \
-    docker-compose up app
-```
-
-(Get the initial root user password from the program output.)
+You can quickly get a server running using Docker. You need to have
+[docker](https://www.docker.com/community-edition) and
+[docker-compose](https://docs.docker.com/compose/install/) installed.
 
 ## Production
 
-PR welcome!
+### Build your own Docker image
+
+```bash
+$ git clone https://github.com/chocobozzz/PeerTube /tmp/peertube
+$ cd /tmp/peertube
+$ docker build . -f ./support/docker/production/Dockerfile.stretch
+```
+
+### Run a preconfigured setup with all dependencies
+
+PeerTube needs a PostgreSQL and a Redis instance to work correctly. If you want
+to quickly set up a full environment, either for trying the service or in
+production, you can use a `docker-compose` setup.
+
+```bash
+$ git clone https://github.com/chocobozzz/PeerTube /tmp/peertube
+$ cd /tmp/peertube/support/docker/production
+```
+
+Then tweak the `docker-compose.yml` file there according to your needs. Then
+you can use the regular `up` command to set it up, with possible overrides of
+the environment variables:
+
+```bash
+$ PEERTUBE_HOSTNAME=peertube.lvh.me \
+  PEERTUBE_ADMIN_EMAIL=test@example.com \
+  PEERTUBE_TRANSCODING_ENABLED=true \
+  PEERTUBE_SIGNUP_ENABLED=true \
+  PEERTUBE_SMTP_HOST=mail.lvh.me \
+  PEERTUBE_SMTP_PORT=1025 \
+  PEERTUBE_SMTP_FROM=noreply@peertube.lvh.me \
+    docker-compose up
+```
+
+Other environment variables are used in
+`support/docker/production/config/custom-environment-variables.yaml` and can be
+intuited from usage.
+
+For this example configuration, a reverse proxy is quite recommended. The
+example Docker Compose file provides example labels for a Traefik load
+balancer, although any HTTP reverse proxy will work fine. See the example
+Nginx configuration `support/nginx/peertube` file to get an idea of
+recommendations and requirements to run PeerTube the most efficiently.
+
+**Important**: note that you'll get the initial `root` user password from the
+program output, so check out your logs to find them.
+
+## Development
+
+The Docker image that's preconfigured in `support/docker/dev` contains all the
+services embedded in one image, so as to work correctly on
+[Janitor](https://janitor.technology). It is much not advised to use it in
+production.

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -33,7 +33,7 @@ smtp:
   tls:
     __name: "PEERTUBE_SMTP_TLS"
     __format: "json"
-  form_address: "PEERTUBE_ADMIN_EMAIL"
+  from_address: "PEERTUBE_SMTP_FROM"
 
 admin:
   email: "PEERTUBE_ADMIN_EMAIL"

--- a/support/docker/production/config/production.yaml
+++ b/support/docker/production/config/production.yaml
@@ -78,3 +78,7 @@ instance:
   name: 'PeerTube'
   description: '' # Support markdown
   terms: '' # Support markdown
+  default_client_route: '/videos/trending'
+  customizations:
+    javascript: '' # Directly your JavaScript code (without <script> tags). Will be eval at runtime
+    css: '' # Directly your CSS code (without <style> tags). Will be injected at runtime

--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -1,19 +1,27 @@
 version: "3.3"
 
 services:
-  peertube:
 
-    build: .
+  peertube:
+    build:
+      context: ../../../
+      dockerfile: ./support/docker/production/Dockerfile.stretch
     image: peertube:stretch
     environment:
       PEERTUBE_HOSTNAME: my.domain.tld
       PEERTUBE_PORT: 443
-      PEERTUBE_HTTPS: true
+      PEERTUBE_HTTPS: "true"
       PEERTUBE_ADMIN_EMAIL: admin@domain.tld
-      PEERTUBE_DB_USERNAME: user
-      PEERTUBE_DB_PASSWORD: password
-      PEERTUBE_SIGNUP_ENABLED: true
-      PEERTUBE_TRANSCODING_ENABLED: true
+      PEERTUBE_DB_HOSTNAME: postgres
+      PEERTUBE_DB_USERNAME: postgres_user
+      PEERTUBE_DB_PASSWORD: postgres_password
+      PEERTUBE_SIGNUP_ENABLED: "true"
+      PEERTUBE_TRANSCODING_ENABLED: "true"
+      PEERTUBE_REDIS_HOSTNAME: redis
+      PEERTUBE_SMTP_HOSTNAME: mail.domain.tld
+      PEERTUBE_SMTP_PORT: 25
+      PEERTUBE_SMTP_FROM: noreply@peertube.domain.tld
+      PEERTUBE_SMTP_TLS: "true"
     # Traefik labels are suggested as an example for people using Traefik,
     # remove them if you are using another reverse proxy.
     labels:
@@ -23,13 +31,22 @@ services:
     volumes:
       - ./data:/usr/src/app/data
     depends_on:
-      - db
+      - postgres
+      - redis
+    restart: "always"
 
-  db:
+  postgres:
     image: postgres:10
     environment:
-      POSTGRES_USERNAME: user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: peertube_prod
+      POSTGRES_USER: postgres_user
+      POSTGRES_PASSWORD: postgres_password
+      POSTGRES_DB: peertube
     volumes:
       - ./db:/var/lib/postgresql/data
+    restart: "always"
+
+  redis:
+    image: redis
+    volumes:
+      - ./redis:/data
+    restart: "always"


### PR DESCRIPTION
Updated the docker compose file so I can keep on using it on my server. In particular, it tweaks a few configuration options in the example yaml configuration file, requests to always restart the docker images if one of them is shut down, fixes many issues in the docker-compose file (incorrect env var names, quotes, etc).

I've also added some documentation to make it clearer how to use this image with `docker-compose`.

I've build it and tested it locally and it works great (including email support).