### PR TITLE
[#766] Fix the change of speed when quality changes

### DIFF
--- a/client/src/assets/player/peertube-videojs-plugin.ts
+++ b/client/src/assets/player/peertube-videojs-plugin.ts
@@ -240,6 +240,8 @@ class PeerTubePlugin extends Plugin {
 
             if (options.seek) this.seek(options.seek)
             if (options.forcePlay === false && paused === true) this.player.pause()
+
+            return done(err)
           })
         })
       }, options.delay || 0)


### PR DESCRIPTION
When changing the `playbackRate` of the video then changing the quality,
the `playbackRate` returned to its initial value (1).

The reason behind it is that the callback was not called when change
of the quality was done if there was no error.

This commit does the following:

* Ensure the callback (`done`) is called after changing the quality

This PR resolves #766 .