### PR TITLE
Add search by original publication year

### DIFF
--- a/client/src/app/search/advanced-search.model.ts
+++ b/client/src/app/search/advanced-search.model.ts
@@ -4,6 +4,9 @@ export class AdvancedSearch {
   publishedStartDate: string // ISO 8601
   publishedEndDate: string // ISO 8601
 
+  originallyPublishedStartYear: string // ISO 8601
+  originallyPublishedEndYear: string // ISO 8601
+
   nsfw: NSFWQuery
 
   categoryOneOf: string
@@ -23,6 +26,8 @@ export class AdvancedSearch {
   constructor (options?: {
     publishedStartDate?: string
     publishedEndDate?: string
+    originallyPublishedStartYear?: string
+    originallyPublishedEndYear?: string
     nsfw?: NSFWQuery
     categoryOneOf?: string
     licenceOneOf?: string
@@ -37,6 +42,8 @@ export class AdvancedSearch {
 
     this.publishedStartDate = options.publishedStartDate || undefined
     this.publishedEndDate = options.publishedEndDate || undefined
+    this.originallyPublishedStartYear = options.originallyPublishedStartYear || undefined
+    this.originallyPublishedEndYear = options.originallyPublishedEndYear || undefined
     this.nsfw = options.nsfw || undefined
     this.categoryOneOf = options.categoryOneOf || undefined
     this.licenceOneOf = options.licenceOneOf || undefined
@@ -66,6 +73,8 @@ export class AdvancedSearch {
   reset () {
     this.publishedStartDate = undefined
     this.publishedEndDate = undefined
+    this.originallyPublishedStartYear = undefined
+    this.originallyPublishedEndYear = undefined
     this.nsfw = undefined
     this.categoryOneOf = undefined
     this.licenceOneOf = undefined
@@ -82,6 +91,8 @@ export class AdvancedSearch {
     return {
       publishedStartDate: this.publishedStartDate,
       publishedEndDate: this.publishedEndDate,
+      originallyPublishedStartYear: this.originallyPublishedStartYear,
+      originallyPublishedEndYear: this.originallyPublishedEndYear,
       nsfw: this.nsfw,
       categoryOneOf: this.categoryOneOf,
       licenceOneOf: this.licenceOneOf,
@@ -98,6 +109,8 @@ export class AdvancedSearch {
     return {
       publishedStartDate: this.publishedStartDate,
       publishedEndDate: this.publishedEndDate,
+      originallyPublishedStartYear: this.originallyPublishedStartYear,
+      originallyPublishedEndYear: this.originallyPublishedEndYear,
       nsfw: this.nsfw,
       categoryOneOf: this.intoArray(this.categoryOneOf),
       licenceOneOf: this.intoArray(this.licenceOneOf),

--- a/client/src/app/search/advanced-search.model.ts
+++ b/client/src/app/search/advanced-search.model.ts
@@ -1,8 +1,8 @@
 import { NSFWQuery } from '../../../../shared/models/search'
 
 export class AdvancedSearch {
-  startDate: string // ISO 8601
-  endDate: string // ISO 8601
+  publishedStartDate: string // ISO 8601
+  publishedEndDate: string // ISO 8601
 
   nsfw: NSFWQuery
 
@@ -21,8 +21,8 @@ export class AdvancedSearch {
   sort: string
 
   constructor (options?: {
-    startDate?: string
-    endDate?: string
+    publishedStartDate?: string
+    publishedEndDate?: string
     nsfw?: NSFWQuery
     categoryOneOf?: string
     licenceOneOf?: string
@@ -35,8 +35,8 @@ export class AdvancedSearch {
   }) {
     if (!options) return
 
-    this.startDate = options.startDate || undefined
-    this.endDate = options.endDate || undefined
+    this.publishedStartDate = options.publishedStartDate || undefined
+    this.publishedEndDate = options.publishedEndDate || undefined
     this.nsfw = options.nsfw || undefined
     this.categoryOneOf = options.categoryOneOf || undefined
     this.licenceOneOf = options.licenceOneOf || undefined
@@ -64,8 +64,8 @@ export class AdvancedSearch {
   }
 
   reset () {
-    this.startDate = undefined
-    this.endDate = undefined
+    this.publishedStartDate = undefined
+    this.publishedEndDate = undefined
     this.nsfw = undefined
     this.categoryOneOf = undefined
     this.licenceOneOf = undefined
@@ -80,8 +80,8 @@ export class AdvancedSearch {
 
   toUrlObject () {
     return {
-      startDate: this.startDate,
-      endDate: this.endDate,
+      publishedStartDate: this.publishedStartDate,
+      publishedEndDate: this.publishedEndDate,
       nsfw: this.nsfw,
       categoryOneOf: this.categoryOneOf,
       licenceOneOf: this.licenceOneOf,
@@ -96,8 +96,8 @@ export class AdvancedSearch {
 
   toAPIObject () {
     return {
-      startDate: this.startDate,
-      endDate: this.endDate,
+      publishedStartDate: this.publishedStartDate,
+      publishedEndDate: this.publishedEndDate,
       nsfw: this.nsfw,
       categoryOneOf: this.intoArray(this.categoryOneOf),
       licenceOneOf: this.intoArray(this.licenceOneOf),

--- a/client/src/app/search/search-filters.component.html
+++ b/client/src/app/search/search-filters.component.html
@@ -21,6 +21,29 @@
       </div>
 
       <div class="form-group">
+        <label i18n for="original-publication-year">Original publication year</label>
+
+        <div class="row">
+          <div class="col-sm-6">
+            <input
+              type="text" id="original-publication-after"
+              name="original-publication-after" i18n-placeholder
+              placeholder="After..."
+              [(ngModel)]="advancedSearch.originallyPublishedStartYear"
+            >
+          </div>
+          <div class="col-sm-6">
+            <input
+              type="text" id="original-publication-before"
+              name="original-publication-before"
+              i18n-placeholder placeholder="Before..."
+              [(ngModel)]="advancedSearch.originallyPublishedEndYear"
+            >
+          </div>
+        </div>
+      </div>
+
+      <div class="form-group">
         <div i18n class="radio-label">Duration</div>
 
         <div class="peertube-radio-container" *ngFor="let duration of durationRanges">

--- a/client/src/app/search/search-filters.component.ts
+++ b/client/src/app/search/search-filters.component.ts
@@ -111,8 +111,8 @@ export class SearchFiltersComponent implements OnInit {
   }
 
   private loadFromPublishedRange () {
-    if (this.advancedSearch.startDate) {
-      const date = new Date(this.advancedSearch.startDate)
+    if (this.advancedSearch.publishedStartDate) {
+      const date = new Date(this.advancedSearch.publishedStartDate)
       const now = new Date()
 
       const diff = Math.abs(date.getTime() - now.getTime())
@@ -172,6 +172,6 @@ export class SearchFiltersComponent implements OnInit {
         break
     }
 
-    this.advancedSearch.startDate = date.toISOString()
+    this.advancedSearch.publishedStartDate = date.toISOString()
   }
 }

--- a/client/src/app/search/search-filters.component.ts
+++ b/client/src/app/search/search-filters.component.ts
@@ -23,6 +23,8 @@ export class SearchFiltersComponent implements OnInit {
   durationRanges: { id: string, label: string }[] = []
 
   publishedDateRange: string
+  originallyPublishedStartYear: string
+  originallyPublishedEndYear: string
   durationRange: string
 
   constructor (
@@ -174,4 +176,5 @@ export class SearchFiltersComponent implements OnInit {
 
     this.advancedSearch.publishedStartDate = date.toISOString()
   }
+
 }

--- a/client/src/app/shared/forms/form-validators/video-validators.service.ts
+++ b/client/src/app/shared/forms/form-validators/video-validators.service.ts
@@ -16,6 +16,7 @@ export class VideoValidatorsService {
   readonly VIDEO_TAGS: BuildFormValidator
   readonly VIDEO_SUPPORT: BuildFormValidator
   readonly VIDEO_SCHEDULE_PUBLICATION_AT: BuildFormValidator
+  readonly VIDEO_ORIGINALLY_PUBLISHED_AT: BuildFormValidator
 
   constructor (private i18n: I18n) {
 
@@ -91,6 +92,11 @@ export class VideoValidatorsService {
       MESSAGES: {
         'required': this.i18n('A date is required to schedule video update.')
       }
+    }
+
+    this.VIDEO_ORIGINALLY_PUBLISHED_AT = {
+      VALIDATORS: [ ],
+      MESSAGES: {}
     }
   }
 }

--- a/client/src/app/shared/video-import/video-import.service.ts
+++ b/client/src/app/shared/video-import/video-import.service.ts
@@ -67,6 +67,7 @@ export class VideoImportService {
     const description = video.description || null
     const support = video.support || null
     const scheduleUpdate = video.scheduleUpdate || null
+    const originallyPublishedAt = video.originallyPublishedAt || null
 
     return {
       name: video.name,
@@ -83,7 +84,8 @@ export class VideoImportService {
       commentsEnabled: video.commentsEnabled,
       thumbnailfile: video.thumbnailfile,
       previewfile: video.previewfile,
-      scheduleUpdate
+      scheduleUpdate,
+      originallyPublishedAt
     }
   }
 

--- a/client/src/app/shared/video/video-edit.model.ts
+++ b/client/src/app/shared/video/video-edit.model.ts
@@ -25,6 +25,7 @@ export class VideoEdit implements VideoUpdate {
   uuid?: string
   id?: number
   scheduleUpdate?: VideoScheduleUpdate
+  originallyPublishedAt?: Date | string
 
   constructor (video?: Video & { tags: string[], commentsEnabled: boolean, support: string, thumbnailUrl: string, previewUrl: string }) {
     if (video) {
@@ -46,6 +47,7 @@ export class VideoEdit implements VideoUpdate {
       this.previewUrl = video.previewUrl
 
       this.scheduleUpdate = video.scheduledUpdate
+      this.originallyPublishedAt = new Date(video.originallyPublishedAt)
     }
   }
 
@@ -67,6 +69,12 @@ export class VideoEdit implements VideoUpdate {
     } else {
       this.scheduleUpdate = null
     }
+
+    // Convert originallyPublishedAt to string so that function objectToFormData() works correctly
+    if (this.originallyPublishedAt) {
+      const originallyPublishedAt = new Date(values['originallyPublishedAt'])
+      this.originallyPublishedAt = originallyPublishedAt.toISOString()
+    }
   }
 
   toFormPatch () {
@@ -82,7 +90,8 @@ export class VideoEdit implements VideoUpdate {
       commentsEnabled: this.commentsEnabled,
       waitTranscoding: this.waitTranscoding,
       channelId: this.channelId,
-      privacy: this.privacy
+      privacy: this.privacy,
+      originallyPublishedAt: this.originallyPublishedAt
     }
 
     // Special case if we scheduled an update

--- a/client/src/app/shared/video/video.model.ts
+++ b/client/src/app/shared/video/video.model.ts
@@ -17,6 +17,7 @@ export class Video implements VideoServerModel {
   createdAt: Date
   updatedAt: Date
   publishedAt: Date
+  originallyPublishedAt: Date | string
   category: VideoConstant<number>
   licence: VideoConstant<number>
   language: VideoConstant<string>
@@ -116,6 +117,9 @@ export class Video implements VideoServerModel {
     this.privacy.label = peertubeTranslate(this.privacy.label, translations)
 
     this.scheduledUpdate = hash.scheduledUpdate
+    this.originallyPublishedAt = hash.originallyPublishedAt ?
+    new Date(hash.originallyPublishedAt.toString())
+    : null
     if (this.state) this.state.label = peertubeTranslate(this.state.label, translations)
 
     this.blacklisted = hash.blacklisted

--- a/client/src/app/shared/video/video.service.ts
+++ b/client/src/app/shared/video/video.service.ts
@@ -81,6 +81,7 @@ export class VideoService implements VideosProvider {
     const description = video.description || null
     const support = video.support || null
     const scheduleUpdate = video.scheduleUpdate || null
+    const originallyPublishedAt = video.originallyPublishedAt || null
 
     const body: VideoUpdate = {
       name: video.name,
@@ -97,7 +98,8 @@ export class VideoService implements VideosProvider {
       commentsEnabled: video.commentsEnabled,
       thumbnailfile: video.thumbnailfile,
       previewfile: video.previewfile,
-      scheduleUpdate
+      scheduleUpdate,
+      originallyPublishedAt
     }
 
     const data = objectToFormData(body)

--- a/client/src/app/videos/+video-edit/shared/video-edit.component.html
+++ b/client/src/app/videos/+video-edit/shared/video-edit.component.html
@@ -114,6 +114,20 @@
               </div>
             </div>
 
+            <div class="form-group">
+              <label i18n for="originallyPublishedAt">Original publication date</label>
+              <my-help i18n-preHtml preHtml="This is the date when the content was originally published (e.g. the release date for a film)"></my-help>
+              <p-calendar
+                id="originallyPublishedAt" formControlName="originallyPublishedAt" [dateFormat]="calendarDateFormat"
+                [locale]="calendarLocale" [showTime]="true" [hideOnDateTimeSelect]="true" [monthNavigator]="true" [yearNavigator]="true" [yearRange]="myYearRange"
+              >
+              </p-calendar>
+
+              <div *ngIf="formErrors.originallyPublishedAt" class="form-error">
+                {{ formErrors.originallyPublishedAt }}
+              </div>
+            </div>
+
             <my-peertube-checkbox
               inputName="nsfw" formControlName="nsfw"
               i18n-labelText labelText="This video contains mature or explicit content"

--- a/client/src/app/videos/+video-edit/shared/video-edit.component.ts
+++ b/client/src/app/videos/+video-edit/shared/video-edit.component.ts
@@ -45,6 +45,7 @@ export class VideoEditComponent implements OnInit, OnDestroy {
 
   calendarLocale: any = {}
   minScheduledDate = new Date()
+  myYearRange = '1880:' + (new Date()).getFullYear()
 
   calendarTimezone: string
   calendarDateFormat: string
@@ -99,7 +100,8 @@ export class VideoEditComponent implements OnInit, OnDestroy {
       thumbnailfile: null,
       previewfile: null,
       support: this.videoValidatorsService.VIDEO_SUPPORT,
-      schedulePublicationAt: this.videoValidatorsService.VIDEO_SCHEDULE_PUBLICATION_AT
+      schedulePublicationAt: this.videoValidatorsService.VIDEO_SCHEDULE_PUBLICATION_AT,
+      originallyPublishedAt: this.videoValidatorsService.VIDEO_ORIGINALLY_PUBLISHED_AT
     }
 
     this.formValidatorService.updateForm(

--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -33,7 +33,6 @@
           <div>
             <div class="d-block d-sm-none"> <!-- only shown on small devices, has its conterpart for larger viewports below -->
               <h1 class="video-info-name">{{ video.name }}</h1>
-
               <div i18n class="video-info-date-views">
                 Published {{ video.publishedAt | myFromNow }} - {{ video.views | myNumberFormatter }} views
               </div>
@@ -158,6 +157,14 @@
           <div class="video-attribute">
             <span i18n class="video-attribute-label">Privacy</span>
             <span class="video-attribute-value">{{ video.privacy.label }}</span>
+          </div>
+
+          <div class="video-attribute">
+            <span i18n class="video-attribute-label">Published on</span>
+            <span *ngIf="!video.originallyPublishedAt" class="video-attribute-value">Unknown</span>
+            <span *ngIf="video.originallyPublishedAt" class="video-attribute-value"> 
+              {{ video.originallyPublishedAt | date: 'dd MMMM yyyy' }}
+            </span>
           </div>
 
           <div class="video-attribute">

--- a/client/src/app/videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/videos/+video-watch/video-watch.component.scss
@@ -336,7 +336,7 @@ $other-videos-width: 260px;
       margin-bottom: 12px;
 
       .video-attribute-label {
-        min-width: 91px;
+        min-width: 117px;
         padding-right: 5px;
         display: inline-block;
         color: #585858;

--- a/server/controllers/api/videos/index.ts
+++ b/server/controllers/api/videos/index.ts
@@ -188,7 +188,8 @@ async function addVideo (req: express.Request, res: express.Response) {
     support: videoInfo.support,
     privacy: videoInfo.privacy,
     duration: videoPhysicalFile['duration'], // duration was added by a previous middleware
-    channelId: res.locals.videoChannel.id
+    channelId: res.locals.videoChannel.id,
+    originallyPublishedAt: videoInfo.originallyPublishedAt
   }
   const video = new VideoModel(videoData)
   video.url = getVideoActivityPubUrl(video) // We use the UUID, so set the URL after building the object
@@ -325,6 +326,11 @@ async function updateVideo (req: express.Request, res: express.Response) {
       if (videoInfoToUpdate.support !== undefined) videoInstance.set('support', videoInfoToUpdate.support)
       if (videoInfoToUpdate.description !== undefined) videoInstance.set('description', videoInfoToUpdate.description)
       if (videoInfoToUpdate.commentsEnabled !== undefined) videoInstance.set('commentsEnabled', videoInfoToUpdate.commentsEnabled)
+      if (videoInfoToUpdate.originallyPublishedAt !== undefined &&
+          videoInfoToUpdate.originallyPublishedAt !== null) {
+        videoInstance.set('originallyPublishedAt', videoInfoToUpdate.originallyPublishedAt)
+      }
+
       if (videoInfoToUpdate.privacy !== undefined) {
         const newPrivacy = parseInt(videoInfoToUpdate.privacy.toString(), 10)
         videoInstance.set('privacy', newPrivacy)

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -13,7 +13,7 @@ import {
   VIDEO_STATES
 } from '../../initializers'
 import { VideoModel } from '../../models/video/video'
-import { exists, isArray, isFileValid } from './misc'
+import { exists, isArray, isDateValid, isFileValid } from './misc'
 import { VideoChannelModel } from '../../models/video/video-channel'
 import { UserModel } from '../../models/account/user'
 import * as magnetUtil from 'magnet-uri'
@@ -113,6 +113,10 @@ function isScheduleVideoUpdatePrivacyValid (value: number) {
       value === VideoPrivacy.UNLISTED ||
       value === VideoPrivacy.PUBLIC
     )
+}
+
+function isVideoOriginallyPublishedAtValid (value: string | null) {
+  return value === null || isDateValid(value)
 }
 
 function isVideoFileInfoHashValid (value: string | null | undefined) {
@@ -220,6 +224,7 @@ export {
   isVideoTagsValid,
   isVideoFPSResolutionValid,
   isScheduleVideoUpdatePrivacyValid,
+  isVideoOriginallyPublishedAtValid,
   isVideoFile,
   isVideoMagnetUriValid,
   isVideoStateValid,

--- a/server/initializers/migrations/0295-add-originally-published-at.ts
+++ b/server/initializers/migrations/0295-add-originally-published-at.ts
@@ -1,0 +1,42 @@
+import * as Sequelize from 'sequelize'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction,
+  queryInterface: Sequelize.QueryInterface,
+  sequelize: Sequelize.Sequelize
+}): Promise<void> {
+
+  {
+    const data = {
+      type: Sequelize.DATE,
+      allowNull: true,
+      defaultValue: Sequelize.NOW
+    }
+    await utils.queryInterface.addColumn('video', 'originallyPublishedAt', data)
+  }
+
+  {
+    const query = 'UPDATE video SET "originallyPublishedAt" = video."publishedAt"'
+    await utils.sequelize.query(query)
+  }
+
+  // Sequelize does not alter the column with NOW as default value
+  {
+    const data = {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.NOW
+    }
+    await utils.queryInterface.changeColumn('video', 'originallyPublishedAt', data)
+  }
+
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export {
+  up,
+  down
+}

--- a/server/middlewares/validators/search.ts
+++ b/server/middlewares/validators/search.ts
@@ -7,8 +7,8 @@ import { isDateValid } from '../../helpers/custom-validators/misc'
 const videosSearchValidator = [
   query('search').optional().not().isEmpty().withMessage('Should have a valid search'),
 
-  query('startDate').optional().custom(isDateValid).withMessage('Should have a valid start date'),
-  query('endDate').optional().custom(isDateValid).withMessage('Should have a valid end date'),
+  query('publishedStartDate').optional().custom(isDateValid).withMessage('Should have a valid start date'),
+  query('publishedEndDate').optional().custom(isDateValid).withMessage('Should have a valid end date'),
 
   query('durationMin').optional().isInt().withMessage('Should have a valid min duration'),
   query('durationMax').optional().isInt().withMessage('Should have a valid max duration'),

--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../helpers/custom-validators/misc'
 import {
   checkUserCanManageVideo,
+  isVideoOriginallyPublishedAtValid,
   isScheduleVideoUpdatePrivacyValid,
   isVideoCategoryValid,
   isVideoChannelOfAccountExist,
@@ -340,6 +341,10 @@ function getCommonVideoAttributes () {
       .optional()
       .toBoolean()
       .custom(isBooleanValid).withMessage('Should have comments enabled boolean'),
+    body('originallyPublishedAt')
+      .optional()
+      .customSanitizer(toValueOrNull)
+      .custom(isVideoOriginallyPublishedAtValid).withMessage('Should have a valid original publication date'),
 
     body('scheduleUpdate')
       .optional()

--- a/server/models/video/video-format-utils.ts
+++ b/server/models/video/video-format-utils.ts
@@ -60,6 +60,7 @@ function videoModelToFormattedJSON (video: VideoModel, options?: VideoFormatting
     createdAt: video.createdAt,
     updatedAt: video.updatedAt,
     publishedAt: video.publishedAt,
+    originallyPublishedAt: video.originallyPublishedAt,
     account: {
       id: formattedAccount.id,
       uuid: formattedAccount.uuid,
@@ -264,6 +265,9 @@ function videoModelToActivityPubObject (video: VideoModel): VideoTorrentObject {
     state: video.state,
     commentsEnabled: video.commentsEnabled,
     published: video.publishedAt.toISOString(),
+    originallyPublishedAt: video.originallyPublishedAt ?
+      video.originallyPublishedAt.toISOString() :
+      null,
     updated: video.updatedAt.toISOString(),
     mediaType: 'text/markdown',
     content: video.getTruncatedDescription(),

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -102,6 +102,7 @@ const indexes: Sequelize.DefineIndexesOptions[] = [
 
   { fields: [ 'createdAt' ] },
   { fields: [ 'publishedAt' ] },
+  { fields: [ 'originallyPublishedAt' ] },
   { fields: [ 'duration' ] },
   { fields: [ 'views' ] },
   { fields: [ 'channelId' ] },
@@ -683,6 +684,9 @@ export class VideoModel extends Model<VideoModel> {
   @Default(Sequelize.NOW)
   @Column
   publishedAt: Date
+
+  @Column
+  originallyPublishedAt: Date
 
   @ForeignKey(() => VideoChannelModel)
   @Column

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1098,8 +1098,8 @@ export class VideoModel extends Model<VideoModel> {
     start?: number
     count?: number
     sort?: string
-    startDate?: string // ISO 8601
-    endDate?: string // ISO 8601
+    publishedStartDate?: string // ISO 8601
+    publishedEndDate?: string // ISO 8601
     nsfw?: boolean
     categoryOneOf?: number[]
     licenceOneOf?: number[]
@@ -1113,11 +1113,11 @@ export class VideoModel extends Model<VideoModel> {
   }) {
     const whereAnd = []
 
-    if (options.startDate || options.endDate) {
+    if (options.publishedStartDate || options.publishedEndDate) {
       const publishedAtRange = {}
 
-      if (options.startDate) publishedAtRange[ Sequelize.Op.gte ] = options.startDate
-      if (options.endDate) publishedAtRange[ Sequelize.Op.lte ] = options.endDate
+      if (options.publishedStartDate) publishedAtRange[ Sequelize.Op.gte ] = options.publishedStartDate
+      if (options.publishedEndDate) publishedAtRange[ Sequelize.Op.lte ] = options.publishedEndDate
 
       whereAnd.push({ publishedAt: publishedAtRange })
     }

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1100,6 +1100,8 @@ export class VideoModel extends Model<VideoModel> {
     sort?: string
     publishedStartDate?: string // ISO 8601
     publishedEndDate?: string // ISO 8601
+    originallyPublishedStartYear?: string
+    originallyPublishedEndYear?: string
     nsfw?: boolean
     categoryOneOf?: number[]
     licenceOneOf?: number[]
@@ -1120,6 +1122,15 @@ export class VideoModel extends Model<VideoModel> {
       if (options.publishedEndDate) publishedAtRange[ Sequelize.Op.lte ] = options.publishedEndDate
 
       whereAnd.push({ publishedAt: publishedAtRange })
+    }
+
+    if (options.originallyPublishedStartYear || options.originallyPublishedEndYear) {
+      const originallyPublishedAtRange = {}
+
+      if (options.originallyPublishedStartYear) originallyPublishedAtRange[ Sequelize.Op.gte ] = new Date(options.originallyPublishedStartYear).toISOString()
+      if (options.originallyPublishedEndYear) originallyPublishedAtRange[ Sequelize.Op.lte ] = new Date(options.originallyPublishedEndYear).toISOString()
+
+      whereAnd.push({ originallyPublishedAt: originallyPublishedAtRange })
     }
 
     if (options.durationMin || options.durationMax) {

--- a/server/tests/api/check-params/search.ts
+++ b/server/tests/api/check-params/search.ts
@@ -108,10 +108,10 @@ describe('Test videos API validator', function () {
     })
 
     it('Should fail with invalid dates', async function () {
-      const customQuery1 = immutableAssign(query, { startDate: 'hello' })
+      const customQuery1 = immutableAssign(query, { publishedStartDate: 'hello' })
       await makeGetRequest({ url: server.url, path, query: customQuery1, statusCodeExpected: 400 })
 
-      const customQuery2 = immutableAssign(query, { endDate: 'hello' })
+      const customQuery2 = immutableAssign(query, { publishedEndDate: 'hello' })
       await makeGetRequest({ url: server.url, path, query: customQuery2, statusCodeExpected: 400 })
     })
   })

--- a/server/tests/api/search/search-videos.ts
+++ b/server/tests/api/search/search-videos.ts
@@ -19,7 +19,7 @@ const expect = chai.expect
 
 describe('Test a videos search', function () {
   let server: ServerInfo = null
-  let startDate: string
+  let publishedStartDate: string
 
   before(async function () {
     this.timeout(30000)
@@ -52,7 +52,7 @@ describe('Test a videos search', function () {
 
       await wait(1000)
 
-      startDate = new Date().toISOString()
+      publishedStartDate = new Date().toISOString()
 
       const attributes5 = immutableAssign(attributes1, { name: attributes1.name + ' - 5', licence: 2 })
       await uploadVideo(server.url, server.accessToken, attributes5)
@@ -250,10 +250,10 @@ describe('Test a videos search', function () {
     expect(res2.body.total).to.equal(0)
   })
 
-  it('Should search by start date', async function () {
+  it('Should search by PublishedAt start date', async function () {
     const query = {
       search: '1111 2222 3333',
-      startDate
+      publishedStartDate
     }
 
     const res = await advancedVideosSearch(server.url, query)

--- a/shared/models/activitypub/objects/video-torrent-object.ts
+++ b/shared/models/activitypub/objects/video-torrent-object.ts
@@ -24,6 +24,7 @@ export interface VideoTorrentObject {
   waitTranscoding: boolean
   state: VideoState
   published: string
+  originallyPublishedAt: string
   updated: string
   mediaType: 'text/markdown'
   content: string

--- a/shared/models/search/videos-search-query.model.ts
+++ b/shared/models/search/videos-search-query.model.ts
@@ -8,8 +8,8 @@ export interface VideosSearchQuery {
   count?: number
   sort?: string
 
-  startDate?: string // ISO 8601
-  endDate?: string // ISO 8601
+  publishedStartDate?: string // ISO 8601
+  publishedEndDate?: string // ISO 8601
 
   nsfw?: NSFWQuery
 

--- a/shared/models/search/videos-search-query.model.ts
+++ b/shared/models/search/videos-search-query.model.ts
@@ -11,6 +11,9 @@ export interface VideosSearchQuery {
   publishedStartDate?: string // ISO 8601
   publishedEndDate?: string // ISO 8601
 
+  originallyPublishedStartYear?: string // ISO 8601
+  originallyPublishedEndYear?: string // ISO 8601
+
   nsfw?: NSFWQuery
 
   categoryOneOf?: number[]

--- a/shared/models/videos/video-create.model.ts
+++ b/shared/models/videos/video-create.model.ts
@@ -15,4 +15,5 @@ export interface VideoCreate {
   commentsEnabled?: boolean
   privacy: VideoPrivacy
   scheduleUpdate?: VideoScheduleUpdate
+  originallyPublishedAt: Date | string
 }

--- a/shared/models/videos/video-update.model.ts
+++ b/shared/models/videos/video-update.model.ts
@@ -17,4 +17,5 @@ export interface VideoUpdate {
   thumbnailfile?: Blob
   previewfile?: Blob
   scheduleUpdate?: VideoScheduleUpdate
+  originallyPublishedAt?: Date | string
 }

--- a/shared/models/videos/video.model.ts
+++ b/shared/models/videos/video.model.ts
@@ -43,6 +43,7 @@ export interface Video {
   createdAt: Date | string
   updatedAt: Date | string
   publishedAt: Date | string
+  originallyPublishedAt: Date | string
   category: VideoConstant<number>
   licence: VideoConstant<number>
   language: VideoConstant<string>


### PR DESCRIPTION
Follow-up to #1285 (which allows to add original publication date to videos)

This PR allows to search videos by original publication year. Demo: 

![screencast_recherche_small](https://user-images.githubusercontent.com/18473412/51076539-0a97b580-169a-11e9-8f12-b11448a6a49d.gif)
