### PR TITLE
refactor subscribe button and comment-add for visitor-interact UX

### DIFF
--- a/client/src/app/+video-channels/video-channels.component.html
+++ b/client/src/app/+video-channels/video-channels.component.html
@@ -9,7 +9,7 @@
           <div class="actor-display-name">{{ videoChannel.displayName }}</div>
           <div class="actor-name">{{ videoChannel.nameWithHost }}</div>
 
-          <my-subscribe-button #subscribeButton *ngIf="isUserLoggedIn()" [videoChannel]="videoChannel"></my-subscribe-button>
+          <my-subscribe-button #subscribeButton [videoChannel]="videoChannel"></my-subscribe-button>
         </div>
         <div i18n class="actor-followers">{{ videoChannel.followersCount }} subscribers</div>
 

--- a/client/src/app/search/search.component.html
+++ b/client/src/app/search/search.component.html
@@ -41,7 +41,7 @@
         <div i18n class="video-channel-followers">{{ result.followersCount }} subscribers</div>
       </div>
 
-      <my-subscribe-button *ngIf="isUserLoggedIn()" [videoChannel]="result"></my-subscribe-button>
+      <my-subscribe-button [videoChannel]="result"></my-subscribe-button>
     </div>
 
     <div *ngIf="isVideo(result)" class="entry video">

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -53,7 +53,7 @@ import { PeertubeCheckboxComponent } from '@app/shared/forms/peertube-checkbox.c
 import { VideoImportService } from '@app/shared/video-import/video-import.service'
 import { ActionDropdownComponent } from '@app/shared/buttons/action-dropdown.component'
 import { NgbDropdownModule, NgbModalModule, NgbPopoverModule, NgbTabsetModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap'
-import { SubscribeButtonComponent, UserSubscriptionService } from '@app/shared/user-subscription'
+import { SubscribeButtonComponent, RemoteSubscribeComponent, UserSubscriptionService } from '@app/shared/user-subscription'
 import { InstanceFeaturesTableComponent } from '@app/shared/instance/instance-features-table.component'
 import { OverviewService } from '@app/shared/overview'
 
@@ -93,6 +93,7 @@ import { OverviewService } from '@app/shared/overview'
     ReactiveFileComponent,
     PeertubeCheckboxComponent,
     SubscribeButtonComponent,
+    RemoteSubscribeComponent,
     InstanceFeaturesTableComponent
   ],
 
@@ -127,6 +128,7 @@ import { OverviewService } from '@app/shared/overview'
     ReactiveFileComponent,
     PeertubeCheckboxComponent,
     SubscribeButtonComponent,
+    RemoteSubscribeComponent,
     InstanceFeaturesTableComponent,
 
     NumberFormatterPipe,

--- a/client/src/app/shared/user-subscription/index.ts
+++ b/client/src/app/shared/user-subscription/index.ts
@@ -1,2 +1,3 @@
 export * from './user-subscription.service'
 export * from './subscribe-button.component'
+export * from './remote-subscribe.component'

--- a/client/src/app/shared/user-subscription/remote-subscribe.component.html
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.html
@@ -1,0 +1,25 @@
+<form novalidate [formGroup]="form" 
+      class="px-3 py-1" (ngSubmit)="formValidated()">
+  <div class="form-group">
+    <input type="email"
+      formControlName="text"
+      class="form-control"
+      (keyup.control.enter)="onValidKey()" (keyup.meta.enter)="onValidKey()"
+      placeholder="jane_doe@example.com">
+  </div>
+  <button type="submit"
+    [disabled]="!form.valid"
+    class="btn btn-sm btn-remote-follow"
+    i18n>
+    <span *ngIf="!interact">Remote subscribe</span>
+    <span *ngIf="interact">Remote interact</span>
+  </button>
+  <my-help *ngIf="!interact && showHelp"
+           helpType="custom"
+           i18n-customHtml customHtml="You can subscribe to the channel via any ActivityPub-capable fediverse instance. For instance with Mastodon or Pleroma you can type the channel URL in the search box and subscribe there.">
+  </my-help>
+  <my-help *ngIf="showHelp && interact"
+           helpType="custom"
+           i18n-customHtml customHtml="You can interact with this via any ActivityPub-capable fediverse instance. For instance with Mastodon or Pleroma you can type the current URL in the search box and interact with it there.">
+  </my-help>
+</form>

--- a/client/src/app/shared/user-subscription/remote-subscribe.component.html
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.html
@@ -1,5 +1,5 @@
 <form novalidate [formGroup]="form" 
-      class="px-3 py-1" (ngSubmit)="formValidated()">
+      (ngSubmit)="formValidated()">
   <div class="form-group">
     <input type="email"
       formControlName="text"

--- a/client/src/app/shared/user-subscription/remote-subscribe.component.scss
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.scss
@@ -1,0 +1,5 @@
+@import '_mixins';
+
+.btn-remote-follow {
+  @include orange-button;
+}

--- a/client/src/app/shared/user-subscription/remote-subscribe.component.ts
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnInit } from '@angular/core'
+import { FormReactive } from '@app/shared/forms/form-reactive'
+import {
+  FormValidatorService,
+  UserValidatorsService
+} from '@app/shared/forms/form-validators'
+
+@Component({
+  selector: 'my-remote-subscribe',
+  templateUrl: './remote-subscribe.component.html',
+  styleUrls: ['./remote-subscribe.component.scss']
+})
+export class RemoteSubscribeComponent extends FormReactive implements OnInit {
+  @Input() account: string
+  @Input() interact = false
+  @Input() showHelp = false
+
+  constructor (
+    protected formValidatorService: FormValidatorService,
+    private userValidatorsService: UserValidatorsService
+  ) {
+    super()
+  }
+
+  ngOnInit () {
+    this.buildForm({
+      text: this.userValidatorsService.USER_EMAIL
+    })
+  }
+
+  onValidKey () {
+    this.onValueChanged()
+    if (!this.form.valid) return
+
+    this.formValidated()
+  }
+
+  formValidated () {
+    const address = this.form.value['text']
+    const hostname = address.substring(address.lastIndexOf('@') + 1)
+    window.open(`https://${hostname}/authorize_interaction?acct=${this.account}`)
+  }
+}

--- a/client/src/app/shared/user-subscription/remote-subscribe.component.ts
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.ts
@@ -37,7 +37,7 @@ export class RemoteSubscribeComponent extends FormReactive implements OnInit {
 
   formValidated () {
     const address = this.form.value['text']
-    const hostname = address.substring(address.lastIndexOf('@') + 1)
+    const [ , hostname ] = address.split('@')
     window.open(`https://${hostname}/authorize_interaction?acct=${this.account}`)
   }
 }

--- a/client/src/app/shared/user-subscription/subscribe-button.component.html
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.html
@@ -1,15 +1,45 @@
-<span i18n *ngIf="subscribed === false" class="subscribe-button" [ngClass]="size" role="button" (click)="subscribe()">
-  <span>Subscribe</span>
-  <span *ngIf="displayFollowers && videoChannel.followersCount !== 0" class="followers-count">
-    {{ videoChannel.followersCount | myNumberFormatter }}
-  </span>
-</span>
+<div class="btn-group-subscribe btn-group"
+    [ngClass]="{'subscribe-button': subscribed == false, 'unsubscribe-button': subscribed == true}">
+  <button *ngIf="subscribed === false && isUserLoggedIn()" type="button"
+          class="btn btn-sm" role="button"
+          (click)="subscribe()" i18n>
+    <span>
+      Subscribe
+    </span>
+    <span *ngIf="displayFollowers && videoChannel.followersCount !== 0" class="followers-count">
+      {{ videoChannel.followersCount | myNumberFormatter }}
+    </span>
+  </button>
+  <button *ngIf="subscribed === true" type="button"
+          class="btn btn-sm" role="button"
+          (click)="unsubscribe()" i18n>Unsubscribe</button>
 
-<span *ngIf="subscribed === true" class="unsubscribe-button" [ngClass]="size" role="button" (click)="unsubscribe()">
-  <span class="subscribed" i18n>Subscribed</span>
-  <span class="unsubscribe" i18n>Unsubscribe</span>
+  <div class="btn-group" ngbDropdown autoClose="outside" 
+       placement="bottom-right" role="group"
+       aria-label="Multiple ways to subscribe to the current channel">
+    <button class="btn btn-sm dropdown-toggle-split" ngbDropdownToggle>
+      <span *ngIf="!isUserLoggedIn()">
+        Subscribe
+      </span>
+      <span *ngIf="displayFollowers && videoChannel.followersCount !== 0" class="followers-count">
+        {{ videoChannel.followersCount | myNumberFormatter }}
+      </span>
+    </button>
+    <div class="dropdown-menu" ngbDropdownMenu>
 
-  <span *ngIf="displayFollowers && videoChannel.followersCount !== 0" class="followers-count">
-    {{ videoChannel.followersCount | myNumberFormatter }}
-  </span>
-</span>
+      <h6 class="dropdown-header" i18n>Using an ActivityPub-compatible account</h6>
+      <button class="dropdown-item" (click)="subscribe()"
+              *ngIf="subscribed === false">
+        <span *ngIf="!isUserLoggedIn()" i18n>Subscribe with an account on {{ videoChannel.host }}</span>
+        <span *ngIf="isUserLoggedIn()" i18n>Subscribe with your local account</span>
+      </button>
+      <button class="dropdown-item" i18n>Subscribe with a remote account:</button>
+      <my-remote-subscribe showHelp="true" account="{{ uriAccount }}"></my-remote-subscribe>
+      <div class="dropdown-divider"></div>
+
+      <h6 class="dropdown-header" i18n>Using a syndication feed</h6>
+      <button (click)="rssOpen()" class="dropdown-item" i18n>Subscribe via RSS</button>
+
+    </div>
+  </div>
+</div>

--- a/client/src/app/shared/user-subscription/subscribe-button.component.html
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.html
@@ -1,5 +1,5 @@
 <div class="btn-group-subscribe btn-group"
-    [ngClass]="{'subscribe-button': subscribed == false, 'unsubscribe-button': subscribed == true}">
+    [ngClass]="{'subscribe-button': subscribed !== true, 'unsubscribe-button': subscribed === true}">
   <button *ngIf="subscribed === false && isUserLoggedIn()" type="button"
           class="btn btn-sm" role="button"
           (click)="subscribe()" i18n>

--- a/client/src/app/shared/user-subscription/subscribe-button.component.scss
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.scss
@@ -7,8 +7,16 @@
   float: right;
   padding: 0;
 
+  &.btn-group > .btn:not(.dropdown-toggle) {
+    padding-right: 5px;
+    font-size: 15px;
+  }
+  &.btn-group > .btn-group:not(:first-child) > .btn {
+    padding-left: 2px;
+  }
+
   &.subscribe-button {
-    /deep/ .btn {
+    .btn {
       @include orange-button;
       font-weight: 600;
     }
@@ -18,10 +26,18 @@
     }
   }
   &.unsubscribe-button {
-    /deep/ .btn {
+    .btn {
       @include grey-button;
       font-weight: 600;
     }
+  }
+
+  .dropdown-header {
+    padding-left: 1rem;
+  }
+
+  /deep/ form {
+    padding: 0.25rem 1rem;
   }
 
   input {

--- a/client/src/app/shared/user-subscription/subscribe-button.component.scss
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.scss
@@ -1,51 +1,30 @@
 @import '_variables';
 @import '_mixins';
 
-.subscribe-button {
+.btn-group-subscribe {
   @include peertube-button;
-  @include orange-button;
-}
+  @include disable-default-a-behaviour;
+  float: right;
+  padding: 0;
 
-.unsubscribe-button {
-  @include peertube-button;
-  @include grey-button
-}
-
-.subscribe-button,
-.unsubscribe-button {
-  display: inline-block;
-
-  &.small {
-    min-width: 75px;
-    height: 20px;
-    line-height: 20px;
-    font-size: 13px;
-  }
-
-  &.normal {
-    min-width: 120px;
-    height: 30px;
-    line-height: 30px;
-    font-size: 16px;
-  }
-}
-
-.unsubscribe-button {
-  .subscribed {
-    display: inline;
-  }
-
-  .unsubscribe {
-    display: none;
-  }
-
-  &:hover {
-    .subscribed {
-      display: none;
+  &.subscribe-button {
+    /deep/ .btn {
+      @include orange-button;
+      font-weight: 600;
     }
 
-    .unsubscribe {
-      display: inline;
+    span.followers-count {
+      padding-left:5px;
     }
+  }
+  &.unsubscribe-button {
+    /deep/ .btn {
+      @include grey-button;
+      font-weight: 600;
+    }
+  }
+
+  input {
+    @include peertube-input-text(100%);
   }
 }

--- a/client/src/app/shared/user-subscription/subscribe-button.component.ts
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.ts
@@ -16,7 +16,7 @@ export class SubscribeButtonComponent implements OnInit {
   @Input() displayFollowers = false
   @Input() size: 'small' | 'normal' = 'normal'
 
-  subscribed = false
+  subscribed: boolean
 
   constructor (
     private authService: AuthService,

--- a/client/src/app/shared/user-subscription/subscribe-button.component.ts
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core'
+import { Router } from '@angular/router'
+import { AuthService } from '@app/core'
 import { UserSubscriptionService } from '@app/shared/user-subscription/user-subscription.service'
 import { VideoChannel } from '@app/shared/video-channel/video-channel.model'
 import { NotificationsService } from 'angular2-notifications'
@@ -14,9 +16,11 @@ export class SubscribeButtonComponent implements OnInit {
   @Input() displayFollowers = false
   @Input() size: 'small' | 'normal' = 'normal'
 
-  subscribed: boolean
+  subscribed = false
 
   constructor (
+    private authService: AuthService,
+    private router: Router,
     private notificationsService: NotificationsService,
     private userSubscriptionService: UserSubscriptionService,
     private i18n: I18n
@@ -26,16 +30,30 @@ export class SubscribeButtonComponent implements OnInit {
     return this.videoChannel.name + '@' + this.videoChannel.host
   }
 
-  ngOnInit () {
-    this.userSubscriptionService.isSubscriptionExists(this.uri)
-      .subscribe(
-        res => this.subscribed = res[this.uri],
+  get uriAccount () {
+    return this.videoChannel.ownerAccount.name + '@' + this.videoChannel.host
+  }
 
-        err => this.notificationsService.error(this.i18n('Error'), err.message)
-      )
+  ngOnInit () {
+    if (this.isUserLoggedIn()) {
+      this.userSubscriptionService.isSubscriptionExists(this.uri)
+        .subscribe(
+          res => this.subscribed = res[this.uri],
+
+          err => this.notificationsService.error(this.i18n('Error'), err.message)
+        )
+    }
   }
 
   subscribe () {
+    if (this.isUserLoggedIn()) {
+      this.localSubscribe()
+    } else {
+      this.gotoLogin()
+    }
+  }
+
+  localSubscribe () {
     this.userSubscriptionService.addSubscription(this.uri)
       .subscribe(
         () => {
@@ -52,6 +70,12 @@ export class SubscribeButtonComponent implements OnInit {
   }
 
   unsubscribe () {
+    if (this.isUserLoggedIn()) {
+      this.localUnsubscribe()
+    }
+  }
+
+  localUnsubscribe () {
     this.userSubscriptionService.deleteSubscription(this.uri)
         .subscribe(
           () => {
@@ -65,5 +89,17 @@ export class SubscribeButtonComponent implements OnInit {
 
           err => this.notificationsService.error(this.i18n('Error'), err.message)
         )
+  }
+
+  isUserLoggedIn () {
+    return this.authService.isLoggedIn()
+  }
+
+  gotoLogin () {
+    this.router.navigate([ '/login' ])
+  }
+
+  rssOpen () {
+    window.open('')
   }
 }

--- a/client/src/app/videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/videos/+video-watch/comment/video-comment-add.component.html
@@ -1,9 +1,11 @@
 <form novalidate [formGroup]="form" (ngSubmit)="formValidated()">
   <div class="avatar-and-textarea">
-    <img [src]="user.accountAvatarUrl" alt="Avatar" />
+    <img [src]="getAvatarUrl()" alt="Avatar" />
 
     <div class="form-group">
       <textarea i18n-placeholder placeholder="Add comment..." autosize
+                [readonly]="(user === null) ? true : false"
+                (click)="openVisitorModal($event)"
                 formControlName="text" [ngClass]="{ 'input-error': formErrors['text'] }"
                 (keyup.control.enter)="onValidKey()" (keyup.meta.enter)="onValidKey()" #textarea>
 
@@ -20,3 +22,25 @@
     </button>
   </div>
 </form>
+
+<ng-template #visitorModal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title" id="modal-basic-title" i18n>You are one step away from commenting</h4>
+    <button type="button" class="close" aria-label="Close" (click)="hideVisitorModal()"></button>
+  </div>
+  <div class="modal-body" i18n>
+    <span i18n>
+      If you have an account on this instance, you can login:
+    </span>
+    <span class="btn btn-sm mx-3" role="button" (click)="gotoLogin()" i18n>login to comment</span>
+    <span i18n>
+      Otherwise you can comment using an account on an ActivityPub-compatible instance:
+    </span>
+    <my-remote-subscribe [interact]="true" account="{{ uri }}"></my-remote-subscribe>
+  </div>
+  <div class="modal-footer inputs">
+    <span i18n class="action-button action-button-cancel" role="button" (click)="hideVisitorModal()">
+      Cancel
+    </span>
+  </div>
+</ng-template>

--- a/client/src/app/videos/+video-watch/comment/video-comment-add.component.scss
+++ b/client/src/app/videos/+video-watch/comment/video-comment-add.component.scss
@@ -36,12 +36,24 @@ form {
 
   button {
     @include peertube-button;
-    @include orange-button
+    @include orange-button;
   }
 }
 
 @media screen and (max-width: 450px) {
   textarea, .submit-comment button {
     font-size: 14px !important;
+  }
+}
+
+.modal-body {
+  .btn {
+    @include peertube-button;
+    @include orange-button;
+  }
+
+  span {
+    float: left;
+    margin-bottom: 20px;
   }
 }

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.html
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.html
@@ -10,7 +10,6 @@
 
   <ng-template [ngIf]="video.commentsEnabled === true">
     <my-video-comment-add
-      *ngIf="isUserLoggedIn()"
       [video]="video"
       [user]="user"
       (commentCreated)="onCommentThreadCreated($event)"

--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -126,7 +126,7 @@
                 <img [src]="video.videoChannelAvatarUrl" alt="Video channel avatar" />
               </a>
 
-              <my-subscribe-button #subscribeButton *ngIf="isUserLoggedIn()" [videoChannel]="video.channel" size="small"></my-subscribe-button>
+              <my-subscribe-button #subscribeButton [videoChannel]="video.channel" size="small"></my-subscribe-button>
             </div>
 
             <div class="video-info-by">
@@ -134,8 +134,6 @@
                 <span i18n>By {{ video.byAccount }}</span>
                 <img [src]="video.accountAvatarUrl" alt="Account avatar" />
               </a>
-
-              <my-help helpType="custom" i18n-customHtml customHtml="You can subscribe to this account via any ActivityPub-capable fediverse instance. For instance with Mastodon or Pleroma you can type in the search box <strong>@{{video.account.name}}@{{video.account.host}}</strong> and subscribe there."></my-help>
             </div>
           </div>
 

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -195,9 +195,18 @@ label {
 
   .dropdown-item {
     padding: 3px 15px;
+
+    &:active {
+      color: #000 !important;
+    }
+  }
+
+  button {
+    @include disable-default-a-behaviour;
   }
 
   a {
+    @include disable-default-a-behaviour;
     color: #000 !important;
   }
 }

--- a/client/src/sass/include/_bootstrap.scss
+++ b/client/src/sass/include/_bootstrap.scss
@@ -46,7 +46,7 @@ $nav-pills-link-active-color: #000;
 @import '~bootstrap/scss/buttons';
 //@import '~bootstrap/scss/transitions';
 @import '~bootstrap/scss/dropdown';
-//@import '~bootstrap/scss/button-group';
+@import '~bootstrap/scss/button-group';
 @import '~bootstrap/scss/input-group';
 //@import '~bootstrap/scss/custom-forms';
 @import '~bootstrap/scss/nav';


### PR DESCRIPTION
@Chocobozzz I didn't know how to properly inject the RSS URI in the button, so I left that aside.

![screenshot_2018-09-22 nay](https://user-images.githubusercontent.com/6329880/45910907-7618f700-be0d-11e8-8049-7e2c825f599c.png)

The advantage of this button is that it even shows for visitors. It gives them a tour of the available possibilities to subscribe, while also being interactive via a form for remote follow.

The appearance differs slightly if you are logged-in: the button is then a two-action button, whose left part subscribes directly with your local account (as the original button). The right part open the dropdown-menu.

The button is now put on the right side, much like with YT.