### PR TITLE
Answer to peertube issue 1536. Add a name to postgresql container

### DIFF
--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -46,6 +46,7 @@ services:
 
   postgres:
     image: postgres:10-alpine
+    container_name: db
     environment:
       POSTGRES_USER: ${PEERTUBE_DB_USERNAME}
       POSTGRES_PASSWORD: ${PEERTUBE_DB_PASSWORD}


### PR DESCRIPTION
The default configuration miss a name in the postgresql container declaration (needed by the other containers).