### PR TITLE
Remove hard-coded 8GB upload limit in client

### DIFF
--- a/client/src/app/videos/+video-edit/video-add-components/video-upload.component.ts
+++ b/client/src/app/videos/+video-edit/video-add-components/video-upload.component.ts
@@ -113,12 +113,6 @@ export class VideoUploadComponent extends VideoSend implements OnInit, OnDestroy
     const videofile = this.videofileInput.nativeElement.files[0] as File
     if (!videofile) return
 
-    // Cannot upload videos > 8GB for now
-    if (videofile.size > 8 * 1024 * 1024 * 1024) {
-      this.notificationsService.error(this.i18n('Error'), this.i18n('We are sorry but PeerTube cannot handle videos > 8GB'))
-      return
-    }
-
     const bytePipes = new BytesPipe()
     const videoQuota = this.authService.getUser().videoQuota
     if (videoQuota !== -1 && (this.userVideoQuotaUsed + videofile.size) > videoQuota) {

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -96,8 +96,18 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-    # Hard limit, PeerTube does not support videos > 8GB
+    # This is the maximum upload size, which roughly matches the maximum size of a video file
+    # you can send via the API or the web interface. By default this is 8GB, but administrators
+    # can increase or decrease the limit. Currently there's no way to communicate this limit
+    # to users automatically, so you may want to leave a note in your instance 'about' page if
+    # you change this.
+    #
+    # Note that temporary space is needed equal to the total size of all concurrent uploads.
+    # This data gets stored in /var/lib/nginx by default, so you may want to put this directory
+    # on a dedicated filesystem.
+    #
     client_max_body_size 8G;
+
     proxy_connect_timeout       600;
     proxy_send_timeout          600;
     proxy_read_timeout          600;


### PR DESCRIPTION
Ideally we'd know what the specific server's configured upload limit
is before starting, but this 8GB limit is not useful if an administrator
has changed the nginx post limit on the server.