### PR TITLE
Use the config file values in upgrade.sh script

### DIFF
--- a/scripts/parse_yaml.sh
+++ b/scripts/parse_yaml.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+parse_yaml() {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -20,11 +20,24 @@ if [ ! -e "$PEERTUBE_PATH/versions" -o ! -e "$PEERTUBE_PATH/config/production.ya
   exit 1
 fi
 
+# read config file
+## Read the parse_yaml.sh file function
+. parse_yaml.sh
+
+## parse the config file
+eval $(parse_yaml /var/www/peertube/config/production.yaml "")
+
+## Remove unexecpted ' charaters
+hostname=$(echo ${database_hostname} | /usr/bin/sed "s/\'//g")
+
+## Display the database password (read from config file)
+
+echo "Your database password is (read from your config file): ${database_password}"
 
 # Backup database
 SQL_BACKUP_PATH="$PEERTUBE_PATH/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").bak" 
 mkdir -p $PEERTUBE_PATH/backup
-pg_dump -U peertube -W -h localhost -F c peertube_prod -f "$SQL_BACKUP_PATH" 
+pg_dump -U peertube -W -h ${hostname} -F c peertube_prod -f "$SQL_BACKUP_PATH" 
 
 # Get and Display the Latest Version
 VERSION=$(curl -s https://api.github.com/repos/chocobozzz/peertube/releases/latest | grep tag_name | cut -d '"' -f 4)


### PR DESCRIPTION
If the postgresql database is not hosted on the same host as Peertube, the upgrade.sh script failed.
I added a small parse_yaml,sh function file (found  [here}(https://gist.github.com/pkuczynski/8665367) and use it in the upgrade.sh script. I print the database password to avoid looking for it during ages and resign user from upgrade.