### PR TITLE
Cleaner warning of IP address leaking on embedded videos

### DIFF
--- a/client/src/sass/player/peertube-skin.scss
+++ b/client/src/sass/player/peertube-skin.scss
@@ -20,11 +20,6 @@
   .vjs-dock-description {
     font-size: 11px;
 
-    .text::before, .text::after {
-      display: inline-block;
-      content: '\1F308';
-    }
-
     .text::before {
       margin-right: 4px;
     }

--- a/client/src/standalone/videos/embed.ts
+++ b/client/src/standalone/videos/embed.ts
@@ -239,7 +239,7 @@ export class PeerTubeEmbed {
 
       const config: ServerConfig = await configResponse.json()
       const description = config.tracker.enabled && this.warningTitle
-        ? '<span class="text">' + this.player.localize('Uses P2P, others may know your IP is downloading this video.') + '</span>'
+        ? '<span class="text">' + this.player.localize('Watching this video may reveal your IP address to others.') + '</span>'
         : undefined
 
       this.player.dock({


### PR DESCRIPTION
Small change includes removing unnecessary emojis and making the text clearer and easier to understand for people who aren't familiar with words like “P2P” and “IP is downloading” on embedded videos.