### PR TITLE
Configure path used by script upgrade.sh

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2,26 +2,28 @@
 
 set -eu
 
+PEERTUBE_PATH=/var/www/peertube/
+
 # Backup database
-SQL_BACKUP_PATH="/var/www/peertube/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").bak" 
-mkdir -p /var/www/peertube/backup
+SQL_BACKUP_PATH="$PEERTUBE_PATH/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").bak" 
+mkdir -p $PEERTUBE_PATH/backup
 pg_dump -U peertube -W -h localhost -F c peertube_prod -f "$SQL_BACKUP_PATH" 
 
 # Get and Display the Latest Version
 VERSION=$(curl -s https://api.github.com/repos/chocobozzz/peertube/releases/latest | grep tag_name | cut -d '"' -f 4)
 echo "Latest Peertube version is $VERSION"
-wget -q "https://github.com/Chocobozzz/PeerTube/releases/download/${VERSION}/peertube-${VERSION}.zip" -O "/var/www/peertube/versions/peertube-${VERSION}.zip"
-cd /var/www/peertube/versions
+wget -q "https://github.com/Chocobozzz/PeerTube/releases/download/${VERSION}/peertube-${VERSION}.zip" -O "$PEERTUBE_PATH/versions/peertube-${VERSION}.zip"
+cd $PEERTUBE_PATH/versions
 unzip -o "peertube-${VERSION}.zip"
 rm -f "peertube-${VERSION}.zip"
 
 # Upgrade Scripts
-rm -rf /var/www/peertube/peertube-latest
-ln -s "/var/www/peertube/versions/peertube-${VERSION}" /var/www/peertube/peertube-latest
-cd /var/www/peertube/peertube-latest
+rm -rf $PEERTUBE_PATH/peertube-latest
+ln -s "$PEERTUBE_PATH/versions/peertube-${VERSION}" $PEERTUBE_PATH/peertube-latest
+cd $PEERTUBE_PATH/peertube-latest
 yarn install --production --pure-lockfile 
-cp /var/www/peertube/peertube-latest/config/default.yaml /var/www/peertube/config/default.yaml
+cp $PEERTUBE_PATH/peertube-latest/config/default.yaml $PEERTUBE_PATH/config/default.yaml
 
 echo "Differences in configuration files..."
-diff "/var/www/peertube/versions/peertube-${VERSION}/config/production.yaml.example" /var/www/peertube/config/production.yaml
+diff "$PEERTUBE_PATH/versions/peertube-${VERSION}/config/production.yaml.example" $PEERTUBE_PATH/config/production.yaml
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2,7 +2,24 @@
 
 set -eu
 
-PEERTUBE_PATH=/var/www/peertube/
+PEERTUBE_PATH=${1:-/var/www/peertube/}
+
+if [ ! -e "$PEERTUBE_PATH" ]; then
+  echo "Error - path \"$PEERTUBE_PATH\" wasn't found"
+  echo ""
+  echo "If peertube was installed in another path, you can specify it with"
+  echo "    ./upgrade.sh <PATH>"
+  exit 1
+fi
+
+if [ ! -e "$PEERTUBE_PATH/versions" -o ! -e "$PEERTUBE_PATH/config/production.yaml" ]; then
+  echo "Error - Couldn't find peertube installation in \"$PEERTUBE_PATH\""
+  echo ""
+  echo "If peertube was installed in another path, you can specify it with"
+  echo "    ./upgrade.sh <PATH>"
+  exit 1
+fi
+
 
 # Backup database
 SQL_BACKUP_PATH="$PEERTUBE_PATH/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").bak" 


### PR DESCRIPTION
It is now possible to pass the path to upgrade on script, as Peertube could be installed in another path than /var/www/peertube.

I couldn't find a clean way to guess the path to use, so I've chosen instead to let administrator specify the path by hand.