### PR TITLE
fix: Close modal after clicking on download

### DIFF
--- a/client/src/app/shared/video/modals/video-download.component.ts
+++ b/client/src/app/shared/video/modals/video-download.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core'
 import { VideoDetails } from '../../../shared/video/video-details.model'
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
+import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { I18n } from '@ngx-translate/i18n-polyfill'
 import { Notifier } from '@app/core'
 
@@ -16,6 +16,7 @@ export class VideoDownloadComponent {
   resolutionId: number | string = -1
 
   video: VideoDetails
+  activeModal: NgbActiveModal
 
   constructor (
     private notifier: Notifier,
@@ -26,9 +27,7 @@ export class VideoDownloadComponent {
   show (video: VideoDetails) {
     this.video = video
 
-    const m = this.modalService.open(this.modal)
-    m.result.then(() => this.onClose())
-     .catch(() => this.onClose())
+    this.activeModal = this.modalService.open(this.modal)
 
     this.resolutionId = this.video.files[0].resolution.id
   }
@@ -39,6 +38,7 @@ export class VideoDownloadComponent {
 
   download () {
     window.location.assign(this.getLink())
+    this.activeModal.close()
   }
 
   getLink () {


### PR DESCRIPTION
Use the NgActiveModal method to close it on a click by adding a specific
modalActive object and use it on download function.

See issue: Chocobozzz#1436