### PR TITLE
Add warning about RAM to contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,7 +44,9 @@ before you start working on them :).
 
 ### Prerequisites
 
-First, make sure that you have followed 
+First, you should use a server or PC with at least 4GB of RAM. Less RAM may lead to crashes.
+
+Make sure that you have followed 
 [the steps](/support/doc/dependencies.md) 
 to install the dependencies.
 


### PR DESCRIPTION
I tried to run a dev instance of PeerTube on a VPS with Fedora. I tried with 1GB of RAM, then 2GB. In both cases, running `npm run dev:server` failed when the RAM got full. 

[See the screencast](https://framadrop.org/r/WPQds1jgVe#BuAlnYIxOU63BesiMhNRtKifPe5KbMFUCjEBW4F8TwU=)

I tried then with a VPS with 4GB of RAM, and it worked.
