### PR TITLE
Improve left menu

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -115,7 +115,6 @@ export class AppComponent implements OnInit {
   }
 
   toggleMenu () {
-    window.scrollTo(0, 0)
     this.isMenuDisplayed = !this.isMenuDisplayed
   }
 }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -286,11 +286,9 @@ table {
   }
 }
 
-// On small screen, menu is absolute
 @media screen and (max-width: 600px) {
   .menu-wrapper {
     width: 100% !important;
-    position: absolute !important;
     z-index: 10000;
   }
 


### PR DESCRIPTION
- Add a transition when opening/closing the left menu
- Suppress the scroll to top when opening/closing the left menu.

Note: regarding the scroll to top, I did see the commit about it https://github.com/Chocobozzz/PeerTube/commit/a01f107bc436250706d4bc765f45335ee15b8e80#diff-30532d215cbc6539c241db5bdfc9b60eR60 
It is not clear to me how it improved the mobile version, but it is clearly annoying for the desktop one.
Still, I assume it has been done for a good reason, so I would be happy to talk about it in order to find the best solution on this matter.