### PR TITLE
increase timeout in redundancy tests

### DIFF
--- a/server/tests/api/server/redundancy.ts
+++ b/server/tests/api/server/redundancy.ts
@@ -456,19 +456,19 @@ describe('Test videos redundancy', function () {
 
       await waitJobs(servers)
 
-      await wait(7000)
+      await wait(10000)
 
       try {
         await check1WebSeed(strategy, video1Server2UUID)
         await check2Webseeds(strategy, video2Server2UUID)
       } catch {
-        await wait(3000)
+        await wait(10000)
 
         try {
           await check1WebSeed(strategy, video1Server2UUID)
           await check2Webseeds(strategy, video2Server2UUID)
         } catch {
-          await wait(5000)
+          await wait(10000)
 
           await check1WebSeed(strategy, video1Server2UUID)
           await check2Webseeds(strategy, video2Server2UUID)


### PR DESCRIPTION
Increase timeout so to avoid the test failing because `expect undefined not to be undefined`

```
Should cache video 2 webseed on the first video
```

Been having to push the code over and over again because this test would fail https://github.com/Chocobozzz/PeerTube/blob/develop/server/tests/api/server/redundancy.ts#L454