### PR TITLE
Use daemon(8) in the FreeBSD startup service

### DIFF
--- a/support/freebsd/peertube
+++ b/support/freebsd/peertube
@@ -24,8 +24,9 @@ NODE_CONFIG_DIR=/var/www/peertube/config \
 USER=peertube"
 peertube_user=peertube
 procname="node:"
+pidfile="/var/run/peertube.pid"
 
-command="/usr/local/bin/npm"
-command_args="start >> /var/log/peertube/${name}.log 2>&1 &"
+command="/usr/sbin/daemon"
+command_args="-p ${pidfile} -o /var/log/peertube/${name}.log -t ${name} -u ${peertube_user} /usr/local/bin/npm start"
 
 run_rc_command "$1"


### PR DESCRIPTION
This commit aims to solve the problem existing in #1477. Thanks to using
the daemon(8) utility, the service is able to always stop the correct
process as it is going to check both PID and the process name before
killing the PeerTube service.

----

I am not running PeerTube so I couldn't test this patch. I just saw [a call for help on Mastodon](https://stoneartprod.xyz/@gegeweb/101226782080800619) and decided to contribute. I'm happy to help you improve this solution if it happens to be broken.

