### PR TITLE
Update production.md

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -107,6 +107,13 @@ Activate the configuration file:
 $ sudo ln -s /etc/nginx/sites-available/peertube /etc/nginx/sites-enabled/peertube
 ```
 
+Remove default configuration file:
+
+```
+$ sudo rm /etc/nginx/sites-enabled/default
+```
+
+
 To generate the certificate for your domain as required to make https work you can use [Let's Encrypt](https://letsencrypt.org/):
 
 ```


### PR DESCRIPTION
When I followed the production guide, one issue that I came across dealt with the fact that the default configuration file was still linked under sites-enabled.  Updated the production document to add this.