### PR TITLE
Add gzip support to the sample nginx configuration

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -37,6 +37,11 @@ server {
   # resolver $DNS-IP-1 $DNS-IP-2 valid=300s;
   # resolver_timeout 5s;
 
+  # Enable compression for JS/CSS/HTML and JSON, for improved client load times
+  gzip on;
+  gzip_types text/plain text/css text/html application/javascript application/json;
+  gzip_vary on;
+
   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
   access_log /var/log/nginx/peertube.example.com.access.log;

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -37,9 +37,11 @@ server {
   # resolver $DNS-IP-1 $DNS-IP-2 valid=300s;
   # resolver_timeout 5s;
 
-  # Enable compression for JS/CSS/HTML and JSON, for improved client load times
+  # Enable compression for JS/CSS/HTML bundle, for improved client load times.
+  # It might be nice to compress JSON, but leaving that out to protect against potential
+  # compression+encryption information leak attacks like BREACH.
   gzip on;
-  gzip_types text/plain text/css text/html application/javascript application/json;
+  gzip_types text/css text/html application/javascript;
   gzip_vary on;
 
   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";


### PR DESCRIPTION
Without gzip explicitly enabled, load times suffer from transferring
over a megabyte of plaintext javascript. With gzip enabled, the bundle
is down to about 300K, and loads much faster.

This change does not enable gzip on files that are already compressed,
so images, fonts, and videos will be sent without the CPU overhead.

closes #948