### PR TITLE
Fix Quotation marks on database backup files

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Backup database
-SQL_BACKUP_PATH="/var/www/peertube/backup/sql-peertube_prod-$(date +\"%Y%m%d-%H%M\").bak" 
+SQL_BACKUP_PATH="/var/www/peertube/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").bak" 
 mkdir -p /var/www/peertube/backup
 pg_dump -U peertube -W -h localhost -F c peertube_prod -f "$SQL_BACKUP_PATH" 
 


### PR DESCRIPTION
Remove Quotation marks on database backup files.
Example in backup folder, showing files  : 
`sql-peertube_prod-"20180507-2328".bak`
