### PR TITLE
Add automated dev setup using Gitpod

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,8 +57,8 @@ before you start working on them :).
 
 First, you should use a server or PC with at least 4GB of RAM. Less RAM may lead to crashes.
 
-Make sure that you have followed 
-[the steps](/support/doc/dependencies.md) 
+Make sure that you have followed
+[the steps](/support/doc/dependencies.md)
 to install the dependencies.
 
 Then clone the sources and install node modules:
@@ -92,6 +92,12 @@ $ sudo -u postgres psql -c "CREATE EXTENSION unaccent;" peertube_dev
 ```
 
 In dev mode, administrator username is **root** and password is **test**.
+
+### Online development
+
+You can get a complete PeerTube development setup with Gitpod, a free one-click online IDE for GitHub:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Chocobozzz/PeerTube)
 
 ### Server side
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+image:
+  file: support/docker/gitpod/Dockerfile
+ports:
+- port: 3000
+  onOpen: open-preview
+- port: 5432
+  onOpen: ignore
+- port: 6379
+  onOpen: ignore
+- port: 9000
+  onOpen: ignore
+tasks:
+- command: redis-server
+- before: export NODE_CONFIG="{\"import\":{\"videos\":{\"torrent\":{\"enabled\":false}}},\"webserver\":{\"hostname\":\"$(gp url 3000 | cut -d/ -f3)\",\"port\":\"443\",\"https\":true}}"
+  init: yarn install --pure-lockfile
+  command: npm run dev

--- a/client/proxy.config.json
+++ b/client/proxy.config.json
@@ -1,0 +1,10 @@
+{
+  "/api": {
+    "target": "http://localhost:9000",
+    "secure": false
+  },
+  "/static": {
+    "target": "http://localhost:9000",
+    "secure": false
+  }
+}

--- a/client/src/environments/environment.hmr.ts
+++ b/client/src/environments/environment.hmr.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   hmr: true,
-  apiUrl: 'http://localhost:9000'
+  apiUrl: ''
 }

--- a/scripts/watch/client.sh
+++ b/scripts/watch/client.sh
@@ -4,4 +4,4 @@ set -eu
 
 cd client
 
-npm run ng -- serve --hmr --configuration hmr --host 0.0.0.0 --disable-host-check --port 3000
+npm run ng -- serve --proxy-config proxy.config.json --hmr --configuration hmr --host 0.0.0.0 --disable-host-check --port 3000

--- a/support/docker/gitpod/Dockerfile
+++ b/support/docker/gitpod/Dockerfile
@@ -1,0 +1,11 @@
+FROM gitpod/workspace-postgres
+
+# Install PeerTube's dependencies.
+RUN sudo apt-get update -q && sudo apt-get install -qy \
+ ffmpeg \
+ openssl \
+ redis-server
+
+# Set up PostgreSQL.
+COPY --chown=gitpod:gitpod setup_postgres.sql /tmp/
+RUN pg_start && psql -h localhost -d postgres --file=/tmp/setup_postgres.sql

--- a/support/docker/gitpod/setup_postgres.sql
+++ b/support/docker/gitpod/setup_postgres.sql
@@ -1,0 +1,6 @@
+create database peertube_dev;
+create user peertube password 'peertube';
+grant all privileges on database peertube_dev to peertube;
+\c peertube_dev
+CREATE EXTENSION pg_trgm;
+CREATE EXTENSION unaccent;


### PR DESCRIPTION
Hi @Chocobozzz! 👋

These days I work for gitpod.io (a free one-click online IDE for GitHub) and I really wanted to contribute a fully-automated dev setup for PeerTube. ⚡️📺⚡️

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/PeerTube)
<img width="1552" alt="Screenshot 2019-04-09 at 18 16 48" src="https://user-images.githubusercontent.com/599268/55816952-b9119200-5af3-11e9-8384-9539ec4b260c.png">

Notes:
- This changes the `hmr` config slightly to make the front-end proxy `/api` requests to `http://localhost:9000`, instead of the front-end referencing the backend directly.
- Please let me know if I should create a dedicated Gitpod config instead or re-using `hmr`.

I hope this can save PeerTube contributors a lot of time and troubles. Please let me know what you think. 🙂