### PR TITLE
[Issue 641] Add 'My Videos' shortcut to profile dropdown 

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -14,7 +14,6 @@
 - [I want to change my domain name, how can I do that?](#i-want-to-change-my-domain-name-how-can-i-do-that)
 - [Should I have a big server to run PeerTube?](#should-i-have-a-big-server-to-run-peertube)
 - [Can I seed videos with my classic BitTorrent client (Transmission, rTorrent...)?](#can-i-seed-videos-with-my-classic-bittorrent-client-transmission-rtorrent)
-- [Why host on GitHub and Framagit?](#why-host-on-github-and-framagit)
 - [Are you going to use the Steem blockchain?](#are-you-going-to-use-the-steem-blockchain)
 - [Are you going to support advertisements?](#are-you-going-to-support-advertisements)
 - [What is "creation dynamic" and why not modify it?](#what-is-creation-dynamic-and-why-not-modify-it)
@@ -26,7 +25,6 @@
 PeerTube is just the name of the software. You can install it on your
 server, and choose a name you want. For example, [this instance](https://framatube.org/)
 is named "Framatube".
-
 
 ## If nobody watches a video, is it seeded?
 
@@ -81,11 +79,6 @@ So you would need:
 Yes you can, but you won't be able to send data to users that watch the video in their web browser.
 The reason is they connects to peers through WebRTC whereas your BitTorrent client uses classic TCP/UDP.
 We hope to see compatibility with WebRTC in popular BitTorrent client in the future. See this issue for more information: https://github.com/webtorrent/webtorrent/issues/369
-
-
-## Why host on GitHub and Framagit?
-
-The project has initially been hosted on GitHub by Chocobozzz. A full migration to [Framagit](https://framagit.org/chocobozzz/PeerTube) would be ideal now that Framasoft supports PeerTube, but it would take a lot of time and is an ongoing effort.
 
 
 ## Are you going to use the Steem blockchain?

--- a/README.md
+++ b/README.md
@@ -179,8 +179,7 @@ Copyright (C) 2018 PeerTube Contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or 
-(at your option) any later version.
+by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -24,6 +24,10 @@
                 My account
               </a>
 
+              <a i18n routerLink="/my-account/videos" class="dropdown-item" title="My videos">
+                My videos
+              </a>
+
               <a i18n (click)="logout($event)" class="dropdown-item" title="Log out" href="#">
                 Log out
               </a>

--- a/client/src/app/shared/video/video-miniature.component.html
+++ b/client/src/app/shared/video/video-miniature.component.html
@@ -2,14 +2,26 @@
   <my-video-thumbnail [video]="video" [nsfw]="isVideoBlur()"></my-video-thumbnail>
 
   <div class="video-miniature-information">
-    <a
-      class="video-miniature-name"
-      [routerLink]="[ '/videos/watch', video.uuid ]" [attr.title]="video.name" [ngClass]="{ 'blur-filter': isVideoBlur() }"
-    >
+    <a class="video-miniature-name" [routerLink]="[ '/videos/watch', video.uuid ]" [attr.title]="video.name" [ngClass]="{ 'blur-filter': isVideoBlur() }">
       {{ video.name }}
     </a>
 
     <span i18n class="video-miniature-created-at-views">{{ video.publishedAt | myFromNow }} - {{ video.views | myNumberFormatter }} views</span>
     <a class="video-miniature-account" [routerLink]="[ '/accounts', video.by ]">{{ video.by }}</a>
+    <div *ngIf="isOwner()" class="action-more" dropdown placement='right'>
+      <span class="glyphicon glyphicon-option-horizontal" dropdownToggle></span>
+      <ul *dropdownMenu class="dropdown-menu" id="more-menu" role="menu">
+        <li role='menuitem'>
+          <a i18n class="dropdown-item" [routerLink]="[ '/videos', 'update', video.uuid ]">
+            <span class="icon-text" i18n>Update</span>
+          </a>
+        </li>
+        <li role='menuitem'>
+          <a i18n class="dropdown-item" (click)="deleteVideo(video)">
+            <span class="icon-text" i18n>Delete</span>
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>

--- a/client/src/app/shared/video/video-miniature.component.ts
+++ b/client/src/app/shared/video/video-miniature.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core'
 import { User } from '../users'
+import { AuthService } from '../../core'
 import { Video } from './video.model'
 import { ServerService } from '@app/core'
 
@@ -12,9 +13,13 @@ export class VideoMiniatureComponent {
   @Input() user: User
   @Input() video: Video
 
-  constructor (private serverService: ServerService) { }
+  constructor (private serverService: ServerService, private authService: AuthService) { }
 
   isVideoBlur () {
     return this.video.isVideoNSFWForUser(this.user, this.serverService.getConfig())
+  }
+
+  isOwner () {
+    return this.video.isOwner(this.authService.getUser())
   }
 }

--- a/client/src/app/shared/video/video.model.ts
+++ b/client/src/app/shared/video/video.model.ts
@@ -6,6 +6,7 @@ import { getAbsoluteAPIUrl } from '../misc/utils'
 import { ServerConfig } from '../../../../../shared/models'
 import { Actor } from '@app/shared/actor/actor.model'
 import { peertubeTranslate } from '@app/shared/i18n/i18n-utils'
+import { AuthUser } from '../../core'
 import { VideoScheduleUpdate } from '../../../../../shared/models/videos/video-schedule-update.model'
 
 export class Video implements VideoServerModel {
@@ -74,7 +75,8 @@ export class Video implements VideoServerModel {
     return displayedHours + minutesPadding + minutes.toString() + ':' + secondsPadding + seconds.toString()
   }
 
-  constructor (hash: VideoServerModel, translations = {}) {
+  constructor (
+    hash: VideoServerModel, translations = {}) {
     const absoluteAPIUrl = getAbsoluteAPIUrl()
 
     this.createdAt = new Date(hash.createdAt.toString())
@@ -127,5 +129,12 @@ export class Video implements VideoServerModel {
 
     // Return default instance config
     return serverConfig.instance.defaultNSFWPolicy !== 'display'
+  }
+
+  isOwner (user: AuthUser) {
+    if (user) {
+      return user.username === this.account.name
+    }
+    return false
   }
 }


### PR DESCRIPTION
Currently it's in the profile dropdown as suggested by @Chocobozzz but if it doesn't fit with the need we can add some links on left navbar bellow the profile name.

#[WIP] Show video options from list views for owner
Can quickly access to delete and update options for owned video via video list view, but options appear at bottom left of the page (you have to scroll down to see its). I might need some help to understand where dropdownMenu position is set in scss files.

FAQ and README are older than the ones in current dev branch. 