### PR TITLE
Rearrange search filter options

### DIFF
--- a/client/src/app/search/search-filters.component.ts
+++ b/client/src/app/search/search-filters.component.ts
@@ -57,12 +57,12 @@ export class SearchFiltersComponent implements OnInit {
         label: this.i18n('Short (< 4 min)')
       },
       {
-        id: 'long',
-        label: this.i18n('Long (> 10 min)')
-      },
-      {
         id: 'medium',
         label: this.i18n('Medium (4-10 min)')
+      },
+      {
+        id: 'long',
+        label: this.i18n('Long (> 10 min)')
       }
     ]
 


### PR DESCRIPTION
Search filter options (for searching by duration) were out of sequence (short, long, medium) and now they are in sequence (short, medium, long)

I am not able to test this change (I do not have a working instance of PeerTube at the moment). I will make updates if necessary.

Closes #1920