### PR TITLE
Fix problem with SMTP in default docker-compose setup

### DIFF
--- a/support/docker/production/.env
+++ b/support/docker/production/.env
@@ -7,12 +7,12 @@ PEERTUBE_WEBSERVER_HTTPS=true
 # pass them as a comma separated array:
 PEERTUBE_TRUST_PROXY=["127.0.0.1"]
 #PEERTUBE_TRUST_PROXY=["127.0.0.1", "loopback", "192.168.1.0/24"]
-PEERTUBE_SMTP_USERNAME=
-PEERTUBE_SMTP_PASSWORD=
+#PEERTUBE_SMTP_USERNAME=
+#PEERTUBE_SMTP_PASSWORD=
 PEERTUBE_SMTP_HOSTNAME=postfix
 PEERTUBE_SMTP_PORT=25
 PEERTUBE_SMTP_FROM=noreply@domain.tld
-PEERTUBE_SMTP_TLS=true
+PEERTUBE_SMTP_TLS=false
 PEERTUBE_SMTP_DISABLE_STARTTLS=false
 PEERTUBE_ADMIN_EMAIL=admin@domain.tld
 # /!\ Prefer to use the PeerTube admin interface to set the following configurations /!\


### PR DESCRIPTION
I was following the instructions here: https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/docker.md

However, after completing the instructions and running `docker-compose up`, I Peertube failed to start and I received the following errors:
```
peertube_1       | [testing.peertube.social:443] 2019-03-08 14:30:12.044 error: Failed to connect to SMTP postfix:25. {
peertube_1       |   "meta": {
peertube_1       |     "err": {
peertube_1       |       "stack": "Error: Invalid login: 503 5.5.1 Error: authentication not enabled\n    at SMTPConnection._formatError (/app/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)\n    at SMTPConnection._actionAUTHComplete (/app/node_modules/nodemailer/lib/smtp-connection/index.js:1340:34)\n    at SMTPConnection._responseActions.push.str (/app/node_modules/nodemailer/lib/smtp-connection/index.js:378:26)\n    at SMTPConnection._processResponse (/app/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)\n    at SMTPConnection._onData (/app/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)\n    at Socket._socket.on.chunk (/app/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)\n    at emitOne (events.js:116:13)\n    at Socket.emit (events.js:211:7)\n    at addChunk (_stream_readable.js:263:12)\n    at readableAddChunk (_stream_readable.js:250:11)\n    at Socket.Readable.push (_stream_readable.js:208:10)\n    at TCP.onread (net.js:601:20)",
peertube_1       |       "message": "Invalid login: 503 5.5.1 Error: authentication not enabled",
peertube_1       |       "code": "EAUTH",
peertube_1       |       "response": "503 5.5.1 Error: authentication not enabled",
peertube_1       |       "responseCode": 503,
peertube_1       |       "command": "AUTH PLAIN"
peertube_1       |     }
peertube_1       |   }
peertube_1       | }
```

The changes in this PR fix this problem.