### PR TITLE
Remove the eventual trailing '/' at the end of urls (see #1453)

### DIFF
--- a/server/tools/peertube-import-videos.ts
+++ b/server/tools/peertube-import-videos.ts
@@ -58,7 +58,7 @@ getSettings()
         settings.remotes[settings.default] :
         settings.remotes[0]
     }
-    
+
     if (!program['username']) program['username'] = netrc.machines[program['url']].login
     if (!program['password']) program['password'] = netrc.machines[program['url']].password
   }
@@ -69,7 +69,7 @@ getSettings()
     if (!program['targetUrl']) console.error('--targetUrl field is required.')
     process.exit(-1)
   }
-  
+
   removeEndSlashes(program['url'])
   removeEndSlashes(program['targetUrl'])
 
@@ -326,8 +326,8 @@ function isNSFW (info: any) {
   return false
 }
 
-function removeEndSlashes(url: string) {
-  while(url.endsWith('/')){
+function removeEndSlashes (url: string) {
+  while (url.endsWith('/')) {
     url.slice(0, -1)
   }
 }

--- a/server/tools/peertube-import-videos.ts
+++ b/server/tools/peertube-import-videos.ts
@@ -58,6 +58,7 @@ getSettings()
         settings.remotes[settings.default] :
         settings.remotes[0]
     }
+    
     if (!program['username']) program['username'] = netrc.machines[program['url']].login
     if (!program['password']) program['password'] = netrc.machines[program['url']].password
   }
@@ -68,6 +69,9 @@ getSettings()
     if (!program['targetUrl']) console.error('--targetUrl field is required.')
     process.exit(-1)
   }
+  
+  removeEndSlashes(program['url'])
+  removeEndSlashes(program['targetUrl'])
 
   const user = {
     username: program['username'],
@@ -320,4 +324,10 @@ function isNSFW (info: any) {
   if (info.age_limit && info.age_limit >= 16) return true
 
   return false
+}
+
+function removeEndSlashes(url: string) {
+  while(url.endsWith('/')){
+    url.slice(0, -1)
+  }
 }


### PR DESCRIPTION
This is my solution for the '/' at the end of urls which create problems in the import videos script (issue #1453).
I forgot to open a pull request for this.
The issue was closed yersterday but is the problem resolved or not ? Cause I haven't seen any proposal to solved it.
Maybe, it wasn't a real problem.

Thanks.
