### PR TITLE
Added redis-server.service to After

### DIFF
--- a/support/systemd/peertube.service
+++ b/support/systemd/peertube.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PeerTube daemon
-After=network.target postgresql.service
+After=network.target postgresql.service redis-server.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
On very very slow server, peertube can generate error if redis isn't started.