### PR TITLE
Scale bitrate linearly with FPS

### DIFF
--- a/shared/models/videos/video-resolution.enum.ts
+++ b/shared/models/videos/video-resolution.enum.ts
@@ -43,14 +43,20 @@ export function getBaseBitrate (resolution: VideoResolution) {
 
 /**
  * Calculate the target bitrate based on video resolution and FPS.
+ *
+ * The calculation is based on two values:
+ * Bitrate at VideoTranscodingFPS.AVERAGE is always the same as
+ * getBaseBitrate(). Bitrate at VideoTranscodingFPS.MAX is always
+ * getBaseBitrate() * 1.4. All other values are calculated linearly
+ * between these two points.
  */
 export function getTargetBitrate (resolution: VideoResolution, fps: number,
     fpsTranscodingConstants: VideoTranscodingFPS) {
   const baseBitrate = getBaseBitrate(resolution)
   // The maximum bitrate, used when fps === VideoTranscodingFPS.MAX
   // Based on numbers from Youtube, 60 fps bitrate divided by 30 fps bitrate:
-  //  720p: 2600 / 1750 = 1.48571428571
-  // 1080p: 4400 / 3300 = 1.33333333333
+  //  720p: 2600 / 1750 = 1.49
+  // 1080p: 4400 / 3300 = 1.33
   const maxBitrate = baseBitrate * 1.4
   const maxBitrateDifference = maxBitrate - baseBitrate
   const maxFpsDifference = fpsTranscodingConstants.MAX - fpsTranscodingConstants.AVERAGE
@@ -58,7 +64,7 @@ export function getTargetBitrate (resolution: VideoResolution, fps: number,
   // 3300 + (x - 30) * (1320/30)
   // Example outputs:
   // 1080p10: 2420 kbps, 1080p30: 3300 kbps, 1080p60: 4620 kbps
-  //  720p10: 1283 kbps,  720p30: 1750 kbps,  720p60: 2450
+  //  720p10: 1283 kbps,  720p30: 1750 kbps,  720p60: 2450 kbps
   return baseBitrate + (fps - fpsTranscodingConstants.AVERAGE) * (maxBitrateDifference / maxFpsDifference)
 }
 

--- a/shared/models/videos/video-resolution.enum.ts
+++ b/shared/models/videos/video-resolution.enum.ts
@@ -49,14 +49,16 @@ export function getTargetBitrate (resolution: VideoResolution, fps: number,
   const baseBitrate = getBaseBitrate(resolution)
   // The maximum bitrate, used when fps === VideoTranscodingFPS.MAX
   // Based on numbers from Youtube, 60 fps bitrate divided by 30 fps bitrate:
-  // 2600 / 1750 = 1.48571428571
-  // 4400 / 3300 = 1.33333333333
+  //  720p: 2600 / 1750 = 1.48571428571
+  // 1080p: 4400 / 3300 = 1.33333333333
   const maxBitrate = baseBitrate * 1.4
   const maxBitrateDifference = maxBitrate - baseBitrate
   const maxFpsDifference = fpsTranscodingConstants.MAX - fpsTranscodingConstants.AVERAGE
   // For 1080p video with default settings, this results in the following formula:
   // 3300 + (x - 30) * (1320/30)
-  // Example outputs: 1080p30: 3300 kbps, 1080p60: 4620 kbps, 720p30: 1750, 720p60: 2450
+  // Example outputs:
+  // 1080p10: 2420 kbps, 1080p30: 3300 kbps, 1080p60: 4620 kbps
+  //  720p10: 1283 kbps,  720p30: 1750 kbps,  720p60: 2450
   return baseBitrate + (fps - fpsTranscodingConstants.AVERAGE) * (maxBitrateDifference / maxFpsDifference)
 }
 

--- a/shared/models/videos/video-resolution.enum.ts
+++ b/shared/models/videos/video-resolution.enum.ts
@@ -9,13 +9,13 @@ export enum VideoResolution {
 }
 
 /**
- * Bitrate targets for different resolutions and frame rates, in bytes per second.
+ * Bitrate targets for different resolutions, at VideoTranscodingFPS.AVERAGE.
+ *
  * Sources for individual quality levels:
  * Google Live Encoder: https://support.google.com/youtube/answer/2853702?hl=en
  * YouTube Video Info (tested with random music video): https://www.h3xed.com/blogmedia/youtube-info.php
  */
-export function getTargetBitrate (resolution: VideoResolution, fps: number,
-    fpsTranscodingConstants: VideoTranscodingFPS) {
+export function getBaseBitrate (resolution: VideoResolution) {
   switch (resolution) {
   case VideoResolution.H_240P:
     // quality according to Google Live Encoder: 300 - 700 Kbps
@@ -30,27 +30,34 @@ export function getTargetBitrate (resolution: VideoResolution, fps: number,
     // Quality according to YouTube Video Info: 879 Kbps
     return 900 * 1000
   case VideoResolution.H_720P:
-    if (fps === fpsTranscodingConstants.MAX) {
-      // quality according to Google Live Encoder: 2,250 - 6,000 Kbps
-      // Quality according to YouTube Video Info: 2634 Kbps
-      return 2600 * 1000
-    }
-
     // quality according to Google Live Encoder: 1,500 - 4,000 Kbps
     // Quality according to YouTube Video Info: 1752 Kbps
     return 1750 * 1000
   case VideoResolution.H_1080P: // fallthrough
   default:
-    if (fps === fpsTranscodingConstants.MAX) {
-      // quality according to Google Live Encoder: 3000 - 6000 Kbps
-      // Quality according to YouTube Video Info: 4387 Kbps
-      return 4400 * 1000
-    }
-
     // quality according to Google Live Encoder: 3000 - 6000 Kbps
     // Quality according to YouTube Video Info: 3277 Kbps
     return 3300 * 1000
   }
+}
+
+/**
+ * Calculate the target bitrate based on video resolution and FPS.
+ */
+export function getTargetBitrate (resolution: VideoResolution, fps: number,
+    fpsTranscodingConstants: VideoTranscodingFPS) {
+  const baseBitrate = getBaseBitrate(resolution)
+  // The maximum bitrate, used when fps === VideoTranscodingFPS.MAX
+  // Based on numbers from Youtube, 60 fps bitrate divided by 30 fps bitrate:
+  // 2600 / 1750 = 1.48571428571
+  // 4400 / 3300 = 1.33333333333
+  const maxBitrate = baseBitrate * 1.4
+  const maxBitrateDifference = maxBitrate - baseBitrate
+  const maxFpsDifference = fpsTranscodingConstants.MAX - fpsTranscodingConstants.AVERAGE
+  // For 1080p video with default settings, this results in the following formula:
+  // 3300 + (x - 30) * (1320/30)
+  // Example outputs: 1080p30: 3300 kbps, 1080p60: 4620 kbps, 720p30: 1750, 720p60: 2450
+  return baseBitrate + (fps - fpsTranscodingConstants.AVERAGE) * (maxBitrateDifference / maxFpsDifference)
 }
 
 /**

--- a/shared/models/videos/video-resolution.enum.ts
+++ b/shared/models/videos/video-resolution.enum.ts
@@ -15,7 +15,7 @@ export enum VideoResolution {
  * Google Live Encoder: https://support.google.com/youtube/answer/2853702?hl=en
  * YouTube Video Info (tested with random music video): https://www.h3xed.com/blogmedia/youtube-info.php
  */
-export function getBaseBitrate (resolution: VideoResolution) {
+function getBaseBitrate (resolution: VideoResolution) {
   switch (resolution) {
   case VideoResolution.H_240P:
     // quality according to Google Live Encoder: 300 - 700 Kbps


### PR DESCRIPTION
The current implementation after #1135 uses the same bitrate for any fps number, except for exactly 60 fps, where it uses a higher bitrate. As an extreme case, a video with 10 fps and a video with 59 fps will have the same bitrate (at the same resolution).

This is a suggestion to scale the bitrate linearly. Example bitrates (also as comment in the source code):
```
1080p10: 2420 kbps, 1080p30: 3300 kbps, 1080p60: 4620 kbps
 720p10: 1283 kbps,  720p30: 1750 kbps,  720p60: 2450 kbps
```
This approach will also work correctly with e.g. 480p60 video (if enabled). It should also work correctly with different `VIDEO_TRANSCODING_FPS.AVERAGE`, `VIDEO_TRANSCODING_FPS.MAX` etc values (untested).

You can visualize the formula here: https://www.wolframalpha.com/input/?i=3300+%2B+(x+-+30)+*+(1320%2F30);+0%3C%3Dx%3C%3D60&assumption=%7B%22C%22,+%220%22%7D+-%3E+%7B%22NumberMath%22%7D

If you agree with the idea, I will add some tests for `getTargetBitrate()`. Also feel free to suggest improvements to the documentation, as this is pretty complicated to explain.

Edit: Of course, the bitrate could also be scaled differently, e.g. quadratic scaling, linear scaling only below `VIDEO_TRANSCODING_FPS.AVERAGE`, etc.