### PR TITLE
Updated travis.yml git depth 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - "8"
 
+git:
+  depth: 1
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
We don't do any git operation except include last commit name, so we only need last commit, that will make travis-ci test faster.