### PR TITLE
show quota in stats, display quota on the about page, fixes #405

### DIFF
--- a/client/src/app/about/about.component.html
+++ b/client/src/app/about/about.component.html
@@ -13,6 +13,14 @@
     <div class="section-title">Terms</div>
 
     <div [innerHTML]="termsHTML"></div>
+
+    <div *ngIf="userVideoQuota !== -1;else noQuota">
+      This instance provides a baseline quota of {{ userVideoQuota | bytes: 0 }} space for the videos of its users.
+    </div>
+    
+    <ng-template #noQuota>
+      This instance provides unlimited space for the videos of its users.
+    </ng-template>
   </div>
 
   <div id="p2p-privacy">

--- a/client/src/app/about/about.component.ts
+++ b/client/src/app/about/about.component.ts
@@ -23,6 +23,10 @@ export class AboutComponent implements OnInit {
     return this.serverService.getConfig().instance.name
   }
 
+  get userVideoQuota () {
+    return this.serverService.getConfig().user.videoQuota
+  }
+
   ngOnInit () {
     this.serverService.getAbout()
       .subscribe(
@@ -31,7 +35,7 @@ export class AboutComponent implements OnInit {
           this.termsHTML = this.markdownService.textMarkdownToHTML(res.instance.terms)
         },
 
-        err => this.notificationsService.error('Error', err)
+        err => this.notificationsService.error('Error getting about from server', err)
       )
   }
 

--- a/client/src/app/core/server/server.service.ts
+++ b/client/src/app/core/server/server.service.ts
@@ -5,6 +5,7 @@ import 'rxjs/add/operator/do'
 import { ReplaySubject } from 'rxjs/ReplaySubject'
 import { ServerConfig } from '../../../../../shared'
 import { About } from '../../../../../shared/models/server/about.model'
+import { ServerStats } from '../../../../../shared/models/server/server-stats.model'
 import { environment } from '../../../environments/environment'
 
 @Injectable()
@@ -51,6 +52,9 @@ export class ServerService {
       file: {
         extensions: []
       }
+    },
+    user: {
+      videoQuota: -1
     }
   }
   private videoCategories: Array<{ id: number, label: string }> = []

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -76,6 +76,9 @@ async function getConfig (req: express.Request, res: express.Response, next: exp
       file: {
         extensions: CONSTRAINTS_FIELDS.VIDEOS.EXTNAME
       }
+    },
+    user: {
+      videoQuota: CONFIG.USER.VIDEO_QUOTA
     }
   }
 

--- a/shared/models/server/server-config.model.ts
+++ b/shared/models/server/server-config.model.ts
@@ -39,4 +39,8 @@ export interface ServerConfig {
       extensions: string[]
     }
   }
+
+  user: {
+    videoQuota: number
+  }
 }


### PR DESCRIPTION
As outlined by @Aldarone, the quota is one of the deciding factors when choosing an instance, and we should make it easy to spot.

For now I placed it in the about page as suggested (admittedly the wording could be improved…):


![showing quota on the about page](https://user-images.githubusercontent.com/6329880/37936619-7ee496a8-3156-11e8-8c0a-8dda88996011.png)

It conveniently pulls data from the `API/server/stats` route, which now exposes the video quota defined in the config. This way, servers publicly disclose their baseline quota for potential newcomers to know.