### PR TITLE
add redirect after login

### DIFF
--- a/client/src/app/core/auth/auth.service.ts
+++ b/client/src/app/core/auth/auth.service.ts
@@ -38,6 +38,7 @@ export class AuthService {
   loginChangedSource: Observable<AuthStatus>
   userInformationLoaded = new ReplaySubject<boolean>(1)
   hotkeys: Hotkey[]
+  redirectUrl: string
 
   private clientId: string = peertubeLocalStorage.getItem(AuthService.LOCAL_STORAGE_OAUTH_CLIENT_KEYS.CLIENT_ID)
   private clientSecret: string = peertubeLocalStorage.getItem(AuthService.LOCAL_STORAGE_OAUTH_CLIENT_KEYS.CLIENT_SECRET)
@@ -177,6 +178,8 @@ export class AuthService {
     this.setStatus(AuthStatus.LoggedOut)
 
     this.hotkeysService.remove(this.hotkeys)
+
+    this.redirectUrl = null
   }
 
   refreshAccessToken () {

--- a/client/src/app/core/routing/login-guard.service.ts
+++ b/client/src/app/core/routing/login-guard.service.ts
@@ -20,6 +20,8 @@ export class LoginGuard implements CanActivate, CanActivateChild {
   canActivate (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     if (this.auth.isLoggedIn() === true) return true
 
+    this.auth.redirectUrl = state.url
+
     this.router.navigate([ '/login' ])
     return false
   }

--- a/client/src/app/login/login.component.ts
+++ b/client/src/app/login/login.component.ts
@@ -72,9 +72,9 @@ export class LoginComponent extends FormReactive implements OnInit {
   }
 
   redirect () {
-    let redirect = this.authService.redirectUrl
+    const redirect = this.authService.redirectUrl
     if (redirect) {
-      this.router.navigate([redirect])
+      this.router.navigate([ redirect ])
     } else {
       this.redirectService.redirectToHomepage()
     }

--- a/client/src/app/login/login.component.ts
+++ b/client/src/app/login/login.component.ts
@@ -8,6 +8,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 import { FormValidatorService } from '@app/shared/forms/form-validators/form-validator.service'
 import { LoginValidatorsService } from '@app/shared/forms/form-validators/login-validators.service'
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap'
+import { Router } from '@angular/router'
 
 @Component({
   selector: 'my-login',
@@ -26,6 +27,7 @@ export class LoginComponent extends FormReactive implements OnInit {
   private openedForgotPasswordModal: NgbModalRef
 
   constructor (
+    public router: Router,
     protected formValidatorService: FormValidatorService,
     private modalService: NgbModal,
     private loginValidatorsService: LoginValidatorsService,
@@ -59,7 +61,7 @@ export class LoginComponent extends FormReactive implements OnInit {
 
     this.authService.login(username, password)
       .subscribe(
-        () => this.redirectService.redirectToHomepage(),
+        () => this.redirect(),
 
         err => {
           if (err.message.indexOf('credentials are invalid') !== -1) this.error = this.i18n('Incorrect username or password.')
@@ -67,6 +69,15 @@ export class LoginComponent extends FormReactive implements OnInit {
           else this.error = err.message
         }
       )
+  }
+
+  redirect () {
+    let redirect = this.authService.redirectUrl
+    if (redirect) {
+      this.router.navigate([redirect])
+    } else {
+      this.redirectService.redirectToHomepage()
+    }
   }
 
   askResetPassword () {


### PR DESCRIPTION
this will redirect you back to the page you wanted to go before you were redirected to the login page.

I am not sure why I need `this.redirectUrl = null`.
If I remember correctly and looking at the [example](https://angular.io/guide/router#component-less-route-grouping-routes-without-a-component) this should not be needed. But maybe the `auth.service` is not destroyed at logout.

fixes #294