### PR TITLE
add noImplicitThis flag

### DIFF
--- a/client/src/app/videos/+video-watch/comment/linkifier.service.ts
+++ b/client/src/app/videos/+video-watch/comment/linkifier.service.ts
@@ -41,7 +41,7 @@ export class LinkifierService {
     const TT_UNDERSCORE = TT.UNDERSCORE
     const TT_DOT = TT.DOT
 
-    function MENTION (value: any) {
+    function MENTION (this: any, value: any) {
       this.v = value
     }
 

--- a/client/src/app/videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/videos/+video-watch/video-watch.component.ts
@@ -435,7 +435,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
     const self = this
     this.zone.runOutsideAngular(async () => {
-      videojs(this.playerElement, videojsOptions, function (this: any) {
+      videojs(this.playerElement, videojsOptions, function (this: videojs.Player) {
         self.player = this
         this.on('customError', ({ err }: { err: any }) => self.handleError(err))
 

--- a/client/src/app/videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/videos/+video-watch/video-watch.component.ts
@@ -435,7 +435,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
     const self = this
     this.zone.runOutsideAngular(async () => {
-      videojs(this.playerElement, videojsOptions, function () {
+      videojs(this.playerElement, videojsOptions, function (this: any) {
         self.player = this
         this.on('customError', ({ err }: { err: any }) => self.handleError(err))
 

--- a/client/src/assets/player/peertube-player.ts
+++ b/client/src/assets/player/peertube-player.ts
@@ -213,7 +213,7 @@ function addContextMenu (player: any, videoEmbedUrl: string) {
       {
         label: player.localize('Copy the video URL at the current time'),
         listener: function () {
-          const player = this
+          const player = this as Player
           copyToClipboard(buildVideoLink(player.currentTime()))
         }
       },
@@ -226,7 +226,7 @@ function addContextMenu (player: any, videoEmbedUrl: string) {
       {
         label: player.localize('Copy magnet URI'),
         listener: function () {
-          const player = this
+          const player = this as Player
           copyToClipboard(player.peertube().getCurrentVideoFile().magnetUri)
         }
       }

--- a/client/src/assets/player/settings-menu-button.ts
+++ b/client/src/assets/player/settings-menu-button.ts
@@ -182,7 +182,7 @@ class SettingsButton extends Button {
   }
 
   addMenuItem (entry: any, options: any) {
-    const openSubMenu = function () {
+    const openSubMenu = function (this: any) {
       if (videojsUntyped.dom.hasClass(this.el_, 'open')) {
         videojsUntyped.dom.removeClass(this.el_, 'open')
       } else {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,6 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
+    "noImplicitThis": true,
     "suppressImplicitAnyIndexErrors":true,
     "alwaysStrict": true,
     "target": "es5",


### PR DESCRIPTION
this adds the `noImplicitThis` compiler option to make the code even more type secure.

>Raise error on `this` expressions with an implied `any` type.

please review, as I am not sure if this is the best way to fix the errors