### PR TITLE
Add argument to dockerfile to pass options to npm run build

### DIFF
--- a/support/docker/production/Dockerfile.stretch
+++ b/support/docker/production/Dockerfile.stretch
@@ -1,5 +1,10 @@
 FROM node:8-stretch
 
+# Allow to pass extra options to the npm run build
+# eg: --light --light-fr to not build all client languages
+#     (speed up build time if i18n is not required)
+ARG NPM_RUN_BUILD_OPTS
+
 RUN set -ex; \
     if ! command -v gpg > /dev/null; then \
       apt-get update; \
@@ -34,7 +39,7 @@ RUN chown -R peertube:peertube /app
 USER peertube
 
 RUN yarn install --pure-lockfile \
-    && npm run build \
+    && npm run build -- $NPM_RUN_BUILD_OPTS \
     && rm -r ./node_modules ./client/node_modules \
     && yarn install --pure-lockfile --production \
     && yarn cache clean


### PR DESCRIPTION
Allow to pass extra options to the npm run build eg: --light or --light-fr to not build all client languages (speed up build time if i18n is not required)