### PR TITLE
add pid file in ExecStartPost to peertube systemd service

### DIFF
--- a/support/systemd/peertube.service
+++ b/support/systemd/peertube.service
@@ -9,6 +9,7 @@ Environment=NODE_CONFIG_DIR=/var/www/peertube/config
 User=peertube
 Group=peertube
 ExecStart=/usr/bin/npm start
+ExecStartPost=/bin/sh -c 'umask 022; pgrep peertube > /var/run/peertube.pid'
 WorkingDirectory=/var/www/peertube/peertube-latest
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
There was a missing step in the systemd service, need to also create a pid file /var/run/peertube.pid