### PR TITLE
add webtorrent opt-out settings

### DIFF
--- a/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.html
+++ b/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.html
@@ -15,6 +15,18 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <label i18n for="webTorrentPolicy">Policy regarding P2P technologies</label>
+
+    <div class="peertube-select-container">
+      <select id="webTorrentPolicy" formControlName="webTorrentPolicy">
+        <option i18n value="enable">Enable WebTorrent</option>
+        <option i18n value="disable">Disable WebTorrent globally</option>
+        <option i18n value="disable_on_mobile" disabled>Disable WebTorrent on mobile devices (not yet available)</option>
+      </select>
+    </div>
+  </div>
+
   <my-peertube-checkbox
     inputName="autoPlayVideo" formControlName="autoPlayVideo"
     i18n-labelText labelText="Automatically plays video"

--- a/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.html
+++ b/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.html
@@ -16,16 +16,20 @@
   </div>
 
   <div class="form-group">
-    <label i18n for="webTorrentPolicy">Policy regarding P2P technologies</label>
+    <label i18n for="webTorrentEnabled">Policy regarding P2P technologies</label>
 
     <div class="peertube-select-container">
-      <select id="webTorrentPolicy" formControlName="webTorrentPolicy">
+      <select id="webTorrentEnabled" formControlName="webTorrentEnabled">
         <option i18n value="enable">Enable WebTorrent</option>
-        <option i18n value="disable">Disable WebTorrent globally</option>
-        <option i18n value="disable_on_mobile" disabled>Disable WebTorrent on mobile devices (not yet available)</option>
+        <option i18n value="disable">Disable WebTorrent</option>
       </select>
     </div>
   </div>
+
+  <my-peertube-checkbox
+    inputName="webTorrentEnabled" formControlName="webTorrentEnabled"
+    i18n-labelText labelText="Use WebTorrent to exchange parts of the video with others"
+  ></my-peertube-checkbox>
 
   <my-peertube-checkbox
     inputName="autoPlayVideo" formControlName="autoPlayVideo"

--- a/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.ts
+++ b/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.ts
@@ -29,12 +29,14 @@ export class MyAccountVideoSettingsComponent extends FormReactive implements OnI
   ngOnInit () {
     this.buildForm({
       nsfwPolicy: null,
+      webTorrentPolicy: null,
       autoPlayVideo: null
     })
 
     this.userInformationLoaded.subscribe(() => {
       this.form.patchValue({
         nsfwPolicy: this.user.nsfwPolicy,
+        webTorrentPolicy: this.user.webTorrentPolicy,
         autoPlayVideo: this.user.autoPlayVideo === true
       })
     })
@@ -42,9 +44,11 @@ export class MyAccountVideoSettingsComponent extends FormReactive implements OnI
 
   updateDetails () {
     const nsfwPolicy = this.form.value['nsfwPolicy']
+    const webTorrentPolicy = this.form.value['webTorrentPolicy']
     const autoPlayVideo = this.form.value['autoPlayVideo']
     const details: UserUpdateMe = {
       nsfwPolicy,
+      webTorrentPolicy,
       autoPlayVideo
     }
 

--- a/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.ts
+++ b/client/src/app/+my-account/my-account-settings/my-account-video-settings/my-account-video-settings.component.ts
@@ -29,14 +29,14 @@ export class MyAccountVideoSettingsComponent extends FormReactive implements OnI
   ngOnInit () {
     this.buildForm({
       nsfwPolicy: null,
-      webTorrentPolicy: null,
+      webTorrentEnabled: null,
       autoPlayVideo: null
     })
 
     this.userInformationLoaded.subscribe(() => {
       this.form.patchValue({
         nsfwPolicy: this.user.nsfwPolicy,
-        webTorrentPolicy: this.user.webTorrentPolicy,
+        webTorrentEnabled: this.user.webTorrentEnabled,
         autoPlayVideo: this.user.autoPlayVideo === true
       })
     })
@@ -44,11 +44,11 @@ export class MyAccountVideoSettingsComponent extends FormReactive implements OnI
 
   updateDetails () {
     const nsfwPolicy = this.form.value['nsfwPolicy']
-    const webTorrentPolicy = this.form.value['webTorrentPolicy']
+    const webTorrentEnabled = this.form.value['webTorrentEnabled']
     const autoPlayVideo = this.form.value['autoPlayVideo']
     const details: UserUpdateMe = {
       nsfwPolicy,
-      webTorrentPolicy,
+      webTorrentEnabled,
       autoPlayVideo
     }
 

--- a/client/src/app/core/auth/auth-user.model.ts
+++ b/client/src/app/core/auth/auth-user.model.ts
@@ -4,7 +4,6 @@ import { UserRight } from '../../../../../shared/models/users/user-right.enum'
 import { hasUserRight, UserRole } from '../../../../../shared/models/users/user-role'
 import { User, UserConstructorHash } from '../../shared/users/user.model'
 import { NSFWPolicyType } from '../../../../../shared/models/videos/nsfw-policy.type'
-import { WebTorrentPolicyType } from '../../../../../shared/models/users/user-webtorrent-policy.type'
 
 export type TokenOptions = {
   accessToken: string
@@ -73,7 +72,7 @@ export class AuthUser extends User {
     EMAIL: 'email',
     USERNAME: 'username',
     NSFW_POLICY: 'nsfw_policy',
-    WEBTORRENT_POLICY: 'peertube-videojs-' + 'webtorrent_policy',
+    WEBTORRENT_ENABLED: 'peertube-videojs-' + 'webtorrent_enabled',
     AUTO_PLAY_VIDEO: 'auto_play_video'
   }
 
@@ -89,7 +88,7 @@ export class AuthUser extends User {
           email: peertubeLocalStorage.getItem(this.KEYS.EMAIL),
           role: parseInt(peertubeLocalStorage.getItem(this.KEYS.ROLE), 10) as UserRole,
           nsfwPolicy: peertubeLocalStorage.getItem(this.KEYS.NSFW_POLICY) as NSFWPolicyType,
-          webTorrentPolicy: peertubeLocalStorage.getItem(this.KEYS.WEBTORRENT_POLICY) as WebTorrentPolicyType,
+          webTorrentEnabled: peertubeLocalStorage.getItem(this.KEYS.WEBTORRENT_ENABLED) === 'true',
           autoPlayVideo: peertubeLocalStorage.getItem(this.KEYS.AUTO_PLAY_VIDEO) === 'true'
         },
         Tokens.load()
@@ -104,7 +103,7 @@ export class AuthUser extends User {
     peertubeLocalStorage.removeItem(this.KEYS.ID)
     peertubeLocalStorage.removeItem(this.KEYS.ROLE)
     peertubeLocalStorage.removeItem(this.KEYS.NSFW_POLICY)
-    peertubeLocalStorage.removeItem(this.KEYS.WEBTORRENT_POLICY)
+    peertubeLocalStorage.removeItem(this.KEYS.WEBTORRENT_ENABLED)
     peertubeLocalStorage.removeItem(this.KEYS.AUTO_PLAY_VIDEO)
     peertubeLocalStorage.removeItem(this.KEYS.EMAIL)
     Tokens.flush()
@@ -142,7 +141,7 @@ export class AuthUser extends User {
     peertubeLocalStorage.setItem(AuthUser.KEYS.EMAIL, this.email)
     peertubeLocalStorage.setItem(AuthUser.KEYS.ROLE, this.role.toString())
     peertubeLocalStorage.setItem(AuthUser.KEYS.NSFW_POLICY, this.nsfwPolicy.toString())
-    peertubeLocalStorage.setItem(AuthUser.KEYS.WEBTORRENT_POLICY, this.webTorrentPolicy.toString())
+    peertubeLocalStorage.setItem(AuthUser.KEYS.WEBTORRENT_ENABLED, JSON.stringify(this.webTorrentEnabled))
     peertubeLocalStorage.setItem(AuthUser.KEYS.AUTO_PLAY_VIDEO, JSON.stringify(this.autoPlayVideo))
     this.tokens.save()
   }

--- a/client/src/app/core/auth/auth-user.model.ts
+++ b/client/src/app/core/auth/auth-user.model.ts
@@ -4,6 +4,7 @@ import { UserRight } from '../../../../../shared/models/users/user-right.enum'
 import { hasUserRight, UserRole } from '../../../../../shared/models/users/user-role'
 import { User, UserConstructorHash } from '../../shared/users/user.model'
 import { NSFWPolicyType } from '../../../../../shared/models/videos/nsfw-policy.type'
+import { WebTorrentPolicyType } from '../../../../../shared/models/users/user-webtorrent-policy.type'
 
 export type TokenOptions = {
   accessToken: string
@@ -72,6 +73,7 @@ export class AuthUser extends User {
     EMAIL: 'email',
     USERNAME: 'username',
     NSFW_POLICY: 'nsfw_policy',
+    WEBTORRENT_POLICY: 'peertube-videojs-' + 'webtorrent_policy',
     AUTO_PLAY_VIDEO: 'auto_play_video'
   }
 
@@ -87,6 +89,7 @@ export class AuthUser extends User {
           email: peertubeLocalStorage.getItem(this.KEYS.EMAIL),
           role: parseInt(peertubeLocalStorage.getItem(this.KEYS.ROLE), 10) as UserRole,
           nsfwPolicy: peertubeLocalStorage.getItem(this.KEYS.NSFW_POLICY) as NSFWPolicyType,
+          webTorrentPolicy: peertubeLocalStorage.getItem(this.KEYS.WEBTORRENT_POLICY) as WebTorrentPolicyType,
           autoPlayVideo: peertubeLocalStorage.getItem(this.KEYS.AUTO_PLAY_VIDEO) === 'true'
         },
         Tokens.load()
@@ -101,6 +104,7 @@ export class AuthUser extends User {
     peertubeLocalStorage.removeItem(this.KEYS.ID)
     peertubeLocalStorage.removeItem(this.KEYS.ROLE)
     peertubeLocalStorage.removeItem(this.KEYS.NSFW_POLICY)
+    peertubeLocalStorage.removeItem(this.KEYS.WEBTORRENT_POLICY)
     peertubeLocalStorage.removeItem(this.KEYS.AUTO_PLAY_VIDEO)
     peertubeLocalStorage.removeItem(this.KEYS.EMAIL)
     Tokens.flush()
@@ -138,6 +142,7 @@ export class AuthUser extends User {
     peertubeLocalStorage.setItem(AuthUser.KEYS.EMAIL, this.email)
     peertubeLocalStorage.setItem(AuthUser.KEYS.ROLE, this.role.toString())
     peertubeLocalStorage.setItem(AuthUser.KEYS.NSFW_POLICY, this.nsfwPolicy.toString())
+    peertubeLocalStorage.setItem(AuthUser.KEYS.WEBTORRENT_POLICY, this.webTorrentPolicy.toString())
     peertubeLocalStorage.setItem(AuthUser.KEYS.AUTO_PLAY_VIDEO, JSON.stringify(this.autoPlayVideo))
     this.tokens.save()
   }

--- a/client/src/app/shared/users/user.model.ts
+++ b/client/src/app/shared/users/user.model.ts
@@ -9,6 +9,7 @@ import {
 import { NSFWPolicyType } from '../../../../../shared/models/videos/nsfw-policy.type'
 import { Account } from '@app/shared/account/account.model'
 import { Avatar } from '../../../../../shared/models/avatars/avatar.model'
+import { WebTorrentPolicyType } from '../../../../../shared/models/users/user-webtorrent-policy.type'
 
 export type UserConstructorHash = {
   id: number,
@@ -18,6 +19,7 @@ export type UserConstructorHash = {
   videoQuota?: number,
   videoQuotaDaily?: number,
   nsfwPolicy?: NSFWPolicyType,
+  webTorrentPolicy?: WebTorrentPolicyType,
   autoPlayVideo?: boolean,
   createdAt?: Date,
   account?: AccountServerModel,
@@ -32,6 +34,7 @@ export class User implements UserServerModel {
   email: string
   role: UserRole
   nsfwPolicy: NSFWPolicyType
+  webTorrentPolicy: WebTorrentPolicyType
   autoPlayVideo: boolean
   videoQuota: number
   videoQuotaDaily: number
@@ -52,6 +55,7 @@ export class User implements UserServerModel {
     this.videoQuota = hash.videoQuota
     this.videoQuotaDaily = hash.videoQuotaDaily
     this.nsfwPolicy = hash.nsfwPolicy
+    this.webTorrentPolicy = hash.webTorrentPolicy
     this.autoPlayVideo = hash.autoPlayVideo
     this.createdAt = hash.createdAt
     this.blocked = hash.blocked

--- a/client/src/app/shared/users/user.model.ts
+++ b/client/src/app/shared/users/user.model.ts
@@ -9,7 +9,6 @@ import {
 import { NSFWPolicyType } from '../../../../../shared/models/videos/nsfw-policy.type'
 import { Account } from '@app/shared/account/account.model'
 import { Avatar } from '../../../../../shared/models/avatars/avatar.model'
-import { WebTorrentPolicyType } from '../../../../../shared/models/users/user-webtorrent-policy.type'
 
 export type UserConstructorHash = {
   id: number,
@@ -19,7 +18,7 @@ export type UserConstructorHash = {
   videoQuota?: number,
   videoQuotaDaily?: number,
   nsfwPolicy?: NSFWPolicyType,
-  webTorrentPolicy?: WebTorrentPolicyType,
+  webTorrentEnabled?: boolean,
   autoPlayVideo?: boolean,
   createdAt?: Date,
   account?: AccountServerModel,
@@ -34,7 +33,7 @@ export class User implements UserServerModel {
   email: string
   role: UserRole
   nsfwPolicy: NSFWPolicyType
-  webTorrentPolicy: WebTorrentPolicyType
+  webTorrentEnabled: boolean
   autoPlayVideo: boolean
   videoQuota: number
   videoQuotaDaily: number
@@ -55,7 +54,7 @@ export class User implements UserServerModel {
     this.videoQuota = hash.videoQuota
     this.videoQuotaDaily = hash.videoQuotaDaily
     this.nsfwPolicy = hash.nsfwPolicy
-    this.webTorrentPolicy = hash.webTorrentPolicy
+    this.webTorrentEnabled = hash.webTorrentEnabled
     this.autoPlayVideo = hash.autoPlayVideo
     this.createdAt = hash.createdAt
     this.blocked = hash.blocked

--- a/client/src/assets/player/peertube-player-local-storage.ts
+++ b/client/src/assets/player/peertube-player-local-storage.ts
@@ -10,13 +10,11 @@ function getStoredVolume () {
   return undefined
 }
 
-function getStoredWebTorrentPolicy () {
-  const value = getLocalStorage('webtorrent_policy')
-  if (value !== null && value !== undefined) {
-    if (value.toString() === 'disable') return true
-  }
+function getStoredWebTorrentEnabled (): boolean {
+  const value = getLocalStorage('webtorrent_enabled')
+  if (value !== null && value !== undefined) return value === 'true'
 
-  return undefined
+  return false
 }
 
 function getStoredMute () {
@@ -65,7 +63,7 @@ function getAverageBandwidthInStore () {
 
 export {
   getStoredVolume,
-  getStoredWebTorrentPolicy,
+  getStoredWebTorrentEnabled,
   getStoredMute,
   getStoredTheater,
   saveVolumeInStore,

--- a/client/src/assets/player/peertube-player-local-storage.ts
+++ b/client/src/assets/player/peertube-player-local-storage.ts
@@ -10,6 +10,15 @@ function getStoredVolume () {
   return undefined
 }
 
+function getStoredWebTorrentPolicy () {
+  const value = getLocalStorage('webtorrent_policy')
+  if (value !== null && value !== undefined) {
+    if (value.toString() === 'disable') return true
+  }
+
+  return undefined
+}
+
 function getStoredMute () {
   const value = getLocalStorage('mute')
   if (value !== null && value !== undefined) return value === 'true'
@@ -56,6 +65,7 @@ function getAverageBandwidthInStore () {
 
 export {
   getStoredVolume,
+  getStoredWebTorrentPolicy,
   getStoredMute,
   getStoredTheater,
   saveVolumeInStore,

--- a/client/src/assets/player/peertube-videojs-plugin.ts
+++ b/client/src/assets/player/peertube-videojs-plugin.ts
@@ -8,7 +8,7 @@ import { isMobile, timeToInt, videoFileMaxByResolution, videoFileMinByResolution
 import * as CacheChunkStore from 'cache-chunk-store'
 import { PeertubeChunkStore } from './peertube-chunk-store'
 import {
-  getStoredWebTorrentPolicy,
+  getStoredWebTorrentEnabled,
   getAverageBandwidthInStore,
   getStoredMute,
   getStoredVolume,
@@ -82,6 +82,7 @@ class PeerTubePlugin extends Plugin {
 
     // Disable auto play on iOS
     this.autoplay = options.autoplay && this.isIOS() === false
+    this.playerRefusedP2P = !getStoredWebTorrentEnabled()
 
     this.startTime = timeToInt(options.startTime)
     this.videoFiles = options.videoFiles
@@ -99,7 +100,6 @@ class PeerTubePlugin extends Plugin {
       if (volume !== undefined) this.player.volume(volume)
       const muted = getStoredMute()
       if (muted !== undefined) this.player.muted(muted)
-      this.playerRefusedP2P = getStoredWebTorrentPolicy() || false
 
       this.initializePlayer()
       this.runTorrentInfoScheduler()
@@ -291,7 +291,6 @@ class PeerTubePlugin extends Plugin {
         renderVideo(torrent.files[ 0 ], this.playerElement, renderVideoOptions, (err, renderer) => {
           this.renderer = renderer
 
-          console.log('value this.playerRefusedP2P', this.playerRefusedP2P)
           if (err || this.playerRefusedP2P) return this.fallbackToHttp(done)
 
           return this.tryToPlay(err => {

--- a/server/controllers/api/users/me.ts
+++ b/server/controllers/api/users/me.ts
@@ -327,6 +327,7 @@ async function updateMe (req: express.Request, res: express.Response, next: expr
   if (body.password !== undefined) user.password = body.password
   if (body.email !== undefined) user.email = body.email
   if (body.nsfwPolicy !== undefined) user.nsfwPolicy = body.nsfwPolicy
+  if (body.webTorrentPolicy !== undefined) user.webTorrentPolicy = body.webTorrentPolicy
   if (body.autoPlayVideo !== undefined) user.autoPlayVideo = body.autoPlayVideo
 
   await sequelizeTypescript.transaction(async t => {

--- a/server/controllers/api/users/me.ts
+++ b/server/controllers/api/users/me.ts
@@ -327,7 +327,7 @@ async function updateMe (req: express.Request, res: express.Response, next: expr
   if (body.password !== undefined) user.password = body.password
   if (body.email !== undefined) user.email = body.email
   if (body.nsfwPolicy !== undefined) user.nsfwPolicy = body.nsfwPolicy
-  if (body.webTorrentPolicy !== undefined) user.webTorrentPolicy = body.webTorrentPolicy
+  if (body.webTorrentEnabled !== undefined) user.webTorrentEnabled = body.webTorrentEnabled
   if (body.autoPlayVideo !== undefined) user.autoPlayVideo = body.autoPlayVideo
 
   await sequelizeTypescript.transaction(async t => {

--- a/server/helpers/custom-validators/users.ts
+++ b/server/helpers/custom-validators/users.ts
@@ -1,7 +1,7 @@
 import 'express-validator'
 import * as validator from 'validator'
 import { UserRole } from '../../../shared'
-import { CONSTRAINTS_FIELDS, NSFW_POLICY_TYPES, WEBTORRENT_POLICY_TYPES } from '../../initializers'
+import { CONSTRAINTS_FIELDS, NSFW_POLICY_TYPES } from '../../initializers'
 import { exists, isFileValid, isBooleanValid } from './misc'
 import { values } from 'lodash'
 
@@ -42,9 +42,8 @@ function isUserNSFWPolicyValid (value: any) {
   return exists(value) && nsfwPolicies.indexOf(value) !== -1
 }
 
-const webTorrentPolicies = values(WEBTORRENT_POLICY_TYPES)
-function isUserWebTorrentPolicyValid (value: any) {
-  return exists(value) && webTorrentPolicies.indexOf(value) !== -1
+function isUserWebTorrentEnabledValid (value: any) {
+  return isBooleanValid(value)
 }
 
 function isUserAutoPlayVideoValid (value: any) {
@@ -83,7 +82,7 @@ export {
   isUserUsernameValid,
   isUserEmailVerifiedValid,
   isUserNSFWPolicyValid,
-  isUserWebTorrentPolicyValid,
+  isUserWebTorrentEnabledValid,
   isUserAutoPlayVideoValid,
   isUserDisplayNameValid,
   isUserDescriptionValid,

--- a/server/helpers/custom-validators/users.ts
+++ b/server/helpers/custom-validators/users.ts
@@ -1,7 +1,7 @@
 import 'express-validator'
 import * as validator from 'validator'
 import { UserRole } from '../../../shared'
-import { CONSTRAINTS_FIELDS, NSFW_POLICY_TYPES } from '../../initializers'
+import { CONSTRAINTS_FIELDS, NSFW_POLICY_TYPES, WEBTORRENT_POLICY_TYPES } from '../../initializers'
 import { exists, isFileValid, isBooleanValid } from './misc'
 import { values } from 'lodash'
 
@@ -42,6 +42,11 @@ function isUserNSFWPolicyValid (value: any) {
   return exists(value) && nsfwPolicies.indexOf(value) !== -1
 }
 
+const webTorrentPolicies = values(WEBTORRENT_POLICY_TYPES)
+function isUserWebTorrentPolicyValid (value: any) {
+  return exists(value) && webTorrentPolicies.indexOf(value) !== -1
+}
+
 function isUserAutoPlayVideoValid (value: any) {
   return isBooleanValid(value)
 }
@@ -78,6 +83,7 @@ export {
   isUserUsernameValid,
   isUserEmailVerifiedValid,
   isUserNSFWPolicyValid,
+  isUserWebTorrentPolicyValid,
   isUserAutoPlayVideoValid,
   isUserDisplayNameValid,
   isUserDescriptionValid,

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -7,7 +7,6 @@ import { VideoAbuseState, VideoImportState, VideoPrivacy, VideoTranscodingFPS } 
 // Do not use barrels, remain constants as independent as possible
 import { buildPath, isTestInstance, parseDuration, parseBytes, root, sanitizeHost, sanitizeUrl } from '../helpers/core-utils'
 import { NSFWPolicyType } from '../../shared/models/videos/nsfw-policy.type'
-import { WebTorrentPolicyType } from '../../shared/models/users/user-webtorrent-policy.type'
 import { invert } from 'lodash'
 import { CronRepeatOptions, EveryRepeatOptions } from 'bull'
 import * as bytes from 'bytes'
@@ -547,12 +546,6 @@ const NSFW_POLICY_TYPES: { [ id: string]: NSFWPolicyType } = {
   DISPLAY: 'display'
 }
 
-const WEBTORRENT_POLICY_TYPES: { [ id: string]: WebTorrentPolicyType } = {
-  ENABLE: 'enable',
-  DISABLE: 'disable',
-  DISABLE_ON_MOBILE: 'disable_on_mobile'
-}
-
 // ---------------------------------------------------------------------------
 
 // Express static paths (router)
@@ -705,7 +698,6 @@ export {
   FEEDS,
   JOB_TTL,
   NSFW_POLICY_TYPES,
-  WEBTORRENT_POLICY_TYPES,
   TORRENT_MIMETYPE_EXT,
   STATIC_MAX_AGE,
   STATIC_PATHS,

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -7,6 +7,7 @@ import { VideoAbuseState, VideoImportState, VideoPrivacy, VideoTranscodingFPS } 
 // Do not use barrels, remain constants as independent as possible
 import { buildPath, isTestInstance, parseDuration, parseBytes, root, sanitizeHost, sanitizeUrl } from '../helpers/core-utils'
 import { NSFWPolicyType } from '../../shared/models/videos/nsfw-policy.type'
+import { WebTorrentPolicyType } from '../../shared/models/users/user-webtorrent-policy.type'
 import { invert } from 'lodash'
 import { CronRepeatOptions, EveryRepeatOptions } from 'bull'
 import * as bytes from 'bytes'
@@ -16,7 +17,7 @@ let config: IConfig = require('config')
 
 // ---------------------------------------------------------------------------
 
-const LAST_MIGRATION_VERSION = 275
+const LAST_MIGRATION_VERSION = 280
 
 // ---------------------------------------------------------------------------
 
@@ -546,6 +547,12 @@ const NSFW_POLICY_TYPES: { [ id: string]: NSFWPolicyType } = {
   DISPLAY: 'display'
 }
 
+const WEBTORRENT_POLICY_TYPES: { [ id: string]: WebTorrentPolicyType } = {
+  ENABLE: 'enable',
+  DISABLE: 'disable',
+  DISABLE_ON_MOBILE: 'disable_on_mobile'
+}
+
 // ---------------------------------------------------------------------------
 
 // Express static paths (router)
@@ -698,6 +705,7 @@ export {
   FEEDS,
   JOB_TTL,
   NSFW_POLICY_TYPES,
+  WEBTORRENT_POLICY_TYPES,
   TORRENT_MIMETYPE_EXT,
   STATIC_MAX_AGE,
   STATIC_PATHS,

--- a/server/initializers/migrations/0280-webtorrent-policy-user.ts
+++ b/server/initializers/migrations/0280-webtorrent-policy-user.ts
@@ -1,0 +1,26 @@
+import * as Sequelize from 'sequelize'
+import { values } from 'lodash'
+import { WEBTORRENT_POLICY_TYPES } from '../constants'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction
+  queryInterface: Sequelize.QueryInterface
+  sequelize: Sequelize.Sequelize
+}): Promise<any> {
+  {
+    const data = {
+      type: Sequelize.ENUM(values(WEBTORRENT_POLICY_TYPES)),
+      allowNull: false,
+      defaultValue: 'enable'
+    }
+
+    await utils.queryInterface.addColumn('user', 'webTorrentPolicy', data)
+  }
+
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export { up, down }

--- a/server/initializers/migrations/0280-webtorrent-policy-user.ts
+++ b/server/initializers/migrations/0280-webtorrent-policy-user.ts
@@ -1,6 +1,4 @@
 import * as Sequelize from 'sequelize'
-import { values } from 'lodash'
-import { WEBTORRENT_POLICY_TYPES } from '../constants'
 
 async function up (utils: {
   transaction: Sequelize.Transaction
@@ -9,18 +7,22 @@ async function up (utils: {
 }): Promise<any> {
   {
     const data = {
-      type: Sequelize.ENUM(values(WEBTORRENT_POLICY_TYPES)),
+      type: Sequelize.BOOLEAN,
       allowNull: false,
-      defaultValue: 'enable'
+      defaultValue: true
     }
 
-    await utils.queryInterface.addColumn('user', 'webTorrentPolicy', data)
+    await utils.queryInterface.addColumn('user', 'webTorrentEnabled', data)
   }
 
 }
 
-function down (options) {
-  throw new Error('Not implemented.')
+async function down (utils: {
+  transaction: Sequelize.Transaction
+  queryInterface: Sequelize.QueryInterface
+  sequelize: Sequelize.Sequelize
+}): Promise<any> {
+  await utils.queryInterface.removeColumn('user', 'webTorrentEnabled')
 }
 
 export { up, down }

--- a/server/models/account/user.ts
+++ b/server/models/account/user.ts
@@ -31,7 +31,8 @@ import {
   isUserRoleValid,
   isUserUsernameValid,
   isUserVideoQuotaDailyValid,
-  isUserVideoQuotaValid
+  isUserVideoQuotaValid,
+  isUserWebTorrentPolicyValid
 } from '../../helpers/custom-validators/users'
 import { comparePassword, cryptPassword } from '../../helpers/peertube-crypto'
 import { OAuthTokenModel } from '../oauth/oauth-token'
@@ -39,8 +40,9 @@ import { getSort, throwIfNotValid } from '../utils'
 import { VideoChannelModel } from '../video/video-channel'
 import { AccountModel } from './account'
 import { NSFWPolicyType } from '../../../shared/models/videos/nsfw-policy.type'
+import { WebTorrentPolicyType } from '../../../shared/models/users/user-webtorrent-policy.type'
 import { values } from 'lodash'
-import { NSFW_POLICY_TYPES } from '../../initializers'
+import { NSFW_POLICY_TYPES, WEBTORRENT_POLICY_TYPES } from '../../initializers'
 import { clearCacheByUserId } from '../../lib/oauth-model'
 
 enum ScopeNames {
@@ -106,6 +108,11 @@ export class UserModel extends Model<UserModel> {
   @Is('UserNSFWPolicy', value => throwIfNotValid(value, isUserNSFWPolicyValid, 'NSFW policy'))
   @Column(DataType.ENUM(values(NSFW_POLICY_TYPES)))
   nsfwPolicy: NSFWPolicyType
+
+  @AllowNull(false)
+  @Is('UserWebTorrentPolicy', value => throwIfNotValid(value, isUserWebTorrentPolicyValid, 'WebTorrent policy'))
+  @Column(DataType.ENUM(values(WEBTORRENT_POLICY_TYPES)))
+  webTorrentPolicy: WebTorrentPolicyType
 
   @AllowNull(false)
   @Default(true)
@@ -355,6 +362,7 @@ export class UserModel extends Model<UserModel> {
       email: this.email,
       emailVerified: this.emailVerified,
       nsfwPolicy: this.nsfwPolicy,
+      webTorrentPolicy: this.webTorrentPolicy,
       autoPlayVideo: this.autoPlayVideo,
       role: this.role,
       roleLabel: USER_ROLE_LABELS[ this.role ],

--- a/server/models/account/user.ts
+++ b/server/models/account/user.ts
@@ -32,7 +32,7 @@ import {
   isUserUsernameValid,
   isUserVideoQuotaDailyValid,
   isUserVideoQuotaValid,
-  isUserWebTorrentPolicyValid
+  isUserWebTorrentEnabledValid
 } from '../../helpers/custom-validators/users'
 import { comparePassword, cryptPassword } from '../../helpers/peertube-crypto'
 import { OAuthTokenModel } from '../oauth/oauth-token'
@@ -40,9 +40,8 @@ import { getSort, throwIfNotValid } from '../utils'
 import { VideoChannelModel } from '../video/video-channel'
 import { AccountModel } from './account'
 import { NSFWPolicyType } from '../../../shared/models/videos/nsfw-policy.type'
-import { WebTorrentPolicyType } from '../../../shared/models/users/user-webtorrent-policy.type'
 import { values } from 'lodash'
-import { NSFW_POLICY_TYPES, WEBTORRENT_POLICY_TYPES } from '../../initializers'
+import { NSFW_POLICY_TYPES } from '../../initializers'
 import { clearCacheByUserId } from '../../lib/oauth-model'
 
 enum ScopeNames {
@@ -110,9 +109,9 @@ export class UserModel extends Model<UserModel> {
   nsfwPolicy: NSFWPolicyType
 
   @AllowNull(false)
-  @Is('UserWebTorrentPolicy', value => throwIfNotValid(value, isUserWebTorrentPolicyValid, 'WebTorrent policy'))
-  @Column(DataType.ENUM(values(WEBTORRENT_POLICY_TYPES)))
-  webTorrentPolicy: WebTorrentPolicyType
+  @Is('UserWebTorrentEnabled', value => throwIfNotValid(value, isUserWebTorrentEnabledValid, 'WebTorrent enabled'))
+  @Column
+  webTorrentEnabled: boolean
 
   @AllowNull(false)
   @Default(true)
@@ -362,7 +361,7 @@ export class UserModel extends Model<UserModel> {
       email: this.email,
       emailVerified: this.emailVerified,
       nsfwPolicy: this.nsfwPolicy,
-      webTorrentPolicy: this.webTorrentPolicy,
+      webTorrentEnabled: this.webTorrentEnabled,
       autoPlayVideo: this.autoPlayVideo,
       role: this.role,
       roleLabel: USER_ROLE_LABELS[ this.role ],

--- a/shared/models/users/user-update-me.model.ts
+++ b/shared/models/users/user-update-me.model.ts
@@ -1,9 +1,11 @@
 import { NSFWPolicyType } from '../videos/nsfw-policy.type'
+import { WebTorrentPolicyType } from './user-webtorrent-policy.type'
 
 export interface UserUpdateMe {
   displayName?: string
   description?: string
-  nsfwPolicy?: NSFWPolicyType
+  nsfwPolicy?: NSFWPolicyType,
+  webTorrentPolicy?: WebTorrentPolicyType,
   autoPlayVideo?: boolean
   email?: string
   currentPassword?: string

--- a/shared/models/users/user-update-me.model.ts
+++ b/shared/models/users/user-update-me.model.ts
@@ -1,11 +1,10 @@
 import { NSFWPolicyType } from '../videos/nsfw-policy.type'
-import { WebTorrentPolicyType } from './user-webtorrent-policy.type'
 
 export interface UserUpdateMe {
   displayName?: string
   description?: string
   nsfwPolicy?: NSFWPolicyType,
-  webTorrentPolicy?: WebTorrentPolicyType,
+  webTorrentEnabled?: boolean,
   autoPlayVideo?: boolean
   email?: string
   currentPassword?: string

--- a/shared/models/users/user-webtorrent-policy.type.ts
+++ b/shared/models/users/user-webtorrent-policy.type.ts
@@ -1,1 +1,0 @@
-export type WebTorrentPolicyType = 'enable' | 'disable' | 'disable_on_mobile'

--- a/shared/models/users/user-webtorrent-policy.type.ts
+++ b/shared/models/users/user-webtorrent-policy.type.ts
@@ -1,0 +1,1 @@
+export type WebTorrentPolicyType = 'enable' | 'disable' | 'disable_on_mobile'


### PR DESCRIPTION
- add a key in localstorage to remember the opt-out
- add a user setting

Visitors don't have an interface to modify the setting (yet) but that requires more work (modifying buttons in videojs is no small feat) and will be the subject of another PR. Better do things incrementally.

related to #685 