### PR TITLE
Filter by category

### DIFF
--- a/client/src/app/shared/video/abstract-video-list.ts
+++ b/client/src/app/shared/video/abstract-video-list.ts
@@ -24,6 +24,7 @@ export abstract class AbstractVideoList implements OnInit, OnDestroy {
     totalItems: null
   }
   sort: VideoSortField = '-publishedAt'
+  category?: number
   defaultSort: VideoSortField = '-publishedAt'
   syndicationItems = []
 
@@ -167,7 +168,7 @@ export abstract class AbstractVideoList implements OnInit, OnDestroy {
 
   protected loadRouteParams (routeParams: { [ key: string ]: any }) {
     this.sort = routeParams['sort'] as VideoSortField || this.defaultSort
-
+    this.category = routeParams['category']
     if (routeParams['page'] !== undefined) {
       this.pagination.currentPage = parseInt(routeParams['page'], 10)
     } else {

--- a/client/src/app/shared/video/video.service.ts
+++ b/client/src/app/shared/video/video.service.ts
@@ -158,7 +158,8 @@ export class VideoService {
   getVideos (
     videoPagination: ComponentPagination,
     sort: VideoSortField,
-    filter?: VideoFilter
+    filter?: VideoFilter,
+    category?: number
   ): Observable<{ videos: Video[], totalVideos: number }> {
     const pagination = this.restService.componentPaginationToRestPagination(videoPagination)
 
@@ -167,6 +168,10 @@ export class VideoService {
 
     if (filter) {
       params = params.set('filter', filter)
+    }
+
+    if (category){
+      params = params.set('category', category+"")
     }
 
     return this.authHttp
@@ -202,10 +207,12 @@ export class VideoService {
     return feeds
   }
 
-  getVideoFeedUrls (sort: VideoSortField, filter?: VideoFilter) {
+  getVideoFeedUrls (sort: VideoSortField, filter?: VideoFilter, category?: number) {
     let params = this.restService.addRestGetParams(new HttpParams(), undefined, sort)
 
     if (filter) params = params.set('filter', filter)
+
+    if (category) params = params.set('category', category+"")
 
     return this.buildBaseFeedUrls(params)
   }

--- a/client/src/app/videos/video-list/video-local.component.ts
+++ b/client/src/app/videos/video-list/video-local.component.ts
@@ -50,10 +50,10 @@ export class VideoLocalComponent extends AbstractVideoList implements OnInit, On
   getVideosObservable (page: number) {
     const newPagination = immutableAssign(this.pagination, { currentPage: page })
 
-    return this.videoService.getVideos(newPagination, this.sort, this.filter)
+    return this.videoService.getVideos(newPagination, this.sort, this.filter, this.category)
   }
 
   generateSyndicationList () {
-    this.syndicationItems = this.videoService.getVideoFeedUrls(this.sort, this.filter)
+    this.syndicationItems = this.videoService.getVideoFeedUrls(this.sort, this.filter, this.category)
   }
 }

--- a/client/src/app/videos/video-list/video-recently-added.component.ts
+++ b/client/src/app/videos/video-list/video-recently-added.component.ts
@@ -48,10 +48,10 @@ export class VideoRecentlyAddedComponent extends AbstractVideoList implements On
   getVideosObservable (page: number) {
     const newPagination = immutableAssign(this.pagination, { currentPage: page })
 
-    return this.videoService.getVideos(newPagination, this.sort)
+    return this.videoService.getVideos(newPagination, this.sort, undefined, this.category)
   }
 
   generateSyndicationList () {
-    this.syndicationItems = this.videoService.getVideoFeedUrls(this.sort)
+    this.syndicationItems = this.videoService.getVideoFeedUrls(this.sort, undefined, this.category)
   }
 }

--- a/client/src/app/videos/video-list/video-trending.component.ts
+++ b/client/src/app/videos/video-list/video-trending.component.ts
@@ -47,10 +47,10 @@ export class VideoTrendingComponent extends AbstractVideoList implements OnInit,
 
   getVideosObservable (page: number) {
     const newPagination = immutableAssign(this.pagination, { currentPage: page })
-    return this.videoService.getVideos(newPagination, this.sort)
+    return this.videoService.getVideos(newPagination, this.sort, undefined, this.category)
   }
 
   generateSyndicationList () {
-    this.syndicationItems = this.videoService.getVideoFeedUrls(this.sort)
+    this.syndicationItems = this.videoService.getVideoFeedUrls(this.sort, undefined, this.category)
   }
 }

--- a/server/controllers/api/videos/index.ts
+++ b/server/controllers/api/videos/index.ts
@@ -407,6 +407,7 @@ async function listVideos (req: express.Request, res: express.Response, next: ex
     start: req.query.start,
     count: req.query.count,
     sort: req.query.sort,
+    category: req.query.category,
     hideNSFW: isNSFWHidden(res),
     filter: req.query.filter as VideoFilter,
     withFiles: false

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -106,6 +106,7 @@ export enum ScopeNames {
     actorId: number,
     hideNSFW: boolean,
     filter?: VideoFilter,
+    category?: number,
     withFiles?: boolean,
     accountId?: number,
     videoChannelId?: number
@@ -213,6 +214,10 @@ export enum ScopeNames {
     // Hide nsfw videos?
     if (options.hideNSFW === true) {
       query.where['nsfw'] = false
+    }
+
+    if (options.category) {
+      query.where['category'] = options.category
     }
 
     if (options.accountId) {
@@ -730,6 +735,7 @@ export class VideoModel extends Model<VideoModel> {
     sort: string,
     hideNSFW: boolean,
     withFiles: boolean,
+    category?: number,
     filter?: VideoFilter,
     accountId?: number,
     videoChannelId?: number
@@ -746,6 +752,7 @@ export class VideoModel extends Model<VideoModel> {
         ScopeNames.AVAILABLE_FOR_LIST, {
           actorId: serverActor.id,
           hideNSFW: options.hideNSFW,
+          category: options.category,
           filter: options.filter,
           withFiles: options.withFiles,
           accountId: options.accountId,

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -529,6 +529,11 @@ paths:
       produces:
         - application/json
       parameters:
+        - name: category
+          in: query
+          required: false
+          type: number
+          description: category id of the video
         - name: start
           in: query
           required: false


### PR DESCRIPTION
Just added another filter : category

I needed it to display only musics on exode.me (not yet deployed) and I was wondering if it could be pushed to main peertube repo

Just a question by the way
do you know a way to force reload a component when parameters change : for example 
from
videos/trending

to 
videos/trending?category=1

I will have to refresh the page or go to another component in between
