### PR TITLE
Nginx config file: remove text/html from gzip_types

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -41,7 +41,7 @@ server {
   # It might be nice to compress JSON, but leaving that out to protect against potential
   # compression+encryption information leak attacks like BREACH.
   gzip on;
-  gzip_types text/css text/html application/javascript;
+  gzip_types text/css application/javascript;
   gzip_vary on;
 
   # Enable HSTS


### PR DESCRIPTION
As stated by https://nginx.org/en/docs/http/ngx_http_gzip_module.html, text/html is always part of the gzip_types. This removes a warning when checking the Nginx configuration files.