### PR TITLE
Improve some of the wording around abuse reports UI

### DIFF
--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
@@ -85,7 +85,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit {
   }
 
   async removeVideoAbuse (videoAbuse: VideoAbuse) {
-    const res = await this.confirmService.confirm(this.i18n('Do you really want to delete this abuse?'), this.i18n('Delete'))
+    const res = await this.confirmService.confirm(this.i18n('Do you really want to delete this abuse report?'), this.i18n('Delete'))
     if (res === false) return
 
     this.videoAbuseService.removeVideoAbuse(videoAbuse).subscribe(

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
@@ -36,7 +36,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit {
 
     this.videoAbuseActions = [
       {
-        label: this.i18n('Delete'),
+        label: this.i18n('Delete this report'),
         handler: videoAbuse => this.removeVideoAbuse(videoAbuse)
       },
       {

--- a/client/src/locale/source/angular_en_US.xml
+++ b/client/src/locale/source/angular_en_US.xml
@@ -4351,6 +4351,13 @@ When you will upload a video in this channel, the video support field will be au
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="586bee8c27a761611eb05661524cc7ca944b5978" datatype="html">
+        <source>Delete this report</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cf3b28ba29a907b334ab0e6dccd080a60ba23321" datatype="html">
         <source>Update moderation comment</source>
         <context-group purpose="location">
@@ -4372,8 +4379,8 @@ When you will upload a video in this channel, the video support field will be au
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="01a909e58239b5dde966ef97a79c656d2c452e03" datatype="html">
-        <source>Do you really want to delete this abuse?</source>
+      <trans-unit id="73b70e37cddaa6494d8a666b6cba90dc80595599" datatype="html">
+        <source>Do you really want to delete this abuse report?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts</context>
           <context context-type="linenumber">1</context>


### PR DESCRIPTION
To resolve #1295, I fixed these two strings to make it more obvious that it is referring to the _report_, and not the _content_, that is going to be deleted.

In order to update the i18n files, I ran `npm run build`, which gave me a lot of internationalization warnings for missing translations but only seemed to touch the `en-US` file. I hope this is OK for now, and that the translators to other languages are still able to translate these new strings without much difficulty.

PeerTube is a great project!