### PR TITLE
_miniature.scss .blur-filter from 5px blur to 20px

### DIFF
--- a/client/src/sass/include/_miniature.scss
+++ b/client/src/sass/include/_miniature.scss
@@ -88,7 +88,7 @@ $play-overlay-width: 18px;
     height: inherit;
 
     &.blur-filter {
-      filter: blur(5px);
+      filter: blur(20px);
       transform : scale(1.03);
     }
   }


### PR DESCRIPTION
A temporary fix, until a better solution is found (maybe #1158 + #1588?), that increases the blur because right now NSFW thumbnails are way too transparent.