### PR TITLE
Fix sort order for Greek language

### DIFF
--- a/client/src/locale/source/iso639_en_US.xml
+++ b/client/src/locale/source/iso639_en_US.xml
@@ -122,7 +122,7 @@
         <source>Dzongkha</source>
       </trans-unit>
       <trans-unit id="Modern Greek (1453-)">
-        <source>Modern Greek (1453-)</source>
+        <source>Greek</source>
       </trans-unit>
       <trans-unit id="English">
         <source>English</source>


### PR DESCRIPTION
I could not find the Greek language wile uploading some subtitles and I only found out that it existed when I translated the language list.

I suggest that we drop the "Modern" prefix - we don't call English "Modern English" to distinguish it from "Middle English" either ;)