### PR TITLE
Allow specification of Channel ID in peertube-upload.js

### DIFF
--- a/server/tools/peertube-upload.ts
+++ b/server/tools/peertube-upload.ts
@@ -15,6 +15,7 @@ program
   .option('-P, --privacy <privacy_number>', 'Privacy')
   .option('-N, --nsfw', 'Video is Not Safe For Work')
   .option('-c, --category <category_number>', 'Category number')
+  .option('-C, --channel-id <channel_id>', 'Channel ID')
   .option('-m, --comments-enabled', 'Enable comments')
   .option('-l, --licence <licence_number>', 'Licence number')
   .option('-L, --language <language_code>', 'Language ISO 639 code (fr or en...)')
@@ -105,7 +106,7 @@ async function run () {
 
   console.log('Uploading %s video...', program[ 'videoName' ])
 
-  const videoAttributes = {
+  let videoAttributes:any = {
     name: program['videoName'],
     category: program['category'],
     licence: program['licence'],
@@ -120,6 +121,10 @@ async function run () {
     waitTranscoding: true,
     privacy: program['privacy'],
     support: undefined
+  }
+
+  if (program['channelId']) {
+    videoAttributes.channelId = program['channelId']
   }
 
   await uploadVideo(program[ 'url' ], accessToken, videoAttributes)

--- a/server/tools/peertube-upload.ts
+++ b/server/tools/peertube-upload.ts
@@ -106,9 +106,10 @@ async function run () {
 
   console.log('Uploading %s video...', program[ 'videoName' ])
 
-  let videoAttributes:any = {
+  const videoAttributes = {
     name: program['videoName'],
     category: program['category'],
+    channelId: program['channelId'],
     licence: program['licence'],
     language: program['language'],
     nsfw: program['nsfw'],
@@ -121,10 +122,6 @@ async function run () {
     waitTranscoding: true,
     privacy: program['privacy'],
     support: undefined
-  }
-
-  if (program['channelId']) {
-    videoAttributes.channelId = program['channelId']
   }
 
   await uploadVideo(program[ 'url' ], accessToken, videoAttributes)


### PR DESCRIPTION
Closes #1134.

This PR creates a new command line flag for the `peertube-upload.js` script, `-C, --channel-id` that allows one to specify a channel to upload to rather than the default.

This was very helpful for my own scripts of uploading hundreds of videos to a custom channel, and I hope others will benefit from it too.