### PR TITLE
Add originallyPublishedAt in /videos/upload to the OpenAPI document

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -1062,6 +1062,10 @@ paths:
                 commentsEnabled:
                   description: Enable or disable comments for this video
                   type: string
+                originallyPublishedAt:
+                  description: Date when the content was originally published
+                  type: string
+                  format: date-time
                 scheduleUpdate:
                   $ref: '#/components/schemas/VideoScheduledUpdate'
               required:


### PR DESCRIPTION
When using the API I noticed originallyPublishedAt was missing from the API documentation, but the key/value pair is being accepted in /videos/upload as long as the string has a date-time format.