### PR TITLE
Enable Simplified Chinese support

### DIFF
--- a/scripts/build/client.sh
+++ b/scripts/build/client.sh
@@ -40,7 +40,7 @@ if [ -z ${1+x} ] || [ "$1" != "--light" ]; then
         languages=("fr_FR")
     else
         # Supported languages
-        languages=("fr_FR" "pt_BR" "sv_SE" "eu_ES" "ca_ES" "cs_CZ" "eo" "zh_Hant_TW" "de_DE" "es_ES" "oc")
+        languages=("fr_FR" "pt_BR" "sv_SE" "eu_ES" "ca_ES" "cs_CZ" "eo" "zh_Hant_TW" "de_DE" "es_ES" "oc" "zh_Hans_CN")
     fi
 
     for lang in "${languages[@]}"; do

--- a/shared/models/i18n/i18n.ts
+++ b/shared/models/i18n/i18n.ts
@@ -10,10 +10,11 @@ export const I18N_LOCALES = {
   'de-DE': 'Deutsch',
   'es-ES': 'Español',
   'oc': 'Occitan',
-  'zh-Hant-TW': '中文 (繁體, 台灣)',
+  'zh-Hant-TW': '繁體中文（台灣）',
   'pt-BR': 'Português (Brasil)',
-  'sv-SE': 'svenska'
+  'sv-SE': 'svenska',
   // 'pl-PL': 'Polski'
+  'zh-Hans-CN': '简体中文（中国）'
 }
 
 const I18N_LOCALE_ALIAS = {


### PR DESCRIPTION
Also slightly changed names for both zh languages:
`中文 (繁體, 台灣)` _Chinese (Traditional, Taiwan)_ → `繁體中文（台灣）` _Traditional Chinese (Taiwan)_

Let me know if anything goes wrong :P