### PR TITLE
change og video type

### DIFF
--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -116,7 +116,7 @@ export class ClientHtml {
 
       'og:video:url': embedUrl,
       'og:video:secure_url': embedUrl,
-      'og:video:type': 'text/html',
+      'og:video:type': 'video/mp4',
       'og:video:width': EMBED_SIZE.width,
       'og:video:height': EMBED_SIZE.height,
 


### PR DESCRIPTION
`og:video:type` should be ["MIME type of the video. Either `application/x-shockwave-flash` or `video/mp4`."](https://developers.facebook.com/docs/sharing/webmasters#markup)

But it is
```html
<meta property="og:video:type" content="text/html" />
```

this may help #1080 