### PR TITLE
Add prompt to upgrade.sh to install pre-release version

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -26,9 +26,21 @@ SQL_BACKUP_PATH="$PEERTUBE_PATH/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").
 mkdir -p $PEERTUBE_PATH/backup
 pg_dump -U peertube -W -h localhost -F c peertube_prod -f "$SQL_BACKUP_PATH" 
 
-# Get and Display the Latest Version
-VERSION=$(curl -s https://api.github.com/repos/chocobozzz/peertube/releases/latest | grep tag_name | cut -d '"' -f 4)
-echo "Latest Peertube version is $VERSION"
+# If there is a pre-release, give the user a choice which one to install.
+RELEASE_VERSION=$(curl -s https://api.github.com/repos/chocobozzz/peertube/releases/latest | grep tag_name | cut -d '"' -f 4)
+PRE_RELEASE_VERSION=$(curl -s https://api.github.com/repos/chocobozzz/peertube/releases | grep tag_name | head -1 | cut -d '"' -f 4)
+
+if [ "$RELEASE_VERSION" != "$PRE_RELEASE_VERSION" ]; then
+  echo -e "Which version do you want to install?\n[1] $RELEASE_VERSION (stable) \n[2] $PRE_RELEASE_VERSION (pre-release)"
+  read choice
+  case $choice in
+      [1]* ) VERSION="$RELEASE_VERSION";;
+      [2]* ) VERSION="$PRE_RELEASE_VERSION";;
+      * ) exit;
+  esac
+fi
+
+echo "Installing Peertube version $VERSION"
 wget -q "https://github.com/Chocobozzz/PeerTube/releases/download/${VERSION}/peertube-${VERSION}.zip" -O "$PEERTUBE_PATH/versions/peertube-${VERSION}.zip"
 cd $PEERTUBE_PATH/versions
 unzip -o "peertube-${VERSION}.zip"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -38,6 +38,8 @@ if [ "$RELEASE_VERSION" != "$PRE_RELEASE_VERSION" ]; then
       [2]* ) VERSION="$PRE_RELEASE_VERSION";;
       * ) exit;
   esac
+else
+  VERSION="$RELEASE_VERSION"
 fi
 
 echo "Installing Peertube version $VERSION"


### PR DESCRIPTION
The upgrade.sh script doesn't let you install pre-release versions of Peertube. This change adds a prompt if a pre-release is available. Output looks like this:
```
$ ./upgrade.sh
Which version do you want to install?
[1] v1.0.0-beta.13 (stable)
[2] v1.0.0-beta.15 (pre-release)
```