### PR TITLE
Check free storage before upgrading

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -20,6 +20,14 @@ if [ ! -e "$PEERTUBE_PATH/versions" -o ! -e "$PEERTUBE_PATH/config/production.ya
   exit 1
 fi
 
+REMAINING=$(df -k $PEERTUBE_PATH | awk '{ print $4}' | sed -n 2p)
+ONE_GB=$((1024 * 1024))
+if [ "$REMAINING" -lt "$ONE_GB" ]; then
+  echo "Error - not enough free space for upgrading"
+  echo ""
+  echo "Make sure you have at least 1 GB of free space in $PEERTUBE_PATH"
+  exit 1
+fi
 
 # Backup database
 SQL_BACKUP_PATH="$PEERTUBE_PATH/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").bak" 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -20,13 +20,15 @@ if [ ! -e "$PEERTUBE_PATH/versions" -o ! -e "$PEERTUBE_PATH/config/production.ya
   exit 1
 fi
 
-REMAINING=$(df -k $PEERTUBE_PATH | awk '{ print $4}' | sed -n 2p)
-ONE_GB=$((1024 * 1024))
-if [ "$REMAINING" -lt "$ONE_GB" ]; then
-  echo "Error - not enough free space for upgrading"
-  echo ""
-  echo "Make sure you have at least 1 GB of free space in $PEERTUBE_PATH"
-  exit 1
+if [ -x "$(command -v awk)" ] && [ -x "$(command -v sed)" ] ; then
+    REMAINING=$(df -k $PEERTUBE_PATH | awk '{ print $4}' | sed -n 2p)
+    ONE_GB=$((1024 * 1024))
+    if [ "$REMAINING" -lt "$ONE_GB" ]; then
+    echo "Error - not enough free space for upgrading"
+    echo ""
+    echo "Make sure you have at least 1 GB of free space in $PEERTUBE_PATH"
+    exit 1
+    fi
 fi
 
 # Backup database


### PR DESCRIPTION
I just had my upgrade fail because most of my server's disk space was taken up by the video cache. So I added this quick check to the upgrade script.

The minimum free space of 1 GB is somewhat arbitary, because each Peertube installation only takes around 270 MB on my server. But it's better to have too much than too little.