### PR TITLE
Make backups of files in optimize-old-videos.ts

### DIFF
--- a/scripts/optimize-old-videos.ts
+++ b/scripts/optimize-old-videos.ts
@@ -1,10 +1,11 @@
 import { CONFIG, VIDEO_TRANSCODING_FPS } from '../server/initializers/constants'
-import { getVideoFileBitrate, getVideoFileFPS, getVideoFileResolution } from '../server/helpers/ffmpeg-utils'
+import { getVideoFileBitrate, getVideoFileFPS, getVideoFileResolution, getDurationFromVideoFile } from '../server/helpers/ffmpeg-utils'
 import { getMaxBitrate } from '../shared/models/videos'
 import { VideoModel } from '../server/models/video/video'
 import { optimizeVideofile } from '../server/lib/video-transcoding'
 import { initDatabaseModels } from '../server/initializers'
-import { join } from 'path'
+import { join, basename } from 'path'
+import { copy, remove, move } from 'fs-extra'
 
 run()
   .then(() => process.exit(0))
@@ -28,9 +29,23 @@ async function run () {
         getVideoFileResolution(inputPath)
       ])
 
-      const isMaxBitrateExceeded = videoBitrate > getMaxBitrate(resolution.videoFileResolution, fps, VIDEO_TRANSCODING_FPS)
+      const maxBitrate = getMaxBitrate(resolution.videoFileResolution, fps, VIDEO_TRANSCODING_FPS)
+      const isMaxBitrateExceeded = videoBitrate > maxBitrate
       if (isMaxBitrateExceeded) {
+        console.log('Optimizing video file %s with bitrate %s kbps (max: %s kbps)',
+          basename(inputPath), videoBitrate / 1000, maxBitrate / 1000)
+        const backupFile = inputPath + '_backup'
+        await copy(inputPath, backupFile)
         await optimizeVideofile(video, file)
+        const originalDuration = await getDurationFromVideoFile(backupFile)
+        const newDuration = await getDurationFromVideoFile(inputPath)
+        if (originalDuration === newDuration) {
+          console.log('Finished optimizing %s', basename(inputPath))
+          remove(backupFile)
+        } else {
+          console.log('Failed to optimize %s, restoring original', inputPath)
+          move(backupFile, inputPath, { overwrite: true })
+        }
       }
     }
   }


### PR DESCRIPTION
As mentioned by @Chocobozzz (https://github.com/Chocobozzz/PeerTube/issues/1298#issuecomment-431040970), it makes sense to make backups of the video files before optimizing them. And it would be even better if that would be handled automatically by the script, so this is what I implemented. I also added some output to tell what the script is doing currently.

It currently compares the duration as a check, not sure if that's the best option.