### PR TITLE
Fix docker-compose setup so Peertube sees correct IP

### DIFF
--- a/support/docker/production/.env
+++ b/support/docker/production/.env
@@ -5,8 +5,7 @@ PEERTUBE_WEBSERVER_PORT=443
 PEERTUBE_WEBSERVER_HTTPS=true
 # If you need more than one IP as trust_proxy
 # pass them as a comma separated array:
-PEERTUBE_TRUST_PROXY=["127.0.0.1"]
-#PEERTUBE_TRUST_PROXY=["127.0.0.1", "loopback", "192.168.1.0/24"]
+PEERTUBE_TRUST_PROXY=["127.0.0.1", "loopback", "172.18.0.0/16"]
 #PEERTUBE_SMTP_USERNAME=
 #PEERTUBE_SMTP_PASSWORD=
 PEERTUBE_SMTP_HOSTNAME=postfix

--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -72,3 +72,10 @@ services:
     labels:
       traefik.enable: "false"
     restart: "always"
+
+networks:
+  default:
+    ipam:
+      driver: default
+      config:
+      - subnet:  172.18.0.0/16


### PR DESCRIPTION
Peertube was not getting the correct client IP on my instance, so here is what I did to fix it.

According to [this comment](https://github.com/docker/compose/issues/4336#issuecomment-273341619), docker-compose essentially uses a random subnet by default, so we have to specify that in docker-compose.yml. The same subnet has to be added to .env as trust_proxy.

Slightly unrelated, but can you tell me a good place to link my [peertube-compose](https://radical.town/@felix/102106907762520601) project? @rigelk suggested I add it to the wiki here, but then I have to add a new page or completely rewrite the "Ansible playbook" page, and I dont know how that should look.