### PR TITLE
Add WebFinger support

### DIFF
--- a/client/src/app/shared/user-subscription/remote-subscribe.component.ts
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.ts
@@ -38,7 +38,7 @@ export class RemoteSubscribeComponent extends FormReactive implements OnInit {
   formValidated () {
     const address = this.form.value['text']
     const [ username, hostname ] = address.split('@')
-    
+
     fetch(`https://${hostname}/.well-known/webfinger?resource=acct:${username}@${hostname}`)
       .then(response => response.json())
       .then(data => new Promise((resolve, reject) => {
@@ -47,9 +47,10 @@ export class RemoteSubscribeComponent extends FormReactive implements OnInit {
             template: string
           } = data.links.find(link =>
             link && typeof link.template === 'string' && link.rel === 'http://ostatus.org/schema/1.0/subscribe')
-          
-          if (link && link.template.includes('{uri}'))
+
+          if (link && link.template.includes('{uri}')) {
             resolve(link.template.replace('{uri}', `acct:${this.account}`))
+          }
         }
         reject()
       }))

--- a/client/src/app/shared/user-subscription/remote-subscribe.component.ts
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.ts
@@ -45,7 +45,7 @@ export class RemoteSubscribeComponent extends FormReactive implements OnInit {
         if (data && Array.isArray(data.links)) {
           const link: {
             template: string
-          } = data.links.find(link =>
+          } = data.links.find((link: any) =>
             link && typeof link.template === 'string' && link.rel === 'http://ostatus.org/schema/1.0/subscribe')
 
           if (link && link.template.includes('{uri}')) {

--- a/client/src/app/shared/user-subscription/remote-subscribe.component.ts
+++ b/client/src/app/shared/user-subscription/remote-subscribe.component.ts
@@ -43,7 +43,9 @@ export class RemoteSubscribeComponent extends FormReactive implements OnInit {
       .then(response => response.json())
       .then(data => new Promise((resolve, reject) => {
         if (data && Array.isArray(data.links)) {
-          const link = data.links.find(link =>
+          const link: {
+            template: string
+          } = data.links.find(link =>
             link && typeof link.template === 'string' && link.rel === 'http://ostatus.org/schema/1.0/subscribe')
           
           if (link && link.template.includes('{uri}'))


### PR DESCRIPTION
Some of federation projects don't support `/authorize_interaction?acct={uri}` endpoint (e.g. [Misskey](https://github.com/syuilo/misskey)). So I propose to support WebFinger on the workflow of the remote subscribe button.