### PR TITLE
rewording download option and reorder options

### DIFF
--- a/client/src/app/videos/+video-watch/modal/video-download.component.html
+++ b/client/src/app/videos/+video-watch/modal/video-download.component.html
@@ -16,18 +16,18 @@
 
         <div class="download-type">
           <div class="peertube-radio-container">
-            <input type="radio" name="download" id="download-torrent" [(ngModel)]="downloadType" value="torrent">
-            <label i18n for="download-torrent">Torrent</label>
-          </div>
-
-          <div class="peertube-radio-container">
             <input type="radio" name="download" id="download-direct" [(ngModel)]="downloadType" value="direct">
             <label i18n for="download-direct">Direct download</label>
+          </div>
+          
+          <div class="peertube-radio-container">
+            <input type="radio" name="download" id="download-torrent" [(ngModel)]="downloadType" value="torrent">
+            <label i18n for="download-torrent">Torrent (.torrent file)</label>
           </div>
 
           <div class="peertube-radio-container">
             <input type="radio" name="download" id="download-magnet" [(ngModel)]="downloadType" value="magnet">
-            <label i18n for="download-magnet">Torrent (magnet)</label>
+            <label i18n for="download-magnet">Torrent (magnet link)</label>
           </div>
         </div>
 


### PR DESCRIPTION
".torrent" is a common name for users familiar with BitTorrent, and less
impressive than "metainfo" or no information as opposed to the magnet option,
less commonly known but rather just clicked on most sites.