### PR TITLE
noImplicitAny flag activated

### DIFF
--- a/client/src/app/+my-account/my-account-videos/video-change-ownership/video-change-ownership.component.ts
+++ b/client/src/app/+my-account/my-account-videos/video-change-ownership/video-change-ownership.component.ts
@@ -49,7 +49,8 @@ export class VideoChangeOwnershipComponent extends FormReactive implements OnIni
       .catch((_) => _) // Called when closing (cancel) the modal without validating, do nothing
   }
 
-  search (event) {
+  // TODO: typing
+  search (event: any) {
     const query = event.query
     this.userService.autocomplete(query)
       .subscribe(

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -69,7 +69,7 @@ export function metaFactory (serverService: ServerService): MetaLoader {
   providers: [
     {
       provide: TRANSLATIONS,
-      useFactory: (locale) => {
+      useFactory: (locale: string) => {
         // On dev mode, test localization
         if (isOnDevLocale()) {
           locale = buildFileLocale(getDevLocale())

--- a/client/src/app/core/theme/theme.service.ts
+++ b/client/src/app/core/theme/theme.service.ts
@@ -5,7 +5,8 @@ import { peertubeLocalStorage } from '@app/shared/misc/peertube-local-storage'
 export class ThemeService {
   private theme = document.querySelector('body')
   private darkTheme = false
-  private previousTheme = {}
+
+  private previousTheme: { [ id: string ]: string } = {}
 
   constructor () {
     // initialise the alternative theme with dark theme colors
@@ -33,7 +34,7 @@ export class ThemeService {
     }
   }
 
-  private switchProperty (property, newValue?) {
+  private switchProperty (property: string, newValue?: string) {
     const propertyOldvalue = window.getComputedStyle(this.theme).getPropertyValue('--' + property)
     this.theme.style.setProperty('--' + property, (newValue) ? newValue : this.previousTheme[property])
     this.previousTheme[property] = propertyOldvalue

--- a/client/src/assets/player/peertube-player.ts
+++ b/client/src/assets/player/peertube-player.ts
@@ -71,12 +71,12 @@ function getVideojsOptions (options: {
         enableVolumeScroll: false,
         enableModifiersForNumbers: false,
 
-        fullscreenKey: function (event) {
+        fullscreenKey: function (event: any) {
           // fullscreen with the f key or Ctrl+Enter
           return event.key === 'f' || (event.ctrlKey && event.key === 'Enter')
         },
 
-        seekStep: function (event) {
+        seekStep: function (event: any) {
           // mimic VLC seek behavior, and default to 5 (original value is 5).
           if (event.ctrlKey && event.altKey) {
             return 5 * 60
@@ -107,10 +107,10 @@ function getVideojsOptions (options: {
             }
           },
           frameByFrame: {
-            key: function (event) {
+            key: function (event: any) {
               return event.key === '.'
             },
-            handler: function (player, options, event) {
+            handler: function (player: any) {
               player.pause()
               // Calculate movement distance (assuming 30 fps)
               const dist = 1 / 30


### PR DESCRIPTION
this enables the `noImplicitAny` flag

Imports are fixed following this hint
I hope this won't break anything

> When the noImplicitAny flag is true and the TypeScript compiler cannot infer the type, it still generates the JavaScript files, but it also reports an error. Many seasoned developers prefer this stricter setting because type checking catches more unintentional errors at compile time.

closes: #1131
replaces #1137