### PR TITLE
Various style and margin fixes, per-component hotkeys, and more

### DIFF
--- a/client/src/app/+video-channels/video-channels.component.html
+++ b/client/src/app/+video-channels/video-channels.component.html
@@ -9,7 +9,7 @@
           <div class="actor-display-name">{{ videoChannel.displayName }}</div>
           <div class="actor-name">{{ videoChannel.nameWithHost }}</div>
 
-          <my-subscribe-button *ngIf="isUserLoggedIn()" [videoChannel]="videoChannel"></my-subscribe-button>
+          <my-subscribe-button #subscribeButton *ngIf="isUserLoggedIn()" [videoChannel]="videoChannel"></my-subscribe-button>
         </div>
         <div i18n class="actor-followers">{{ videoChannel.followersCount }} subscribers</div>
 

--- a/client/src/app/+video-channels/video-channels.component.ts
+++ b/client/src/app/+video-channels/video-channels.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core'
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
 import { VideoChannel } from '@app/shared/video-channel/video-channel.model'
 import { VideoChannelService } from '@app/shared/video-channel/video-channel.service'
@@ -6,13 +6,18 @@ import { RestExtractor } from '@app/shared'
 import { catchError, distinctUntilChanged, map, switchMap } from 'rxjs/operators'
 import { Subscription } from 'rxjs'
 import { AuthService } from '@app/core'
+import { Hotkey, HotkeysService } from 'angular2-hotkeys'
+import { SubscribeButtonComponent } from '@app/shared/user-subscription/subscribe-button.component'
 
 @Component({
   templateUrl: './video-channels.component.html',
   styleUrls: [ './video-channels.component.scss' ]
 })
 export class VideoChannelsComponent implements OnInit, OnDestroy {
+  @ViewChild('subscribeButton') subscribeButton: SubscribeButtonComponent
+
   videoChannel: VideoChannel
+  hotkeys: Hotkey[]
 
   private routeSub: Subscription
 
@@ -20,7 +25,8 @@ export class VideoChannelsComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private authService: AuthService,
     private videoChannelService: VideoChannelService,
-    private restExtractor: RestExtractor
+    private restExtractor: RestExtractor,
+    private hotkeysService: HotkeysService
   ) { }
 
   ngOnInit () {
@@ -33,10 +39,22 @@ export class VideoChannelsComponent implements OnInit, OnDestroy {
                         )
                         .subscribe(videoChannel => this.videoChannel = videoChannel)
 
+    this.hotkeys = [
+      new Hotkey('S', (event: KeyboardEvent): boolean => {
+        this.subscribeButton.subscribed ?
+          this.subscribeButton.unsubscribe() :
+          this.subscribeButton.subscribe()
+        return false
+      }, undefined, 'Subscribe to the account')
+    ]
+    if (this.isUserLoggedIn()) this.hotkeysService.add(this.hotkeys)
   }
 
   ngOnDestroy () {
     if (this.routeSub) this.routeSub.unsubscribe()
+
+    // Unbind hotkeys
+    if (this.isUserLoggedIn()) this.hotkeysService.remove(this.hotkeys)
   }
 
   isUserLoggedIn () {

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -14,7 +14,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  background-color: #fff;
+  background-color: $bg-color;
   z-index: 1000;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.16);
   display: flex;

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -128,27 +128,27 @@ export class AppComponent implements OnInit {
         document.getElementById('search-video').focus()
         return false // Prevent bubbling
       }, undefined, 'Focus the search bar'),
-      new Hotkey('g+s', (event: KeyboardEvent): boolean => {
+      new Hotkey('g s', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/subscriptions' ])
         return false
       }, undefined, 'Go to the subscriptions videos page'),
-      new Hotkey('g+o', (event: KeyboardEvent): boolean => {
+      new Hotkey('g o', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/overview' ])
         return false
       }, undefined, 'Go to the videos overview page'),
-      new Hotkey('g+t', (event: KeyboardEvent): boolean => {
+      new Hotkey('g t', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/trending' ])
         return false
       }, undefined, 'Go to the trending videos page'),
-      new Hotkey('g+r', (event: KeyboardEvent): boolean => {
+      new Hotkey('g r', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/recently-added' ])
         return false
       }, undefined, 'Go to the recently added videos page'),
-      new Hotkey('g+l', (event: KeyboardEvent): boolean => {
+      new Hotkey('g l', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/local' ])
         return false
       }, undefined, 'Go to the local videos page'),
-      new Hotkey('g+u', (event: KeyboardEvent): boolean => {
+      new Hotkey('g u', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/upload' ])
         return false
       }, undefined, 'Go to the videos upload page')

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -132,6 +132,10 @@ export class AppComponent implements OnInit {
         this.router.navigate([ '/videos/subscriptions' ])
         return false
       }, undefined, 'Go to the subscriptions videos page'),
+      new Hotkey('g+o', (event: KeyboardEvent): boolean => {
+        this.router.navigate([ '/videos/overview' ])
+        return false
+      }, undefined, 'Go to the videos overview page'),
       new Hotkey('g+t', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/trending' ])
         return false

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -124,10 +124,14 @@ export class AppComponent implements OnInit {
         })
 
     this.hotkeysService.add([
-      new Hotkey('/', (event: KeyboardEvent): boolean => {
+      new Hotkey(['/', 's'], (event: KeyboardEvent): boolean => {
         document.getElementById('search-video').focus()
-        return false // Prevent bubbling
+        return false
       }, undefined, 'Focus the search bar'),
+      new Hotkey('b', (event: KeyboardEvent): boolean => {
+        this.toggleMenu()
+        return false
+      }, undefined, 'Toggle the left menu'),
       new Hotkey('g s', (event: KeyboardEvent): boolean => {
         this.router.navigate([ '/videos/subscriptions' ])
         return false

--- a/client/src/app/menu/menu.component.scss
+++ b/client/src/app/menu/menu.component.scss
@@ -18,12 +18,16 @@ menu {
   overflow: hidden;
   z-index: 1000;
   color: $menu-color;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
 
+  &:focus, &:hover {
+    overflow-y: auto;
+  }
+
   .top-menu {
     flex-grow: 1;
+    width: $menu-width;
   }
 
   .logged-in-block {

--- a/client/src/app/shared/instance/instance-features-table.component.html
+++ b/client/src/app/shared/instance/instance-features-table.component.html
@@ -6,13 +6,13 @@
 
       <td class="value">
         <ng-container *ngIf="initialUserVideoQuota !== -1">
-          {{ initialUserVideoQuota | bytes: 0 }}
+          {{ initialUserVideoQuota | bytes: 0 }} <ng-container *ngIf="dailyUserVideoQuota !== -1">({{ dailyUserVideoQuota | bytes: 0 }} per day)</ng-container>
 
           <my-help helpType="custom" [customHtml]="quotaHelpIndication"></my-help>
         </ng-container>
 
         <ng-container i18n *ngIf="initialUserVideoQuota === -1">
-          Unlimited
+          Unlimited <ng-container *ngIf="dailyUserVideoQuota !== -1">({{ dailyUserVideoQuota | bytes: 0 }} per day)</ng-container>
         </ng-container>
       </td>
     </tr>

--- a/client/src/app/shared/instance/instance-features-table.component.scss
+++ b/client/src/app/shared/instance/instance-features-table.component.scss
@@ -3,7 +3,6 @@
 
 table {
   font-size: 14px;
-  max-width: 400px;
 
   .label {
     font-weight: $font-semibold;

--- a/client/src/app/shared/instance/instance-features-table.component.ts
+++ b/client/src/app/shared/instance/instance-features-table.component.ts
@@ -21,6 +21,10 @@ export class InstanceFeaturesTableComponent implements OnInit {
     return this.serverService.getConfig().user.videoQuota
   }
 
+  get dailyUserVideoQuota () {
+    return this.serverService.getConfig().user.videoQuotaDaily
+  }
+
   ngOnInit () {
     this.serverService.configLoaded
         .subscribe(() => {

--- a/client/src/app/shared/video/video-miniature.component.scss
+++ b/client/src/app/shared/video/video-miniature.component.scss
@@ -14,14 +14,17 @@
     line-height: normal;
 
     .video-miniature-name {
-      display: block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      @include ellipsis-multiline(
+        $font-size: 1rem,
+        $line-height: 1,
+        $lines-to-show: 2
+      );
       transition: color 0.2s;
       font-size: 16px;
       font-weight: $font-semibold;
-      color: #000;
+      color: $fg-color;
+      margin-top: 5px;
+      margin-bottom: 5px;
 
       &:hover {
         text-decoration: none;

--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -26,7 +26,7 @@
   </div>
 
   <!-- Video information -->
-  <div *ngIf="video" class="container video-bottom">
+  <div *ngIf="video" class="container-fluid video-bottom">
     <div class="row fullWidth">
       <div class="col-12 col-md-9 video-info">
         <div class="video-info-first-row">
@@ -201,8 +201,8 @@
     </div>
     <my-recommended-videos class="ml-3 ml-sm-0 col-12 col-md-3"
                            [inputVideo]="video" [user]="user"></my-recommended-videos>
+    </div>
   </div>
-
 
   <div class="privacy-concerns" *ngIf="hasAlreadyAcceptedPrivacyConcern === false">
     <div class="privacy-concerns-text">
@@ -217,7 +217,6 @@
       OK
     </div>
   </div>
-</div>
 
 <ng-template [ngIf]="video !== null">
   <my-video-support #videoSupportModal [video]="video"></my-video-support>

--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -208,7 +208,7 @@
     <div class="privacy-concerns-text">
       <strong i18n>Friendly Reminder: </strong>
       <ng-container i18n>
-        the sharing system used by this video implies that some technical information about your system (such as a public IP address) can be sent to other peers.
+        the sharing system used for this video implies that some technical information about your system (such as a public IP address) can be sent to other peers.
       </ng-container>
       <a i18n i18n-title title="Get more information" target="_blank" rel="noopener noreferrer" href="/about/peertube">More information</a>
     </div>

--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -125,7 +125,7 @@
                 <img [src]="video.videoChannelAvatarUrl" alt="Video channel avatar" />
               </a>
 
-              <my-subscribe-button *ngIf="isUserLoggedIn()" [videoChannel]="video.channel" size="small"></my-subscribe-button>
+              <my-subscribe-button #subscribeButton *ngIf="isUserLoggedIn()" [videoChannel]="video.channel" size="small"></my-subscribe-button>
             </div>
 
             <div class="video-info-by">

--- a/client/src/app/videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/videos/+video-watch/video-watch.component.scss
@@ -358,11 +358,11 @@
     }
   }
 
-  .other-videos {
+  /deep/ .other-videos {
     padding-left: 1em;
 
     .title-page {
-      margin-top: 0;
+      margin-top: 0 !important;
     }
 
     /deep/ .video-miniature {

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -16,6 +16,33 @@
   }
 }
 
+/**
+ *  This mixin will crop text in block for needed amount of lines and put ellipsis at the end
+ *
+ *  @param $font-size font-size property
+ *  @param $line-height line-height property
+ *  @param $lines-to-show amount of lines to show
+ */
+ @mixin ellipsis-multiline($font-size: 1rem, $line-height: 1, $lines-to-show: 2) {
+  display: block;
+  /* Fallback for non-webkit */
+  display: -webkit-box;
+  max-height: $font-size*$line-height*$lines-to-show;
+  /* Fallback for non-webkit */
+  font-size: $font-size;
+  line-height: $line-height;
+  -webkit-line-clamp: $lines-to-show;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@mixin prefix($property, $parameters...) {
+  @each $prefix in -webkit-, -moz-, -ms-, -o-, "" {
+    #{$prefix}#{$property}: $parameters;
+  }
+}
+
 @mixin peertube-word-wrap {
   word-break: normal;
   word-wrap: break-word;

--- a/client/src/sass/include/_variables.scss
+++ b/client/src/sass/include/_variables.scss
@@ -10,6 +10,8 @@ $orange-hoover-color: #F97D46;
 
 $black-background: #000;
 $grey-background: #f6f2f2;
+$bg-color: #fff;
+$fg-color: #000;
 
 $red: #FF0000;
 $green: #39CC0B;


### PR DESCRIPTION
I reduced the rather big margins that followed the grid refactoring. And then I went a bit overboard.

Most notable:
- make the left menu scrollbar appear only on focus/active, with a fixed and defined width for the 'menu' element to make the whole stable. (much like YouTube does)
- fix the 'other videos' margin which got disable through the grid refactoring.
- finally add component hotkeys, and fix the shortcuts (I misunderstood the doc so far, which led to second letters to activate when pressed alone…)
- make the features table show the daily quota, and use enough width to properly display the helper
- ellipsize the titles over two lines instead of one. Since we have already a quite unoptimised font size/weight/typeface for titles (just look at the use of Roboto for YouTube's titles), we should at least use two lines like other video sites do. Unfortunately support within Firefox is not on par with other platforms, but I managed to get the same result as with YouTube (good enough I guess).