### PR TITLE
fix menu to not overlap content on small screens

### DIFF
--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -370,7 +370,6 @@ table {
 
 @media screen and (max-width: $small-view) {
   .main-col {
-    margin-left: 0;
 
     &, &.expanded {
       .margin-content {


### PR DESCRIPTION
remove margin-left: 0; from .main-col on max-width: 800px as it overrides a already good style setting which doesn't break the view on small screens. When toggle menu it makes the content shift over as intended for the menu to work, instead of overlap.