### PR TITLE
For Gentoo : set testing keyword for yarn

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -237,6 +237,15 @@ media-libs/vips[jpeg,png,exif]
 # app-crypt/certbot-nginx
 ```
 
+* If you are on a "stable" Gentoo you need to accept the testing keyword ~amd64 yarn:
+```
+mkdir -p /etc/portage/package.keywords
+cat << EOF >> /etc/portage/package.keywords/peertube
+# required by yarn (argument) for PeerTube
+sys-apps/yarn ~amd64
+EOF
+```
+
 * Compile the peertube set:
 ```
 emerge -a @peertube


### PR DESCRIPTION
Gentoo has not "stable" keyword for yarn (cf source, next line), you need to add "testing" keyword for yarn.
Source : https://packages.gentoo.org/packages/sys-apps/yarn