### PR TITLE
rename ask-email link to ask-send-email

### DIFF
--- a/client/src/app/+verify-account/verify-account-email/verify-account-email.component.html
+++ b/client/src/app/+verify-account/verify-account-email/verify-account-email.component.html
@@ -9,7 +9,7 @@
   <ng-template #verificationError>
     <div>
       <span i18n>An error occurred. </span>
-      <a i18n routerLink="/verify-account/ask-email">Request new verification email.</a>
+      <a i18n routerLink="/verify-account/ask-send-email">Request new verification email.</a>
     </div>
   </ng-template>
 </div>


### PR DESCRIPTION
I encountered this bug when working on #993 . The link is likely rarely needed (only if verification string is wrong) which is why it has not been encountered.