### PR TITLE
fix typo in test accounts api validators

### DIFF
--- a/server/tests/api/check-params/accounts.ts
+++ b/server/tests/api/check-params/accounts.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../shared/utils/requests/check-api-params'
 import { getAccount } from '../../../../shared/utils/users/accounts'
 
-describe('Test users API validators', function () {
+describe('Test accounts API validators', function () {
   const path = '/api/v1/accounts/'
   let server: ServerInfo
 


### PR DESCRIPTION
Noticed this when searching for "Test users API validators" - both in `check-params/users.ts` & `check-params/accounts.ts` so this one must be a typo.