### PR TITLE
For Gentoo : update @peertube set (delete vips)

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -230,7 +230,6 @@ dev-vcs/git
 app-arch/unzip
 dev-lang/python:2.7
 www-servers/nginx
-media-libs/vips[jpeg,png,exif]
 
 # Optionnal, client for Let’s Encrypt:
 # app-crypt/certbot


### PR DESCRIPTION
The media-libs/vips package does not exist on Gentoo (and all works fine on my PeerTube POC without vips).