### PR TITLE
[Server>Middlewares>Follows] Changing error code 400 to 500

### DIFF
--- a/server/middlewares/validators/follows.ts
+++ b/server/middlewares/validators/follows.ts
@@ -14,7 +14,7 @@ const followValidator = [
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     // Force https if the administrator wants to make friends
     if (isTestInstance() === false && CONFIG.WEBSERVER.SCHEME === 'http') {
-      return res.status(400)
+      return res.status(500)
         .json({
           error: 'Cannot follow on a non HTTPS web server.'
         })


### PR DESCRIPTION
Follows on http server is a server error in the configuration not an error of the client.

@Chocobozzz as you ask in #852 this is reopen.