### PR TITLE
rename web app manifest

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -24,7 +24,7 @@
             },
             "assets": [
               "src/assets/images",
-              "src/manifest.json"
+              "src/manifest.webmanifest"
             ],
             "styles": [
               "src/sass/application.scss"
@@ -105,7 +105,7 @@
             ],
             "assets": [
               "src/assets/images",
-              "src/manifest.json"
+              "src/manifest.webmanifest"
             ]
           }
         },

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#fff" />
 
     <!-- Web Manifest file -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/manifest.webmanifest">
 
     <!-- /!\ The following comment is used by the server to prerender some tags /!\ -->
 

--- a/client/src/manifest.webmanifest
+++ b/client/src/manifest.webmanifest
@@ -24,7 +24,7 @@
       "src": "/client/assets/images/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
-    },	
+    },
 	{
       "src": "/client/assets/images/icons/icon-144x144.png",
       "sizes": "144x144",

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -35,7 +35,7 @@ clientsRouter.use('' +
 // Static HTML/CSS/JS client files
 
 const staticClientFiles = [
-  'manifest.json',
+  'manifest.webmanifest',
   'ngsw-worker.js',
   'ngsw.json'
 ]


### PR DESCRIPTION
```html
<link rel="manifest" href="/manifest.webmanifest">
```

>Note: The .webmanifest extension is specified in the Media type registration section of the specification, but browsers generally support manifests with other appropriate extensions like .json. 

https://developer.mozilla.org/en-US/docs/Web/Manifest

as mentioned in #1092

This is no big thing, just a small improvement.
I hope I changed it everywhere where it needs to.
Manifest is still not show duo to problem in #1092