### PR TITLE
Rename context stats to state

### DIFF
--- a/server/helpers/activitypub.ts
+++ b/server/helpers/activitypub.ts
@@ -24,7 +24,7 @@ function activityPubContextify <T> (data: T) {
         sensitive: 'as:sensitive',
         language: 'sc:inLanguage',
         views: 'sc:Number',
-        stats: 'sc:Number',
+        state: 'sc:Number',
         size: 'sc:Number',
         fps: 'sc:Number',
         commentsEnabled: 'sc:Boolean',


### PR DESCRIPTION
I guess it refers to the VideoState enum used here as `state` instead.