### PR TITLE
Make video files immutable (fixes #1777)

### DIFF
--- a/server/controllers/api/videos/index.ts
+++ b/server/controllers/api/videos/index.ts
@@ -212,7 +212,7 @@ async function addVideo (req: express.Request, res: express.Response) {
   }
 
   // Move physical file
-  const videoDir = CONFIG.STORAGE.VIDEOS_DIR
+  const videoDir = CONFIG.STORAGE.VIDEOS_TRANSCODING_DIR
   const destination = join(videoDir, video.getVideoFilename(videoFile))
   await move(videoPhysicalFile.path, destination)
   // This is important in case if there is another attempt in the retry process

--- a/server/controllers/static.ts
+++ b/server/controllers/static.ts
@@ -5,6 +5,7 @@ import {
   ROUTE_CACHE_LIFETIME,
   STATIC_DOWNLOAD_PATHS,
   STATIC_MAX_AGE,
+  VIDEO_MAX_AGE,
   STATIC_PATHS,
   WEBSERVER
 } from '../initializers/constants'
@@ -44,12 +45,25 @@ staticRouter.use(
 staticRouter.use(
   STATIC_PATHS.WEBSEED,
   cors(),
-  express.static(CONFIG.STORAGE.VIDEOS_DIR, { fallthrough: false }) // 404 because we don't have this video
+  express.static(CONFIG.STORAGE.VIDEOS_DIR,
+    { fallthrough: false, // 404 because we don't have this video
+      maxAge: VIDEO_MAX_AGE,
+      immutable: true }) // immutable because video files cant change, deletions are handled by the UI
+)
+staticRouter.use(
+  STATIC_PATHS.WEBSEED_TRANSCODING,
+  cors(),
+  express.static(CONFIG.STORAGE.VIDEOS_TRANSCODING_DIR,
+    { fallthrough: false, // 404 because we don't have this video
+      maxAge: 60 * 60 * 1000 }) // one hour, approximately the time for a transcode, so the cache can be cleared after
 )
 staticRouter.use(
   STATIC_PATHS.REDUNDANCY,
   cors(),
-  express.static(CONFIG.STORAGE.REDUNDANCY_DIR, { fallthrough: false }) // 404 because we don't have this video
+  express.static(CONFIG.STORAGE.REDUNDANCY_DIR,
+    { fallthrough: false, // 404 because we don't have this video
+      maxAge: VIDEO_MAX_AGE,
+      immutable: true }) // immutable because video files cant change, deletions are handled by the UI
 )
 
 staticRouter.use(

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -63,7 +63,8 @@ const CONFIG = {
     PREVIEWS_DIR: buildPath(config.get<string>('storage.previews')),
     CAPTIONS_DIR: buildPath(config.get<string>('storage.captions')),
     TORRENTS_DIR: buildPath(config.get<string>('storage.torrents')),
-    CACHE_DIR: buildPath(config.get<string>('storage.cache'))
+    CACHE_DIR: buildPath(config.get<string>('storage.cache')),
+    VIDEOS_TRANSCODING_DIR: buildPath(config.get<string>('storage.videos') + '/transcoding')
   },
   WEBSERVER: {
     SCHEME: config.get<boolean>('webserver.https') === true ? 'https' : 'http',

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -489,6 +489,7 @@ const STATIC_PATHS = {
   THUMBNAILS: '/static/thumbnails/',
   TORRENTS: '/static/torrents/',
   WEBSEED: '/static/webseed/',
+  WEBSEED_TRANSCODING: '/static/webseed/transcoding/',
   REDUNDANCY: '/static/redundancy/',
   STREAMING_PLAYLISTS: {
     HLS: '/static/streaming-playlists/hls'
@@ -503,6 +504,7 @@ const STATIC_DOWNLOAD_PATHS = {
 
 // Cache control
 let STATIC_MAX_AGE = '2h'
+let VIDEO_MAX_AGE = '7d'
 
 // Videos thumbnail size
 const THUMBNAILS_SIZE = {
@@ -599,6 +601,7 @@ if (isTestInstance() === true) {
   REMOTE_SCHEME.WS = 'ws'
 
   STATIC_MAX_AGE = '0'
+  VIDEO_MAX_AGE = '0'
 
   ACTIVITY_PUB.COLLECTION_ITEMS_PER_PAGE = 2
   ACTIVITY_PUB.ACTOR_REFRESH_INTERVAL = 10 * 1000 // 10 seconds
@@ -671,6 +674,7 @@ export {
   JOB_TTL,
   NSFW_POLICY_TYPES,
   STATIC_MAX_AGE,
+  VIDEO_MAX_AGE,
   STATIC_PATHS,
   VIDEO_IMPORT_TIMEOUT,
   VIDEO_PLAYLIST_TYPES,

--- a/server/lib/job-queue/handlers/video-import.ts
+++ b/server/lib/job-queue/handlers/video-import.ts
@@ -143,7 +143,7 @@ async function processFile (downloader: () => Promise<string>, videoImport: Vide
     videoImport.Video.VideoFiles = [ videoFile ]
 
     // Move file
-    videoDestFile = join(CONFIG.STORAGE.VIDEOS_DIR, videoImport.Video.getVideoFilename(videoFile))
+    videoDestFile = join(CONFIG.STORAGE.VIDEOS_TRANSCODING_DIR, videoImport.Video.getVideoFilename(videoFile))
     await move(tempVideoPath, videoDestFile)
     tempVideoPath = null // This path is not used anymore
 

--- a/server/lib/video-transcoding.ts
+++ b/server/lib/video-transcoding.ts
@@ -15,13 +15,11 @@ import { CONFIG } from '../initializers/config'
  * Optimize the original video file and replace it. The resolution is not changed.
  */
 async function optimizeVideofile (video: VideoModel, inputVideoFileArg?: VideoFileModel) {
-  const videosDirectory = CONFIG.STORAGE.VIDEOS_DIR
-  const transcodeDirectory = CONFIG.STORAGE.TMP_DIR
   const newExtname = '.mp4'
 
   const inputVideoFile = inputVideoFileArg ? inputVideoFileArg : video.getOriginalFile()
-  const videoInputPath = join(videosDirectory, video.getVideoFilename(inputVideoFile))
-  const videoTranscodedPath = join(transcodeDirectory, video.id + '-transcoded' + newExtname)
+  const videoInputPath = join(CONFIG.STORAGE.VIDEOS_TRANSCODING_DIR, video.getVideoFilename(inputVideoFile))
+  const videoTranscodedPath = join(CONFIG.STORAGE.TMP_DIR, video.id + '-transcoded' + newExtname)
 
   const transcodeType: TranscodeOptionsType = await canDoQuickTranscode(videoInputPath)
     ? 'quick-transcode'
@@ -43,7 +41,7 @@ async function optimizeVideofile (video: VideoModel, inputVideoFileArg?: VideoFi
     // Important to do this before getVideoFilename() to take in account the new file extension
     inputVideoFile.extname = newExtname
 
-    const videoOutputPath = video.getVideoFilePath(inputVideoFile)
+    const videoOutputPath = join(CONFIG.STORAGE.VIDEOS_DIR, video.getVideoFilename(inputVideoFile))
 
     await onVideoFileTranscoding(video, inputVideoFile, videoTranscodedPath, videoOutputPath)
   } catch (err) {

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1767,7 +1767,11 @@ export class VideoModel extends Model<VideoModel> {
   }
 
   getVideoFilePath (videoFile: VideoFileModel) {
-    return join(CONFIG.STORAGE.VIDEOS_DIR, this.getVideoFilename(videoFile))
+    if (this.waitTranscoding) {
+      return join(CONFIG.STORAGE.VIDEOS_TRANSCODING_DIR, this.getVideoFilename(videoFile))
+    } else {
+      return join(CONFIG.STORAGE.VIDEOS_DIR, this.getVideoFilename(videoFile))
+    }
   }
 
   async createTorrentAndSetInfoHash (videoFile: VideoFileModel) {


### PR DESCRIPTION
This PR puts newly uploaded videos into the folder `storage/videos/transcoding`, and moves them to `storage/videos/` once transcoding is finished. This means that video files are never changed/replaced on disk, and they can easily be cached.

Side note: it would also be good to use to use cache-control: immutable for other static resources like css files, js files and so on to reduce the number of requests ([Improving Performance with Cache-Control: Immutable](https://www.keycdn.com/blog/cache-control-immutable)).

I havent tested this PR yet.