### PR TITLE
Readme, link to api documentation: Link to a rendered html view instead of raw html

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ coder to help!
 
 For now only on Github:
 
- * HTML version: [/support/doc/api/html/index.html](/support/doc/api/html/index.html)
+ * HTML version: [/support/doc/api/html/index.html](https://htmlpreview.github.io/?https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/api/html/index.html)
  * Swagger/OpenAPI schema: [/support/doc/api/openapi.yaml](/support/doc/api/openapi.yaml)
 
 ## Tools


### PR DESCRIPTION
To avoid to download the html file and view it locally, make documentation readable when I click on the link.