### PR TITLE
Add way to set root password by environnement.

### DIFF
--- a/server/initializers/installer.ts
+++ b/server/initializers/installer.ts
@@ -128,6 +128,8 @@ async function createOAuthAdminIfNotExist () {
 
     // Our password is weak so do not validate it
     validatePassword = false
+  } else if (process.env.PT_INITIAL_ROOT_PASSWORD) {
+    password = process.env.PT_INITIAL_ROOT_PASSWORD
   } else {
     password = passwordGenerator(16, true)
   }

--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -204,6 +204,9 @@ logs. You can set another password with:
 $ cd /var/www/peertube/peertube-latest && NODE_CONFIG_DIR=/var/www/peertube/config NODE_ENV=production npm run reset-password -- -u root
 ```
 
+Alternatively you can set the environment variable `PT_INITIAL_ROOT_PASSWORD`,
+to your own administrator password, although it must be 6 characters or more.
+
 ### What now?
 
 Now your instance is up you can:


### PR DESCRIPTION
Add a condition test to pass by environement a predetermined
root password for setting up.

Related work in documentation: https://framagit.org/framasoft/peertube/documentation/merge_requests/16