### PR TITLE
Specify the restrictions on tags array and it's string items

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -863,8 +863,12 @@ paths:
                 tags:
                   description: Video tags (maximum 5 tags each between 2 and 30 characters)
                   type: array
+                  minItems: 1
+                  maxItems: 5
                   items:
                     type: string
+                    minLength: 2
+                    maxLength: 30
                 commentsEnabled:
                   description: Enable or disable comments for this video
                   type: string
@@ -1055,10 +1059,14 @@ paths:
                   description: Video name
                   type: string
                 tags:
-                  description: Video tags
+                  description: Video tags (maximum 5 tags each between 2 and 30 characters)
                   type: array
+                  minItems: 1
+                  maxItems: 5
                   items:
                     type: string
+                    minLength: 2
+                    maxLength: 30
                 commentsEnabled:
                   description: Enable or disable comments for this video
                   type: string
@@ -1164,10 +1172,14 @@ paths:
                   description: Video name
                   type: string
                 tags:
-                  description: Video tags
+                  description: Video tags (maximum 5 tags each between 2 and 30 characters)
                   type: array
+                  minItems: 1
+                  maxItems: 5
                   items:
                     type: string
+                    minLength: 2
+                    maxLength: 30
                 commentsEnabled:
                   description: Enable or disable comments for this video
                   type: string


### PR DESCRIPTION
The OpenAPI specification allows for specific array and string restrictions. See: https://swagger.io/docs/specification/data-models/data-types/ 