### PR TITLE
correct password reset disabled binding

### DIFF
--- a/client/src/app/reset-password/reset-password.component.html
+++ b/client/src/app/reset-password/reset-password.component.html
@@ -26,6 +26,6 @@
       </div>
     </div>
 
-    <input type="submit" i18n-value value="Reset my password" [disabled]="!form.valid && isConfirmedPasswordValid()">
+    <input type="submit" i18n-value value="Reset my password" [disabled]="!form.valid || !isConfirmedPasswordValid()">
   </form>
 </div>


### PR DESCRIPTION
Fixed by changing the logic - if the form is not valid or the confirmed password does not match the button will be disabled. Considered a refactor with shared module between change and reset passwords but determined the effort did not match the value.

All testing done manually.