### PR TITLE
More systemd service hardening

### DIFF
--- a/support/systemd/peertube.service
+++ b/support/systemd/peertube.service
@@ -22,12 +22,17 @@ PrivateTmp=true
 ; Mount /usr, /boot, and /etc as read-only for processes invoked by this service.
 ProtectSystem=full
 ; Sets up a new /dev mount for the process and only adds API pseudo devices
-; like /dev/null, /dev/zero or /dev/random but not physical devices. Disabled
-; by default because it may not work on devices like the Raspberry Pi.
-PrivateDevices=false
+; like /dev/null, /dev/zero or /dev/random but not physical devices. May not work
+; on devices like the Raspberry Pi.
+PrivateDevices=true
 ; Ensures that the service process and all its children can never gain new
 ; privileges through execve().
 NoNewPrivileges=true
+; This makes /home, /root, and /run/user inaccessible and empty for processes invoked
+; by this unit. Make sure that you do not depend on data inside these folders.
+ProtectHome=true
+; Drops the sys admin capability from the daemon.
+CapabilityBoundingSet=~CAP_SYS_ADMIN
 
 [Install]
 WantedBy=multi-user.target

--- a/support/systemd/peertube.service
+++ b/support/systemd/peertube.service
@@ -22,9 +22,9 @@ PrivateTmp=true
 ; Mount /usr, /boot, and /etc as read-only for processes invoked by this service.
 ProtectSystem=full
 ; Sets up a new /dev mount for the process and only adds API pseudo devices
-; like /dev/null, /dev/zero or /dev/random but not physical devices. May not work
-; on devices like the Raspberry Pi.
-PrivateDevices=true
+; like /dev/null, /dev/zero or /dev/random but not physical devices. Disabled
+; by default because it may not work on devices like the Raspberry Pi.
+PrivateDevices=false
 ; Ensures that the service process and all its children can never gain new
 ; privileges through execve().
 NoNewPrivileges=true


### PR DESCRIPTION
* I set the `PrivateDevices=` directive to true, because I doubt that Peertube is being used on Raspberry Pies currently.
* Because the installation guide recommends `/var/www/peertube` as the home directory for the Peertube user, I think it’s safe to remove the ability for Peertube to access `/home`, `/root`, and `/run/user`.
* The service still has sys admin capabilities, and in theory can circumvent the sandbox restrictions. In the [manual](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ReadWritePaths=) it is recommend to drop this capability for an effective sandbox.