### PR TITLE
peertube-import-videos.ts: add --tmpdir, --first, --last and --verbose [level] parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "jsonld": "~1.1.0",
     "jsonld-signatures": "https://github.com/Chocobozzz/jsonld-signatures#rsa2017",
     "lodash": "^4.17.10",
-    "loglevel": "^1.6.3",
     "lru-cache": "^5.1.1",
     "magnet-uri": "^5.1.4",
     "memoizee": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "jsonld": "~1.1.0",
     "jsonld-signatures": "https://github.com/Chocobozzz/jsonld-signatures#rsa2017",
     "lodash": "^4.17.10",
+    "loglevel": "^1.6.3",
     "lru-cache": "^5.1.1",
     "magnet-uri": "^5.1.4",
     "memoizee": "^0.4.14",

--- a/server/tools/cli.ts
+++ b/server/tools/cli.ts
@@ -5,6 +5,7 @@ import { root } from '../../shared/extra-utils/miscs/miscs'
 import { getVideoChannel } from '../../shared/extra-utils/videos/video-channels'
 import { Command } from 'commander'
 import { VideoChannel, VideoPrivacy } from '../../shared/models/videos'
+import { createLogger, format, transports } from 'winston'
 
 let configName = 'PeerTube/CLI'
 if (isTestInstance()) configName += `-${getAppNumber()}`
@@ -119,6 +120,7 @@ function buildCommonVideoOptions (command: Command) {
     .option('-m, --comments-enabled', 'Enable comments')
     .option('-s, --support <support>', 'Video support text')
     .option('-w, --wait-transcoding', 'Wait transcoding before publishing the video')
+    .option('-v, --verbose <verbose>', 'Verbosity, from 0/\'error\' (only report errors) to 4/\'debug\', default is 2/\'info\'', 'info')
 }
 
 async function buildVideoAttributesFromCommander (url: string, command: Command, defaultAttributes: any = {}) {
@@ -175,11 +177,42 @@ function getServerCredentials (program: any) {
          })
 }
 
+function getLogger (logLevel = 'info') {
+  const logLevels = {
+    0: 0,
+    error: 0,
+    1: 1,
+    warn: 1,
+    2: 2,
+    info: 2,
+    3: 3,
+    verbose: 3,
+    4: 4,
+    debug: 4
+  }
+
+  const logger = createLogger({
+    levels: logLevels,
+    format: format.combine(
+      format.splat(),
+      format.simple()
+    ),
+    transports: [
+      new (transports.Console)({
+        level: logLevel
+      })
+    ]
+  })
+
+  return logger
+}
+
 // ---------------------------------------------------------------------------
 
 export {
   version,
   config,
+  getLogger,
   getSettings,
   getNetrc,
   getRemoteObjectOrDie,

--- a/server/tools/cli.ts
+++ b/server/tools/cli.ts
@@ -120,7 +120,7 @@ function buildCommonVideoOptions (command: Command) {
     .option('-m, --comments-enabled', 'Enable comments')
     .option('-s, --support <support>', 'Video support text')
     .option('-w, --wait-transcoding', 'Wait transcoding before publishing the video')
-    .option('-v, --verbose <verbose>', 'Verbosity, from 0/\'error\' (only report errors) to 4/\'debug\', default is 2/\'info\'', 'info')
+    .option('-v, --verbose <verbose>', 'Verbosity, from 0/\'error\' to 4/\'debug\'', 'info')
 }
 
 async function buildVideoAttributesFromCommander (url: string, command: Command, defaultAttributes: any = {}) {

--- a/server/tools/peertube-import-videos.ts
+++ b/server/tools/peertube-import-videos.ts
@@ -36,6 +36,8 @@ command
   .option('--tmpdir <tmpdir>', 'Working directory')
   .option('--since <since>', 'Publication date (inclusive) since which the videos can be imported (YYYY-MM-DD)', parseDate)
   .option('--until <until>', 'Publication date (inclusive) until which the videos can be imported (YYYY-MM-DD)', parseDate)
+  .option('--first <first>', 'Process first n elements of returned playlist')
+  .option('--last <last>', 'Process last n elements of returned playlist')
   .option('-v, --verbose', 'Verbose mode')
   .parse(process.argv)
 
@@ -88,10 +90,17 @@ async function run (url: string, user: UserInfo) {
 
     // Normalize utf8 fields
     if (Array.isArray(info) === true) {
-      infoArray = info.map(i => normalizeObject(i))
+      if (program[ 'first' ]) {
+        infoArray = info.slice(0, program[ 'first' ]).map(i => normalizeObject(i))
+      } else if (program[ 'last' ]) {
+        infoArray = info.slice(0 - program[ 'last' ]).map(i => normalizeObject(i))
+      } else {
+        infoArray = info.map(i => normalizeObject(i))
+      }
     } else {
       infoArray = [ normalizeObject(info) ]
     }
+
     console.log('Will download and upload %d videos.\n', infoArray.length)
 
     for (const info of infoArray) {

--- a/server/tools/peertube-import-videos.ts
+++ b/server/tools/peertube-import-videos.ts
@@ -45,13 +45,13 @@ let log = getLogger(program[ 'verbose' ])
 getServerCredentials(command)
   .then(({ url, username, password }) => {
     if (!program[ 'targetUrl' ]) {
-      exit_error('--target-url field is required.')
+      exitError('--target-url field is required.')
     }
 
     try {
       accessSync(program[ 'tmpdir' ], constants.R_OK | constants.W_OK)
     } catch (e) {
-      exit_error('--tmpdir %s: directory does not exist or is not accessible', program[ 'tmpdir' ])
+      exitError('--tmpdir %s: directory does not exist or is not accessible', program[ 'tmpdir' ])
     }
 
     removeEndSlashes(url)
@@ -61,7 +61,7 @@ getServerCredentials(command)
 
     run(url, user)
       .catch(err => {
-        exit_error(err)
+        exitError(err)
       })
   })
 
@@ -75,7 +75,7 @@ async function run (url: string, user: UserInfo) {
   const options = [ '-j', '--flat-playlist', '--playlist-reverse' ]
   youtubeDL.getInfo(program[ 'targetUrl' ], options, processOptions, async (err, info) => {
     if (err) {
-      exit_error(err.message)
+      exitError(err.message)
     }
 
     let infoArray: any[]
@@ -240,7 +240,7 @@ async function uploadVideoOnPeerTube (parameters: {
 
       await uploadVideo(url, accessToken, videoAttributes)
     } else {
-      exit_error(err.message)
+      exitError(err.message)
     }
   }
 
@@ -363,17 +363,17 @@ async function getAccessTokenOrDie (url: string, user: UserInfo) {
     const res = await login(url, client, user)
     return res.body.access_token
   } catch (err) {
-    exit_error('Cannot authenticate. Please check your username/password.')
+    exitError('Cannot authenticate. Please check your username/password.')
   }
 }
 
 function parseDate (dateAsStr: string): Date {
   if (!/\d{4}-\d{2}-\d{2}/.test(dateAsStr)) {
-    exit_error(`Invalid date passed: ${dateAsStr}. Expected format: YYYY-MM-DD. See help for usage.`);
+    exitError(`Invalid date passed: ${dateAsStr}. Expected format: YYYY-MM-DD. See help for usage.`);
   }
   const date = new Date(dateAsStr);
   if (isNaN(date.getTime())) {
-    exit_error(`Invalid date passed: ${dateAsStr}. See help for usage.`);
+    exitError(`Invalid date passed: ${dateAsStr}. See help for usage.`);
   }
   return date;
 }
@@ -382,7 +382,7 @@ function formatDate (date: Date): string {
   return date.toISOString().split('T')[0];
 }
 
-function exit_error (message:string, ...meta: any[]) {
+function exitError (message:string, ...meta: any[]) {
   // use console.error instead of log.error here
   console.error(message, ...meta)
   process.exit(-1)


### PR DESCRIPTION
The `--tmpdir <tmpdir>` parameter can be used to designate a working directory for downloading and converting imported videos.

Without this parameter PT will unceremoniously (attempt to) dump videos into its own _tools_ directory - where the user might not even have write access.

I refrained from creating a randomly-named tmpdir inside the designated directory as the file names used by pt-i-v are already randomised and as such the chance of a file name collision is negligible.

The program will error out with `--tmpdir directory_name_here: directory does not exist or is not accessible` if the designated directory does not exist.

The `--first n` and `--last n` parameters can be used to limit processing to the first or last _n_ elements of the playlist returned by `youtube-dl`. These parameters can be used (optionally in combination with `--since YYYY-MM-DD` and/or `--until YYYY-MM-DD`) to limit the number of videos which PT needs to process to mirror a channel. This is a somewhat hackish workaround for the fact that `youtube-dl` can only return an entire channel playlist (which can contains thousands of videos) which `peertube-import-videos` then needs to crawl through to import the last few items. An example says more than many words:

Given a mirrored Youtube channel which starts with _500_ videos and daily adds a single video:
- `peertube-import-videos` would need to trudge through _500_ elements on the second day to import element _501_. The next day it would need to walk over _501_ elements to import numner _502_, etc.
- using `--since <date-last-sync> --last 3` this would be limited to a maximum of _3_ elements per day where the automatic duplicate detection would take care of filtering out those videos which have already been imported.

With `--verbose [verbosity]` the chattiness of `peertube-import-videos` can be set from `0` (_only report on errors_) to `4` (_dump all available data_). Use `--verbose 1` to only be notified of successfully imported videos, `--verbose 0` only reports on errors. These levels are useful when `peertube-import-videos` is run in a cron job to mirror a channel as it (at level `1`) only sends mail when new videos are imported or (at level `0`) when errors occur. The default level is `2` (info), when `--verbose` is used without the optional parameter the logging level is set to `3` (debug) to emulate the way this switch worked before this change.