### PR TITLE
onboarding modification to instances list/website

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ directly in the web browser with <a href="https://github.com/feross/webtorrent">
   </a>
 </p>
 
-<p align="center">
+## Getting Started
+
+<p align="left">
   <strong><a title="Website" target="_blank" href="https://joinpeertube.org">Website</a> |
   <a title="Instances list" target="_blank" href="https://instances.joinpeertube.org">Instances list</a>
   </strong>


### PR DESCRIPTION
added Getting Started header and changed alignment to left. notable that the preview seems to show a green line to the left of it? but i believe that is a visual aid used by github to show that that section changed, and not something i somehow accidentally added. if it is by mistake, i can change it once told how