### PR TITLE
WIP: Warn if email is not enabled for email verification

### DIFF
--- a/client/src/app/+verify-account/verify-account-ask-send-email/verify-account-ask-send-email.component.html
+++ b/client/src/app/+verify-account/verify-account-ask-send-email/verify-account-ask-send-email.component.html
@@ -2,21 +2,27 @@
   <div i18n class="title-page title-page-single">
     Request email for account verification
   </div>
-
-  <form *ngIf="requiresEmailVerification; else emailVerificationNotRequired" role="form" (ngSubmit)="askSendVerifyEmail()" [formGroup]="form">
-    <div class="form-group">
-      <label i18n for="verify-email-email">Email</label>
-      <input
-        type="email" id="verify-email-email" i18n-placeholder placeholder="Email address" required
-        formControlName="verify-email-email" [ngClass]="{ 'input-error': formErrors['verify-email-email'] }"
-      >
-      <div *ngIf="formErrors['verify-email-email']" class="form-error">
-          {{ formErrors['verify-email-email'] }}
-      </div>
+  <div *ngIf="!requiresEmailVerification; else emailVerificationRequired" i18n>
+    This instance does not require email verification.
+  </div>
+  <ng-template #emailVerificationRequired>
+    <div *ngIf="isEmailDisabled(); else askSendVerifyEmailForm" class="alert alert-danger" i18n>
+      We are sorry, you cannot receive a verification email because your instance administrator did not configure the PeerTube email system.
     </div>
-    <input type="submit" i18n-value value="Send verification email" [disabled]="!form.valid">
-  </form>
-  <ng-template #emailVerificationNotRequired>
-    <div i18n>This instance does not require email verification.</div>
+    <ng-template #askSendVerifyEmailForm>
+      <form role="form" (ngSubmit)="askSendVerifyEmail()" [formGroup]="form">
+        <div class="form-group">
+          <label i18n for="verify-email-email">Email</label>
+          <input
+            type="email" id="verify-email-email" i18n-placeholder placeholder="Email address" required
+            formControlName="verify-email-email" [ngClass]="{ 'input-error': formErrors['verify-email-email'] }"
+          >
+          <div *ngIf="formErrors['verify-email-email']" class="form-error">
+              {{ formErrors['verify-email-email'] }}
+          </div>
+        </div>
+        <input type="submit" i18n-value value="Send verification email" [disabled]="!form.valid">
+      </form>
+    </ng-template>
   </ng-template>
 </div>

--- a/client/src/app/+verify-account/verify-account-ask-send-email/verify-account-ask-send-email.component.ts
+++ b/client/src/app/+verify-account/verify-account-ask-send-email/verify-account-ask-send-email.component.ts
@@ -31,6 +31,10 @@ export class VerifyAccountAskSendEmailComponent extends FormReactive implements 
     return this.serverService.getConfig().signup.requiresEmailVerification
   }
 
+  isEmailDisabled () {
+    return this.serverService.getConfig().email.enabled === false
+  }
+
   ngOnInit () {
     this.buildForm({
       'verify-email-email': this.userValidatorsService.USER_EMAIL


### PR DESCRIPTION
Work in progress related to #993 

I originally opened the issue when implementing the email verification feature. This is likely an edge case as it would require the site admin to explicitly enable "Signup requires email verification" without smtp properly setup. 

In the work in progress I implemented a similar error on the client side to that used for ask password reset.

![request-new-email](https://user-images.githubusercontent.com/10546720/49686408-210e8800-fac2-11e8-9158-f52617d902e4.png)

I'm looking for feedback on which other related items to implement (or not): 

1. Client-side error if admin enables "Signup requires email verification" config when email is not enabled
2. Client-side error if user tries to signup when email verification is required and email is not enabled
3. Server-side error (500 response?) via middleware for requests dependent on email (ask password reset, ask verification email)