### PR TITLE
Fix #576 - show 'Others videos' on a <1300px viewport

### DIFF
--- a/client/src/app/videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/videos/+video-watch/video-watch.component.scss
@@ -289,9 +289,11 @@
       display: flex;
       height: 100%;
       margin-bottom: 20px;
+      flex-wrap: wrap;
 
       .video-miniature-information {
         margin-left: 10px;
+        flex-grow: 1;
       }
     }
   }
@@ -387,8 +389,12 @@
 }
 
 @media screen and (max-width: 1300px) {
+  .video-bottom {
+    flex-direction: column;
+  }
+
   .other-videos {
-    display: none;
+    padding-left: 0;
   }
 
   .privacy-concerns {


### PR DESCRIPTION
Hi there,
First of all, thanks for this amazing project. I tried to take screenshots on each responsive view.
![peertube-1366-801](https://user-images.githubusercontent.com/582666/41873684-008e0962-78c6-11e8-88bd-105d0e65a0a1.png)
![peertube-1312-801](https://user-images.githubusercontent.com/582666/41873690-04805fca-78c6-11e8-8dfb-04b83acf50e6.png)
![peertube-956-801](https://user-images.githubusercontent.com/582666/41873691-070477fe-78c6-11e8-84ab-255e0dce28e1.png)
![peertube-648-801](https://user-images.githubusercontent.com/582666/41873709-12767c4a-78c6-11e8-91c4-d489ab19085e.png)
![peertube-462-801](https://user-images.githubusercontent.com/582666/41873715-1527f4dc-78c6-11e8-9789-e655771a3374.png)
I love fluid content. :)
Have a nice day.