### PR TITLE
Add default caching values

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -13,10 +13,22 @@ server {
   location / { return 301 https://$host$request_uri; }
 }
 
+# Expires map
+map $sent_http_content_type $expires {
+    default                    30d;
+    text/html                  epoch;
+    text/css                   max;
+    application/javascript     2h;
+    ~image/                    max;
+    application/font-woff2     max;
+}
+
 server {
   listen 443 ssl http2;
   listen [::]:443 ssl http2;
   server_name peertube.example.com;
+
+  expires $expires;
 
   # For example with certbot (you need a certificate to run https)
   ssl_certificate      /etc/letsencrypt/live/peertube.example.com/fullchain.pem;


### PR DESCRIPTION
Not caching static files hurts the load [performance](https://github.com/Chocobozzz/PeerTube/issues/1277) and also really the [seo score](https://github.com/Chocobozzz/PeerTube/issues/1080).
Especially the 2h which are configured at the moment.

This should add some [better values](https://www.digitalocean.com/community/tutorials/how-to-implement-browser-caching-with-nginx-s-header-module-on-centos-7#step-3-%E2%80%94-configuring-cache-control-and-expires-headers) for caching.

Please test it if you are running an instance (as this **isn't** tested yet).
Suggestions (for better values) are welcome :smiley: 


To see the google seo score improve, test with Lighthouse or [insight](https://developers.google.com/speed/pagespeed/insights/).
(Disclaimer: I never cached Angular and I never cached with nginx)