### PR TITLE
Add the 'email' entry in the default.yaml config file

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -43,6 +43,9 @@ smtp:
   ca_file: null # Used for self signed certificates
   from_address: 'admin@example.com'
 
+email:
+  enabled: false # Set to `true` if you want to enable emails (to reset a password for example)
+
 # From the project root directory
 storage:
   tmp: 'storage/tmp/' # Used to download data (imports etc), store uploaded files before processing...


### PR DESCRIPTION
Fixes #1758

I'm not sure where this could be documented, but at least having it in the `config/default.yaml` file may give a hint that this configuration is needed to enable the emails.