### PR TITLE
Improve FreeBSD setup instructions

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -185,9 +185,8 @@ $ sudo journalctl -feu peertube
 On FreeBSD, copy the startup script and update rc.conf:
 
 ```
-$ sudo cp /var/www/peertube/peertube-latest/support/freebsd/peertube /usr/local/etc/rc.d/
-$ sudo chmod +x /usr/local/etc/rc.d/peertube
-$ sudo echo peertube_enable="YES" >> /etc/rc.conf
+$ sudo install -m 0555 /var/www/peertube/peertube-latest/support/freebsd/peertube /usr/local/etc/rc.d/
+$ sudo sysrc peertube_enable="YES"
 ```
 
 Run:


### PR DESCRIPTION
Use install(1) instead of cp(1) and chmod(1) to install
the service file. Also, use sysrc(8) to enable the PeerTube
service in rc.conf(5).