### PR TITLE
Update translation.md

### DIFF
--- a/support/doc/translation.md
+++ b/support/doc/translation.md
@@ -33,3 +33,5 @@ For example:
 
 should be in french 
 ```<x id="INTERPOLATION" equiv-text="{{ video.publishedAt | myFromNow }}"/> - <x id="INTERPOLATION_1" equiv-text="{{ video.views | myNumberFormatter }}"/> vues```
+
+Please also do not translate the string `yy-mm-dd`, which is going to be replaced with numbers in the application.


### PR DESCRIPTION
add hint, that the string yy-mm-dd shall not be translated, because otherwise you get translated strings in the date chooser like "JJ-August-TT 14:00" (German)