### PR TITLE
Specify Tor Browser instead of just Tor in the recommendation

### DIFF
--- a/client/src/app/about/about.component.html
+++ b/client/src/app/about/about.component.html
@@ -44,7 +44,7 @@
 
     <p i18n>
       PeerTube uses the BitTorrent protocol to share bandwidth between users. It implies that your public IP address is stored in the public BitTorrent tracker of the video PeerTube instance as long as you're watching the video.
-      If you want to keep your public IP address private, please use a VPN or Tor.
+      If you want to keep your public IP address private, please use a VPN or the Tor Browser.
     </p>
   </div>
 </div>


### PR DESCRIPTION
Since Tor Browser disables WebRTC, the fallback to HTTP streaming will respect
Tor's terms of service. Anyway any recommendation to use Tor should point to
the Tor Browser, as it provides sane and secure defaults to use Tor.

Fixes #676