### PR TITLE
check email enabled for requiresEmailVer config

### DIFF
--- a/server/tests/api/check-params/config.ts
+++ b/server/tests/api/check-params/config.ts
@@ -167,6 +167,25 @@ describe('Test config API validators', function () {
       })
     })
 
+    it('Should fail if email disabled and signup requires email verification', async function () {
+      // opposite scenario - succcess when enable enabled - covered via tests/api/users/user-verification.ts
+      const newUpdateParams = immutableAssign(updateParams, {
+        signup: {
+          enabled: true,
+          limit: 5,
+          requiresEmailVerification: true
+        }
+      })
+
+      await makePutBodyRequest({
+        url: server.url,
+        path,
+        fields: newUpdateParams,
+        token: server.accessToken,
+        statusCodeExpected: 400
+      })
+    })
+
     it('Should success with the correct parameters', async function () {
       await makePutBodyRequest({
         url: server.url,

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -81,7 +81,7 @@ function checkUpdatedConfig (data: CustomConfig) {
 
   expect(data.signup.enabled).to.be.false
   expect(data.signup.limit).to.equal(5)
-  expect(data.signup.requiresEmailVerification).to.be.true
+  expect(data.signup.requiresEmailVerification).to.be.false
 
   expect(data.admin.email).to.equal('superadmin1@example.com')
   expect(data.contactForm.enabled).to.be.false
@@ -186,7 +186,7 @@ describe('Test config', function () {
       signup: {
         enabled: false,
         limit: 5,
-        requiresEmailVerification: true
+        requiresEmailVerification: false
       },
       admin: {
         email: 'superadmin1@example.com'


### PR DESCRIPTION
Instead of #1471

Resolves #993

> Chocobozzz: I think we should prevent peertube from starting if it is incorrectly configured. For example, in the `checkConfig` function: https://github.com/Chocobozzz/PeerTube/blob/develop/server/initializers/checker-after-init.ts#L34
> Nutomic: But you can also change these settings in the web interface so there needs to be a warning/error as well.
> Chocobozzz: If both are implemented yep remove the warning above

@Chocobozzz you already implemented the 1st so this is just for the 2nd. I only check if email is enabled for `requiresEmailVerification` since you had `contactForm` as warning only.

I was considering some logic on the client to disable the checkbox if email is not enabled but I feel this is good enough. Let me know if you'd like me to.

![peertube-email-config-check](https://user-images.githubusercontent.com/10546720/52917202-8d71e880-32b6-11e9-9190-5e35855f187d.png)
