### PR TITLE
Patch docker entrypoint to speed up the chown at startup

### DIFF
--- a/support/docker/production/docker-entrypoint.sh
+++ b/support/docker/production/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 # Always copy default and custom env configuration file, in cases where new keys were added
 cp /app/config/default.yaml /config
 cp /app/support/docker/production/config/custom-environment-variables.yaml /config
-chown -R peertube:peertube /config
+find /config ! -user peertube -exec chown peertube:peertube {} \;
 
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
@@ -19,7 +19,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'npm' -a "$(id -u)" = '0' ]; then
-    chown -R peertube:peertube /data
+    find /data ! -user peertube -exec  chown peertube:peertube {} \;
     exec gosu peertube "$0" "$@"
 fi
 


### PR DESCRIPTION
Hello!

Here is a little patch to speed up the docker start on large instance.
Indeed the `chown -R` is executed on all files, even if the right are already ok, which cost IO and is very long with lots of files.

The patch uses find to read (instead of write) each files and apply the chown only if necessary, which speed up the start.

From benchmark on my instance, it reduces the start from 6 minutes to less than 1 minute :)

Datalove <3