### PR TITLE
fix style dependency paths

### DIFF
--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -1,4 +1,4 @@
-$icon-font-path: '../../node_modules/@neos21/bootstrap3-glyphicons/assets/fonts/';
+$icon-font-path: '@neos21/bootstrap3-glyphicons/assets/fonts/';
 @import '_bootstrap';
 
 @import '_variables';

--- a/client/src/sass/include/_fonts.scss
+++ b/client/src/sass/include/_fonts.scss
@@ -1,4 +1,4 @@
-$FontPathSourceSansPro: '../../node_modules/npm-font-source-sans-pro/fonts';
+$FontPathSourceSansPro: 'npm-font-source-sans-pro/fonts';
 
 @font-face {
   font-family: 'Source Sans Pro';


### PR DESCRIPTION
When installing node_modules with npm it's not necessary to put `../../node_modules` ... to include/import resources from installed npm modules when importing style dependencies.