### PR TITLE
Fix negative seconds by displaying 0 instead (#1445)

### DIFF
--- a/client/src/app/shared/misc/from-now.pipe.ts
+++ b/client/src/app/shared/misc/from-now.pipe.ts
@@ -9,7 +9,7 @@ export class FromNowPipe implements PipeTransform {
 
   transform (arg: number | Date | string) {
     const argDate = new Date(arg)
-    const seconds = Math.floor((Date.now() - argDate.getTime()) / 1000)
+    const seconds = Math.max(0, Math.floor((Date.now() - argDate.getTime()) / 1000))
 
     let interval = Math.floor(seconds / 31536000)
     if (interval > 1) {

--- a/client/src/app/shared/misc/from-now.pipe.ts
+++ b/client/src/app/shared/misc/from-now.pipe.ts
@@ -9,7 +9,7 @@ export class FromNowPipe implements PipeTransform {
 
   transform (arg: number | Date | string) {
     const argDate = new Date(arg)
-    const seconds = Math.max(0, Math.floor((Date.now() - argDate.getTime()) / 1000))
+    const seconds = Math.floor((Date.now() - argDate.getTime()) / 1000)
 
     let interval = Math.floor(seconds / 31536000)
     if (interval > 1) {
@@ -35,6 +35,6 @@ export class FromNowPipe implements PipeTransform {
     interval = Math.floor(seconds / 60)
     if (interval >= 1) return this.i18n('{{interval}} min ago', { interval })
 
-    return this.i18n('{{interval}} sec ago', { interval: Math.floor(seconds) })
+    return this.i18n('{{interval}} sec ago', { interval: Math.max(0, seconds) })
   }
 }


### PR DESCRIPTION
Use Math.max to make negative seconds equal to zero instead. Remove redundant Math.floor operation.