### PR TITLE
WIP: Fix #498

### DIFF
--- a/client/src/app/videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.ts
@@ -4,7 +4,7 @@ import { VideoCommentThreadTree } from '../../../../../../shared/models/videos/v
 import { AuthService } from '../../../core/auth'
 import { Video } from '../../../shared/video/video.model'
 import { VideoComment } from './video-comment.model'
-import { HtmlRendererService } from '@app/shared/renderer'
+import { MarkdownService } from '@app/shared/renderer'
 
 @Component({
   selector: 'my-video-comment',
@@ -28,7 +28,7 @@ export class VideoCommentComponent implements OnInit, OnChanges {
   newParentComments: VideoComment[] = []
 
   constructor (
-    private htmlRenderer: HtmlRendererService,
+    private markdownService: MarkdownService,
     private authService: AuthService
   ) {}
 
@@ -86,7 +86,7 @@ export class VideoCommentComponent implements OnInit, OnChanges {
   }
 
   private async init () {
-    this.sanitizedCommentHTML = await this.htmlRenderer.toSafeHtml(this.comment.text)
+    this.sanitizedCommentHTML = await this.markdownService.textMarkdownToHTML(this.comment.text)
 
     this.newParentComments = this.parentComments.concat([ this.comment ])
   }


### PR DESCRIPTION
Fix #498 

I cant actualy make it works.
For an unknown reason `<br />` got been escaped while the same code doesn't do this in :
```
client/src/app/videos/+video-watch/video-watch.component.ts
```
It seems to be done by `avoidTruncatedTags` in :
```
client/src/app/shared/renderer/markdown.service.ts
```
but again in :
```
client/src/app/videos/+video-watch/video-watch.component.ts
```
this doesn't happend and I cant get why.