### PR TITLE
Peertube for Yunohost.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ BitTorrent) inside the web browser, as of today.
 See the [docker guide](/support/doc/docker.md)
 
 ## Run on YunoHost
+[![Install Peertube with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=peertube)
 
-Peertube app for [YunoHost](https://yunohost.org).See [here](https://github.com/YunoHost-Apps/peertube_ynh)
+Peertube app for [YunoHost](https://yunohost.org). See [here](https://github.com/YunoHost-Apps/peertube_ynh)
 
 ## Production
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ BitTorrent) inside the web browser, as of today.
 
 See the [docker guide](/support/doc/docker.md)
 
+## Run on YunoHost
+
+Peertube app for [YunoHost](https://yunohost.org).See [here](https://github.com/YunoHost-Apps/peertube_ynh)
+
 ## Production
 
 See the [production guide](/support/doc/production.md).


### PR DESCRIPTION

Peertube app for YunoHost is ready. People who want to self host without going into deep details for the installation,backup and restore have the option to run Peertube over the YunoHost. Hope to see many more new instances.