### PR TITLE
Revert "Selective route X-Frame-Options to allow embeds, fixes #322 in a better way"

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -38,7 +38,6 @@ server {
   # resolver_timeout 5s;
 
   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-  add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection "1; mode=block";
   add_header X-Robots-Tag none;
@@ -102,11 +101,6 @@ server {
     }
 
     alias /var/www/peertube/storage/videos;
-  }
-
-  # Allow embeds
-  location /videos/embed {
-    proxy_hide_header X-Frame-Options;
   }
 
   # Websocket tracker


### PR DESCRIPTION
Reverts Chocobozzz/PeerTube#364

It does not work because we loose the proxy of `location /`