### PR TITLE
Clean shell scripts

### DIFF
--- a/scripts/build/client.sh
+++ b/scripts/build/client.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-cd client || exit -1
+set -eu
+
+cd client
 
 rm -rf ./dist ./compiled
 

--- a/scripts/build/server.sh
+++ b/scripts/build/server.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 rm -rf ./dist
 

--- a/scripts/clean/client/dist.sh
+++ b/scripts/clean/client/dist.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
-cd client || exit -1
+set -eu
+
+cd client
 rm -rf compiled/ dist/ dll/

--- a/scripts/clean/server/dist.sh
+++ b/scripts/clean/server/dist.sh
@@ -1,3 +1,5 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 rm -rf dist/

--- a/scripts/clean/server/test.sh
+++ b/scripts/clean/server/test.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 for i in $(seq 1 6); do
   dropdb "peertube_test$i"

--- a/scripts/client-report.sh
+++ b/scripts/client-report.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-cd client || exit -1
+set -eu
+
+cd client
 
 npm run webpack-bundle-analyzer ./dist/stats.json

--- a/scripts/danger/clean/dev.sh
+++ b/scripts/danger/clean/dev.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -eu
+
 read -p "This will remove all directories and SQL tables. Are you sure? (y/*) " -n 1 -r
 echo
 
 if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-  NODE_ENV=test npm run ts-node -- --type-check "./scripts/danger/clean/cleaner"
+  NODE_ENV=test npm run ts-node -- --type-check "scripts/danger/clean/cleaner"
 fi

--- a/scripts/danger/clean/modules.sh
+++ b/scripts/danger/clean/modules.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 read -p "This will remove all node server and client modules. Are you sure? " -n 1 -r
 
 if [[ "$REPLY" =~ ^[Yy]$ ]]; then

--- a/scripts/danger/clean/prod.sh
+++ b/scripts/danger/clean/prod.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 read -p "This will remove all directories and SQL tables. Are you sure? (y/*) " -n 1 -r
 echo
 

--- a/scripts/dev/client.sh
+++ b/scripts/dev/client.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 NODE_ENV=test concurrently -k \
   "npm run watch:client" \

--- a/scripts/dev/index.sh
+++ b/scripts/dev/index.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 NODE_ENV=test concurrently -k \
   "npm run watch:client" \

--- a/scripts/dev/server.sh
+++ b/scripts/dev/server.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 if [ ! -f "./client/dist/index.html" ]; then
   echo "client/dist/index.html does not exist, compile client files..."

--- a/scripts/generate-api-doc.sh
+++ b/scripts/generate-api-doc.sh
@@ -1,3 +1,5 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 npm run spectacle-docs -- -t support/doc/api/html support/doc/api/openapi.yaml

--- a/scripts/generate-code-contributors.sh
+++ b/scripts/generate-code-contributors.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
+
+set -eu
 
 curl -s https://api.github.com/repos/chocobozzz/peertube/contributors | \
   jq -r 'map("\\\n * [" + .login + "](" + .url + ")") | .[]' | \

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 printf "############# PeerTube help #############\n\n"
 printf "npm run ...\n"

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 if [ ! -f "dist/server.js" ]; then
   echo "Missing server file (server.js)."
@@ -7,7 +9,7 @@ fi
 
 max=${1:-3}
 
-for i in $(seq 1 $max); do
+for i in $(seq 1 "$max"); do
   NODE_ENV=test NODE_APP_INSTANCE=$i node dist/server.js &
   sleep 1
 done

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-npm run build:server || exit -1
-npm run travis -- lint || exit -1
+set -eu
+
+npm run build:server
+npm run travis -- lint
 
 mocha --exit --require ts-node/register/type-check --bail server/tests/index.ts

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/sh
+
+set -eu
 
 if [ $# -eq 0 ]; then
     echo "Need test suite argument."
@@ -21,9 +23,9 @@ elif [ "$1" = "api-slow" ]; then
     npm run build:server
     mocha --timeout 5000 --exit --require ts-node/register/type-check --bail server/tests/api/index-slow.ts
 elif [ "$1" = "lint" ]; then
-    cd client || exit -1
-    npm run lint || exit -1
+    ( cd client
+      npm run lint
+    )
 
-    cd .. || exit -1
-    npm run tslint -- --project ./tsconfig.json -c ./tslint.json server.ts "server/**/*.ts" "shared/**/*.ts" || exit -1
+    npm run tslint -- --project ./tsconfig.json -c ./tslint.json server.ts "server/**/*.ts" "shared/**/*.ts"
 fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,7 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-# Strict mode
-set -e
+set -eu
 
 # Backup database
 SQL_BACKUP_PATH="/var/www/peertube/backup/sql-peertube_prod-$(date +\"%Y%m%d-%H%M\").bak" 
@@ -11,19 +10,18 @@ pg_dump -U peertube -W -h localhost -F c peertube_prod -f "$SQL_BACKUP_PATH"
 # Get and Display the Latest Version
 VERSION=$(curl -s https://api.github.com/repos/chocobozzz/peertube/releases/latest | grep tag_name | cut -d '"' -f 4)
 echo "Latest Peertube version is $VERSION"
-wget -q "https://github.com/Chocobozzz/PeerTube/releases/download/${VERSION}/peertube-${VERSION}.zip" -O /var/www/peertube/versions/peertube-${VERSION}.zip
+wget -q "https://github.com/Chocobozzz/PeerTube/releases/download/${VERSION}/peertube-${VERSION}.zip" -O "/var/www/peertube/versions/peertube-${VERSION}.zip"
 cd /var/www/peertube/versions
-unzip -o peertube-${VERSION}.zip
-rm -f peertube-${VERSION}.zip
+unzip -o "peertube-${VERSION}.zip"
+rm -f "peertube-${VERSION}.zip"
 
 # Upgrade Scripts
 rm -rf /var/www/peertube/peertube-latest
-ln -s /var/www/peertube/versions/peertube-${VERSION} /var/www/peertube/peertube-latest
-cd  /var/www/peertube/peertube-latest
+ln -s "/var/www/peertube/versions/peertube-${VERSION}" /var/www/peertube/peertube-latest
+cd /var/www/peertube/peertube-latest
 yarn install --production --pure-lockfile 
 cp /var/www/peertube/peertube-latest/config/default.yaml /var/www/peertube/config/default.yaml
 
 echo "Differences in configuration files..."
-diff /var/www/peertube/versions/peertube-${VERSION}/config/production.yaml.example /var/www/peertube/config/production.yaml
+diff "/var/www/peertube/versions/peertube-${VERSION}/config/production.yaml.example" /var/www/peertube/config/production.yaml
 
-exit 0

--- a/scripts/watch/client.sh
+++ b/scripts/watch/client.sh
@@ -1,5 +1,7 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
-cd client || exit -1
+set -eu
+
+cd client
 
 npm run ng -- server --hmr --host 0.0.0.0 --disable-host-check --port 3000

--- a/scripts/watch/server.sh
+++ b/scripts/watch/server.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
+set -eu
 
 NODE_ENV=test concurrently -k \
   "npm run tsc -- --sourceMap && npm run nodemon -- --delay 2 --watch ./dist dist/server" \


### PR DESCRIPTION
Hi,

I switched all the compatible scripts to `#!/bin/sh`, I added `set -eu` on all of them, which allowed me to remove a lot of `|| exit -1`.

Then I fixed some stuff spotted by ShellCheck. A few are remaining:

```sh
In ./scripts/release.sh line 7:
  PGID=$(ps -o pgid= $$ | grep -o "[0-9]*")
         ^-- SC2009: Consider using pgrep instead of grepping ps output.
```

I think this one is a false positive in this case. Can't find a way to do the same using `pgrep` (but I didn't searched a lot). We can leave it like this, and maybe add a shellcheck directive to disable this warning on this line if you want.

```sh
In ./scripts/release.sh line 44:
  [[ "$0" = "$BASH_SOURCE" ]] && exit 0
             ^-- SC2128: Expanding an array without an index only gives the first element.
```

I don't see where does `$BASH_SOURCE` come from, and I don't understand what's the goal of this line: why changing `$0` just before doing `exit 0` ? Depending on this, there's various way to fix the warning...

Last:

```sh
In ./scripts/danger/clean/dev.sh line 9:
  NODE_ENV=$(test npm run ts-node -- --type-check "scripts/danger/clean/cleaner")
  ^-- SC2034: NODE_ENV appears unused. Verify it or export it.


In ./scripts/watch/server.sh line 5:
NODE_ENV=$(test concurrently -k \
^-- SC2034: NODE_ENV appears unused. Verify it or export it.


In ./scripts/dev/client.sh line 5:
NODE_ENV=$(test concurrently -k \
^-- SC2034: NODE_ENV appears unused. Verify it or export it.


In ./scripts/dev/index.sh line 5:
NODE_ENV=$(test concurrently -k \
^-- SC2034: NODE_ENV appears unused. Verify it or export it.
```

I'm also not sure about what I did when changing all `NODE_ENV=test [...]` to `NODE_ENV=$(test [...])` as I don't see where's `NODE_ENV` used. ShellCheck can't find it either...