### PR TITLE
add server/tools/repl.ts

### DIFF
--- a/server/tools/repl.ts
+++ b/server/tools/repl.ts
@@ -1,0 +1,52 @@
+import * as repl from 'repl'
+import * as path from 'path'
+import * as _ from 'lodash'
+import * as moment from 'moment'
+import * as YoutubeDL from 'youtube-dl'
+import * as uuidv1 from 'uuid/v1'
+import * as uuidv3 from 'uuid/v3'
+import * as uuidv4 from 'uuid/v4'
+import * as uuidv5 from 'uuid/v5'
+
+import { initDatabaseModels, sequelizeTypescript } from '../initializers'
+const version = require('../../../package.json').version
+
+const start = async () => {
+  await initDatabaseModels(true)
+
+  const initContext = (replServer) => {
+    return (context) => {
+      context.lodash = _;
+      context.path = path;
+      context.repl = replServer;
+      context.moment = moment;
+      context.env = process.env;
+      context.models = sequelizeTypescript.models;
+      context.YoutubeDL = YoutubeDL
+      context.uuidv1 = uuidv1
+      context.uuidv3 = uuidv3
+      context.uuidv4 = uuidv4
+      context.uuidv5 = uuidv5
+    }
+  }
+
+  const replServer = repl.start({
+    prompt: `PeerTube [${version}] >`,
+  });
+
+  initContext(replServer)(replServer.context);
+  replServer.on('reset', initContext(replServer));
+
+  const resetCommand = {
+    help: 'Reset REPL',
+    action() {
+      this.write('.clear\n');  
+      this.displayPrompt();
+    }
+  };
+  replServer.defineCommand('reset', resetCommand);
+  replServer.defineCommand('r', resetCommand);
+
+}
+
+start().then(()=>{}).catch(()=>{})

--- a/support/doc/tools.md
+++ b/support/doc/tools.md
@@ -206,3 +206,134 @@ To fix this, you have to run:
 ```
 $ sudo -u peertube NODE_CONFIG_DIR=/var/www/peertube/config NODE_ENV=production npm run update-host
 ```
+
+### REPL ([Read Eval Print Loop](https://nodejs.org/docs/latest-v8.x/api/repl.html))
+
+If you want to interact with the application libraries and objects, there is a REPL for that.
+
+usage: `node ./dist/server/tools/repl.js`
+
+"The default evaluator will, by default, assign the result of the most recently evaluated expression to the special variable `_` (underscore). Explicitly setting `_` to a value will disable this behavior."
+
+- type `.help` to list commands available in the repl, notice it starts with a dot
+- type `.exit` to exit, note that you still have to press CTRL-C to actually exit, or press CTRL-C (3 times) without typing `.exit` to exit
+- type `context` to list all available objects and libraries in the context, note: `Promise` is also available but it's not listed in the context, in case you need promises for something
+- type `env` to see the loaded environment variables
+- type `path` to access path library
+- type `lodash` to access lodash library
+- type `uuidv1` to access uuid/v1 library
+- type `uuidv3` to access uuid/v3 library
+- type `uuidv4` to access uuid/v4 library
+- type `uuidv5` to access uuid/v5 library
+- type `YoutubeDL` to access youtube-dl library
+- type `cli` to access the cli helpers object
+- type `logger` to access the logger; if you log to it, it will write to stdout and to the peertube.log file
+- type `constants` to access the constants loaded by the server
+- type `coreUtils` to access the core-utils helpers object
+- type `ffmpegUtils` to access the ffmpeg-utils helpers object
+- type `peertubeCryptoUtils` to access the peertube-crypto helpers object
+- type `signupUtils` to access the signup helpers object
+- type `utils` to access the utils helpers object
+- type `YoutubeDLUtils` to access the youtube-dl helpers object
+- type `sequelizeTypescript` to access sequelizeTypescript
+- type `modelsUtils` to access the models/utils
+- type `models` to access the shortcut to sequelizeTypescript.models
+- type `transaction` to access the shortcut to sequelizeTypescript.transaction
+- type `query` to access the shortcut to sequelizeTypescript.query
+- type `queryInterface` to access the shortcut to sequelizeTypescript.queryInterface
+
+#### .help
+
+```
+PeerTube [1.0.0] (b10eb595)> .help
+.break    Sometimes you get stuck, this gets you out
+.clear    Break, and also clear the local context
+.editor   Enter editor mode
+.exit     Exit the repl
+.help     Print this help message
+.load     Load JS from a file into the REPL session
+.r        Reset REPL
+.reset    Reset REPL
+.save     Save all evaluated commands in this REPL session to a file
+PeerTube [1.0.0] (b10eb595)>
+```
+
+#### Lodash example
+
+```
+PeerTube [1.0.0] (b10eb595)> lodash.keys(context)
+[ 'global',
+  'console',
+  'DTRACE_NET_SERVER_CONNECTION',
+  'DTRACE_NET_STREAM_END',
+  'DTRACE_HTTP_SERVER_REQUEST',
+  'DTRACE_HTTP_SERVER_RESPONSE',
+  'DTRACE_HTTP_CLIENT_REQUEST',
+  'DTRACE_HTTP_CLIENT_RESPONSE',
+  'process',
+  'Buffer',
+  'clearImmediate',
+  'clearInterval',
+  'clearTimeout',
+  'setImmediate',
+  'setInterval',
+  'setTimeout',
+  'XMLHttpRequest',
+  'compact2string',
+  'module',
+  'require',
+  'path',
+  'repl',
+  'context',
+  'env',
+  'lodash',
+  'uuidv1',
+  'uuidv3',
+  'uuidv4',
+  'uuidv5',
+  'cli',
+  'logger',
+  'constants',
+  'Sequelize',
+  'sequelizeTypescript',
+  'modelsUtils',
+  'models',
+  'transaction',
+  'query',
+  'queryInterface',
+  'YoutubeDL',
+  'coreUtils',
+  'ffmpegUtils',
+  'peertubeCryptoUtils',
+  'signupUtils',
+  'utils',
+  'YoutubeDLUtils' ]
+PeerTube [1.0.0] (b10eb595)>
+```
+
+#### YoutubeDL example
+```
+YoutubeDL.getInfo('https://www.youtube.com/watch?v=I5ZN289jjDo', function(err, data) {console.log(err, data)})
+```
+
+#### Models examples
+```
+PeerTube [1.0.0] (b10eb595)> new models.ActorModel({id: 3}).getVideoChannel().then(function(data){console.log(data.dataValues.name)})
+Promise {
+  _bitField: 0,
+  _fulfillmentHandler0: undefined,
+  _rejectionHandler0: undefined,
+  _promise0: undefined,
+  _receiver0: undefined }
+PeerTube [1.0.0] (b10eb595)> Main root channel
+PeerTube [1.0.0] (b10eb595)> let out; new models.UserModel({id: 1}).getAccount().then(function (data) {out = data.dataValues.id})
+Promise {
+  _bitField: 0,
+  _fulfillmentHandler0: undefined,
+  _rejectionHandler0: undefined,
+  _promise0: undefined,
+  _receiver0: undefined }
+PeerTube [1.0.0] (b10eb595)> out
+2
+PeerTube [1.0.0] (b10eb595)>
+```


### PR DESCRIPTION
### REPL ([Read Eval Print Loop](https://nodejs.org/docs/latest-v8.x/api/repl.html))

If you want to interact with the application libraries and objects, there is a REPL for that.

usage: `node ./dist/server/tools/repl.js`

"The default evaluator will, by default, assign the result of the most recently evaluated expression to the special variable `_` (underscore). Explicitly setting `_` to a value will disable this behavior."

- type `.help` to list commands available in the repl, notice it starts with a dot
- type `.exit` to exit, note that you still have to press CTRL-C to actually exit, or press CTRL-C (3 times) without typing `.exit` to exit
- type `context` to list all available objects and libraries in the context, note: `Promise` is also available but it's not listed in the context, in case you need promises for something
- type `env` to see the loaded environment variables
- type `path` to access path library
- type `lodash` to access lodash library
- type `uuidv1` to access uuid/v1 library
- type `uuidv3` to access uuid/v3 library
- type `uuidv4` to access uuid/v4 library
- type `uuidv5` to access uuid/v5 library
- type `YoutubeDL` to access youtube-dl library
- type `cli` to access the cli helpers object
- type `logger` to access the logger; if you log to it, it will write to stdout and to the peertube.log file
- type `constants` to access the constants loaded by the server
- type `coreUtils` to access the core-utils helpers object
- type `ffmpegUtils` to access the ffmpeg-utils helpers object
- type `peertubeCryptoUtils` to access the peertube-crypto helpers object
- type `signupUtils` to access the signup helpers object
- type `utils` to access the utils helpers object
- type `YoutubeDLUtils` to access the youtube-dl helpers object
- type `sequelizeTypescript` to access sequelizeTypescript
- type `modelsUtils` to access the models/utils
- type `models` to access the shortcut to sequelizeTypescript.models
- type `transaction` to access the shortcut to sequelizeTypescript.transaction
- type `query` to access the shortcut to sequelizeTypescript.query
- type `queryInterface` to access the shortcut to sequelizeTypescript.queryInterface

#### .help

```
PeerTube [1.0.0] (b10eb595)> .help
.break    Sometimes you get stuck, this gets you out
.clear    Break, and also clear the local context
.editor   Enter editor mode
.exit     Exit the repl
.help     Print this help message
.load     Load JS from a file into the REPL session
.r        Reset REPL
.reset    Reset REPL
.save     Save all evaluated commands in this REPL session to a file
PeerTube [1.0.0] (b10eb595)>
```

#### Lodash example

```
PeerTube [1.0.0] (b10eb595)> lodash.keys(context)
[ 'global',
  'console',
  'DTRACE_NET_SERVER_CONNECTION',
  'DTRACE_NET_STREAM_END',
  'DTRACE_HTTP_SERVER_REQUEST',
  'DTRACE_HTTP_SERVER_RESPONSE',
  'DTRACE_HTTP_CLIENT_REQUEST',
  'DTRACE_HTTP_CLIENT_RESPONSE',
  'process',
  'Buffer',
  'clearImmediate',
  'clearInterval',
  'clearTimeout',
  'setImmediate',
  'setInterval',
  'setTimeout',
  'XMLHttpRequest',
  'compact2string',
  'module',
  'require',
  'path',
  'repl',
  'context',
  'env',
  'lodash',
  'uuidv1',
  'uuidv3',
  'uuidv4',
  'uuidv5',
  'cli',
  'logger',
  'constants',
  'Sequelize',
  'sequelizeTypescript',
  'modelsUtils',
  'models',
  'transaction',
  'query',
  'queryInterface',
  'YoutubeDL',
  'coreUtils',
  'ffmpegUtils',
  'peertubeCryptoUtils',
  'signupUtils',
  'utils',
  'YoutubeDLUtils' ]
PeerTube [1.0.0] (b10eb595)>
```

#### YoutubeDL example
```
YoutubeDL.getInfo('https://www.youtube.com/watch?v=I5ZN289jjDo', function(err, data) {console.log(err, data)})
```

#### Models examples
```
PeerTube [1.0.0] (b10eb595)> new models.ActorModel({id: 3}).getVideoChannel().then(function(data){console.log(data.dataValues.name)})
Promise {
  _bitField: 0,
  _fulfillmentHandler0: undefined,
  _rejectionHandler0: undefined,
  _promise0: undefined,
  _receiver0: undefined }
PeerTube [1.0.0] (b10eb595)> Main root channel
PeerTube [1.0.0] (b10eb595)> let out; new models.UserModel({id: 1}).getAccount().then(function (data) {out = data.dataValues.id})
Promise {
  _bitField: 0,
  _fulfillmentHandler0: undefined,
  _rejectionHandler0: undefined,
  _promise0: undefined,
  _receiver0: undefined }
PeerTube [1.0.0] (b10eb595)> out
2
PeerTube [1.0.0] (b10eb595)>
```

Here is the issue I created before making this pull request: https://github.com/Chocobozzz/PeerTube/issues/1247