### PR TITLE
Fix #1328 - application-config.read() returns an empty object, test for it

### DIFF
--- a/server/tools/cli.ts
+++ b/server/tools/cli.ts
@@ -23,7 +23,7 @@ async function getSettings () {
       if (err) {
         return rej(err)
       }
-      return res(data || settings)
+      return res(Object.keys(data).length === 0 ? settings : data)
     })
   })
 }


### PR DESCRIPTION
application-config.read() returns an empty object when no config data is present (i.e. when run on a new install) so test for an empty object in cli.ts instead of testing for 'null' (which fails on empty objects)