### PR TITLE
Update sudo command for yarn during upgrade

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -205,7 +205,7 @@ Now your instance is up you can:
 The password it asks is PeerTube's database user password.
 
 ```
-$ cd /var/www/peertube/peertube-latest/scripts && sudo -u peertube ./upgrade.sh
+$ cd /var/www/peertube/peertube-latest/scripts && sudo -H -u peertube ./upgrade.sh
 $ sudo systemctl restart peertube && sudo journalctl -fu peertube
 ```
 
@@ -238,7 +238,7 @@ Install node dependencies:
 
 ```
 $ cd /var/www/peertube/versions/peertube-${VERSION} && \
-    sudo -u peertube yarn install --production --pure-lockfile
+    sudo -H -u peertube yarn install --production --pure-lockfile
 ```
 
 Copy new configuration defaults values and update your configuration file:


### PR DESCRIPTION
Like #267.
Without this, Yarn will try to use `/root/.config/yarn` with the peertube user, which obviously doesn't have access.