### PR TITLE
Improve left menu

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -18,7 +18,7 @@
   </div>
 
   <div class="sub-header-container">
-    <div *ngIf="isMenuDisplayed" class="title-menu-left">
+    <div class="title-menu-left" [class.displayed]="isMenuDisplayed">
         <my-menu></my-menu>
     </div>
 

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -13,7 +13,11 @@
   position: fixed;
   height: calc(100vh - #{$header-height});
   padding: 0;
-  width: $menu-width;
+  width: 0;
+  transition: width 500ms;
+  &.displayed {
+    width: $menu-width;
+  }
 
   .title-menu-left-block.menu {
     height: 100%;

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -115,7 +115,6 @@ export class AppComponent implements OnInit {
   }
 
   toggleMenu () {
-    window.scrollTo(0, 0)
     this.isMenuDisplayed = !this.isMenuDisplayed
   }
 }

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -5,5 +5,5 @@
 export const environment = {
   production: false,
   hmr: false,
-  apiUrl: 'http://localhost:9000'
+  apiUrl: 'http://domain.tld'
 }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -62,8 +62,10 @@ label {
 
 .main-col {
   margin-left: $menu-width;
+  transition: margin-left 500ms;
 
   .margin-content {
+    transition: margin-left 500ms;
     margin-left: $not-expanded-horizontal-margins;
     margin-right: $not-expanded-horizontal-margins;
   }
@@ -76,6 +78,7 @@ label {
     display: flex;
     align-items: center;
     padding-left: $not-expanded-horizontal-margins;
+    transition: padding-left 500ms;
   }
 
   // Override some properties if the main content is expanded (no menu on the left)
@@ -289,7 +292,9 @@ table {
 // On small screen, menu is absolute
 @media screen and (max-width: 600px) {
   .title-menu-left {
-    width: 100% !important;
+    &.displayed {
+      width: 100% !important;
+    }
     position: absolute !important;
     z-index: 10000;
   }


### PR DESCRIPTION
- Add a transition when opening/closing the left menu
- Suppress the scroll to top when opening/closing the left menu.

Note: regarding the scroll to top, I did see the commit about it https://github.com/Chocobozzz/PeerTube/commit/a01f107bc436250706d4bc765f45335ee15b8e80#diff-30532d215cbc6539c241db5bdfc9b60eR60 
It is not clear to me how it improved the mobile version, but it is clearly annoying for the desktop one.
Still, I assume it has been done for a good reason, so I would be happy to talk about it in order to find the best solution on this matter.