### PR TITLE
Update dependencies.md

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -76,7 +76,7 @@ On a fresh install of [FreeBSD](https://www.freebsd.org), new system or new jail
 ```
 # pkg
 # pkg update
-# pkg install -y sudo bash wget git python nginx pkgconf vips postgresql96-server redis openssl node npm yarn ffmpeg unzip
+# pkg install -y sudo bash wget git python nginx pkgconf vips postgresql96-server postgresql96-contrib redis openssl node npm yarn ffmpeg unzip
 ```
 
   2. Allow users in the wheel group (hope you don't forgot to add your user on wheel group!) to use sudo


### PR DESCRIPTION
Because when you whant enable extension :

 sudo -u postgres psql -c "CREATE EXTENSION pg_trgm;" peertube_prod
ERROR:  could not open extension control file "/usr/local/share/postgresql/extension/pg_trgm.control": No such file or directory

pkg install postgresql96-contrib

-> and its ok
(Note : i use a presonal repository whith poudriere, maybe in the offical repository postgresql96-contrib depends on  postgresql96-server )