### PR TITLE
Generate OpenAPI client libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@
 /*.asc
 /server/tools/import-mediacore.ts
 /docker-volume/
+/dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ jobs:
       if: env(NO_TESTING) IS blank
       env: TEST_SUITE=lint
     - stage: openapi
-      if: (tag IS present) OR (env(FORCE_OPENAPI) IS present)
       script:
         - scripts/openapi-clients.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,19 +43,19 @@ before_script:
 
 matrix:
   include:
-    - state: test
+    - stage: test
       env: TEST_SUITE=misc
-    - state: test
+    - stage: test
       env: TEST_SUITE=api-1
-    - state: test
+    - stage: test
       env: TEST_SUITE=api-2
-    - state: test
+    - stage: test
       env: TEST_SUITE=api-3
-    - state: test
+    - stage: test
       env: TEST_SUITE=api-4
-    - state: test
+    - stage: test
       env: TEST_SUITE=cli
-    - state: test
+    - stage: test
       env: TEST_SUITE=lint
     - stage: openapi
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,19 +43,20 @@ before_script:
 
 matrix:
   include:
+#    - stage: test
+#      env: TEST_SUITE=misc
+#    - stage: test
+#      env: TEST_SUITE=api-1
+#    - stage: test
+#      env: TEST_SUITE=api-2
+#    - stage: test
+#      env: TEST_SUITE=api-3
+#    - stage: test
+#      env: TEST_SUITE=api-4
+#    - stage: test
+#      env: TEST_SUITE=cli
     - stage: test
-      env: TEST_SUITE=misc
-    - stage: test
-      env: TEST_SUITE=api-1
-    - stage: test
-      env: TEST_SUITE=api-2
-    - stage: test
-      env: TEST_SUITE=api-3
-    - stage: test
-      env: TEST_SUITE=api-4
-    - stage: test
-      env: TEST_SUITE=cli
-    - stage: test
+      if: env(NO_TESTING) IS blank
       env: TEST_SUITE=lint
     - stage: openapi
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,19 @@ node_js:
 
 git:
   depth: 1
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.9
-  postgresql: "9.6"
-
-cache:
-  directories:
-    - $HOME/.cache/yarn
-    - $HOME/fixtures
+#
+#addons:
+#  apt:
+#    sources:
+#      - ubuntu-toolchain-r-test
+#    packages:
+#      - g++-4.9
+#  postgresql: "9.6"
+#
+#cache:
+#  directories:
+#    - $HOME/.cache/yarn
+#    - $HOME/fixtures
 
 sudo: false
 
@@ -26,8 +26,8 @@ services:
 #  - redis-server
   - docker
 
-install:
-  - CC=gcc-4.9 CXX=g++-4.9 yarn install
+#install:
+#  - CC=gcc-4.9 CXX=g++-4.9 yarn install
 
 #before_script:
 #  - wget --no-check-certificate "https://download.cpy.re/ffmpeg/ffmpeg-release-4.0.3-64bit-static.tar.xz"
@@ -49,7 +49,11 @@ install:
 
 script:
 #  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run ci -- "$TEST_SUITE"
-  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run openapi-clients
+  - docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
+    -i /local/support/doc/api/openapi.yaml \
+    -g python \
+    -o /local/dist/api/python
+  - ls -l dist/api/python
 #
 #after_failure:
 #  - cat test1/logs/peertube.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ cache:
     - $HOME/.cache/yarn
     - $HOME/fixtures
 
-#stages:
-#  - name: test
-#    if: env(NO_TESTING) IS blank
-#  - name: openapi
-#    if: (tag IS present) OR (env(FORCE_OPENAPI) IS present)
+stages:
+  - name: test
+    if: env(NO_TESTING) IS false
+  - name: openapi
+    if: (tag IS present) OR (env(FORCE_OPENAPI) IS true)
 
 services:
   - postgresql
@@ -56,7 +56,6 @@ jobs:
 #    - stage: test
 #      env: TEST_SUITE=cli
     - stage: test
-      if: env(NO_TESTING) IS false
       env: TEST_SUITE=lint
     - stage: openapi
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,58 +5,62 @@ node_js:
 
 git:
   depth: 1
-#
-#addons:
-#  apt:
-#    sources:
-#      - ubuntu-toolchain-r-test
-#    packages:
-#      - g++-4.9
-#  postgresql: "9.6"
-#
-#cache:
-#  directories:
-#    - $HOME/.cache/yarn
-#    - $HOME/fixtures
 
-#sudo: false
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.9
+  postgresql: "9.6"
+
+cache:
+  directories:
+    - $HOME/.cache/yarn
+    - $HOME/fixtures
+
+stages:
+  - name: test
+    if: env(NO_TESTING) IS blank
+  - name: openapi
+    if: (tag IS present) OR (env(FORCE_OPENAPI) IS present)
 
 services:
-#  - postgresql
-#  - redis-server
+  - postgresql
+  - redis-server
   - docker
 
 install:
-#  - CC=gcc-4.9 CXX=g++-4.9 yarn install
-  - echo "doing nothing"
+  - CC=gcc-4.9 CXX=g++-4.9 yarn install
 
-#before_script:
-#  - wget --no-check-certificate "https://download.cpy.re/ffmpeg/ffmpeg-release-4.0.3-64bit-static.tar.xz"
-#  - tar xf ffmpeg-release-4.0.3-64bit-static.tar.xz
-#  - mkdir -p $HOME/bin
-#  - cp ffmpeg-*/{ffmpeg,ffprobe} $HOME/bin
-#  - export PATH=$HOME/bin:$PATH
-#  - psql -c "create user peertube with password 'peertube';" -U postgres
+before_script:
+  - wget --no-check-certificate "https://download.cpy.re/ffmpeg/ffmpeg-release-4.0.3-64bit-static.tar.xz"
+  - tar xf ffmpeg-release-4.0.3-64bit-static.tar.xz
+  - mkdir -p $HOME/bin
+  - cp ffmpeg-*/{ffmpeg,ffprobe} $HOME/bin
+  - export PATH=$HOME/bin:$PATH
+  - psql -c "create user peertube with password 'peertube';" -U postgres
 
-#matrix:
-#  include:
-#  - env: TEST_SUITE=misc
-#  - env: TEST_SUITE=api-1
-#  - env: TEST_SUITE=api-2
-#  - env: TEST_SUITE=api-3
-#  - env: TEST_SUITE=api-4
-#  - env: TEST_SUITE=cli
-#  - env: TEST_SUITE=lint
+matrix:
+  include:
+    - env: TEST_SUITE=misc
+    - env: TEST_SUITE=api-1
+    - env: TEST_SUITE=api-2
+    - env: TEST_SUITE=api-3
+    - env: TEST_SUITE=api-4
+    - env: TEST_SUITE=cli
+    - env: TEST_SUITE=lint
+    - stage: openapi
+      script:
+        - scripts/openapi-clients.sh
 
 script:
-#  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run ci -- "$TEST_SUITE"
-  - scripts/openapi-clients.sh
-  - ls -l dist/api/python
-#
-#after_failure:
-#  - cat test1/logs/peertube.log
-#  - cat test2/logs/peertube.log
-#  - cat test3/logs/peertube.log
-#  - cat test4/logs/peertube.log
-#  - cat test5/logs/peertube.log
-#  - cat test6/logs/peertube.log
+  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run ci -- "$TEST_SUITE"
+
+after_failure:
+  - cat test1/logs/peertube.log
+  - cat test2/logs/peertube.log
+  - cat test3/logs/peertube.log
+  - cat test4/logs/peertube.log
+  - cat test5/logs/peertube.log
+  - cat test6/logs/peertube.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ sudo: false
 services:
   - postgresql
   - redis-server
+  - docker
 
 install:
   - CC=gcc-4.9 CXX=g++-4.9 yarn install
@@ -56,3 +57,6 @@ after_failure:
   - cat test4/logs/peertube.log
   - cat test5/logs/peertube.log
   - cat test6/logs/peertube.log
+
+after_success:
+  -

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
 #    - stage: test
 #      env: TEST_SUITE=cli
     - stage: test
-      if: env(NO_TESTING) IS blank
+      if: env(NO_TESTING) IS true
       env: TEST_SUITE=lint
     - stage: openapi
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ services:
 #  - redis-server
   - docker
 
-#install:
-#  - CC=gcc-4.9 CXX=g++-4.9 yarn install
+install:
+  - CC=gcc-4.9 CXX=g++-4.9 yarn install
 
 #before_script:
 #  - wget --no-check-certificate "https://download.cpy.re/ffmpeg/ffmpeg-release-4.0.3-64bit-static.tar.xz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,7 @@ install:
 
 script:
 #  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run ci -- "$TEST_SUITE"
-  - docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-    -i /local/support/doc/api/openapi.yaml \
-    -g python \
-    -o /local/dist/api/python
+  - scripts/openapi-clients.sh
   - ls -l dist/api/python
 #
 #after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ services:
 #  - redis-server
   - docker
 
-#install:
+install:
 #  - CC=gcc-4.9 CXX=g++-4.9 yarn install
+  - echo "doing nothing"
 
 #before_script:
 #  - wget --no-check-certificate "https://download.cpy.re/ffmpeg/ffmpeg-release-4.0.3-64bit-static.tar.xz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,20 @@ before_script:
 
 matrix:
   include:
-    - env: TEST_SUITE=misc
-    - env: TEST_SUITE=api-1
-    - env: TEST_SUITE=api-2
-    - env: TEST_SUITE=api-3
-    - env: TEST_SUITE=api-4
-    - env: TEST_SUITE=cli
-    - env: TEST_SUITE=lint
+    - state: test
+      env: TEST_SUITE=misc
+    - state: test
+      env: TEST_SUITE=api-1
+    - state: test
+      env: TEST_SUITE=api-2
+    - state: test
+      env: TEST_SUITE=api-3
+    - state: test
+      env: TEST_SUITE=api-4
+    - state: test
+      env: TEST_SUITE=cli
+    - state: test
+      env: TEST_SUITE=lint
     - stage: openapi
       script:
         - scripts/openapi-clients.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,18 +43,18 @@ before_script:
 
 jobs:
   include:
-#    - stage: test
-#      env: TEST_SUITE=misc
-#    - stage: test
-#      env: TEST_SUITE=api-1
-#    - stage: test
-#      env: TEST_SUITE=api-2
-#    - stage: test
-#      env: TEST_SUITE=api-3
-#    - stage: test
-#      env: TEST_SUITE=api-4
-#    - stage: test
-#      env: TEST_SUITE=cli
+    - stage: test
+      env: TEST_SUITE=misc
+    - stage: test
+      env: TEST_SUITE=api-1
+    - stage: test
+      env: TEST_SUITE=api-2
+    - stage: test
+      env: TEST_SUITE=api-3
+    - stage: test
+      env: TEST_SUITE=api-4
+    - stage: test
+      env: TEST_SUITE=cli
     - stage: test
       env: TEST_SUITE=lint
     - stage: openapi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ cache:
     - $HOME/.cache/yarn
     - $HOME/fixtures
 
-stages:
-  - name: test
-    if: env(NO_TESTING) IS blank
-  - name: openapi
-    if: (tag IS present) OR (env(FORCE_OPENAPI) IS present)
+#stages:
+#  - name: test
+#    if: env(NO_TESTING) IS blank
+#  - name: openapi
+#    if: (tag IS present) OR (env(FORCE_OPENAPI) IS present)
 
 services:
   - postgresql
@@ -41,7 +41,7 @@ before_script:
   - export PATH=$HOME/bin:$PATH
   - psql -c "create user peertube with password 'peertube';" -U postgres
 
-matrix:
+jobs:
   include:
 #    - stage: test
 #      env: TEST_SUITE=misc
@@ -59,6 +59,7 @@ matrix:
       if: env(NO_TESTING) IS blank
       env: TEST_SUITE=lint
     - stage: openapi
+      if: (tag IS present) OR (env(FORCE_OPENAPI) IS present)
       script:
         - scripts/openapi-clients.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
 #    - stage: test
 #      env: TEST_SUITE=cli
     - stage: test
-      if: env(NO_TESTING) IS true
+      if: env(NO_TESTING) IS false
       env: TEST_SUITE=lint
     - stage: openapi
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,41 +22,39 @@ cache:
 sudo: false
 
 services:
-  - postgresql
-  - redis-server
+#  - postgresql
+#  - redis-server
   - docker
 
-install:
-  - CC=gcc-4.9 CXX=g++-4.9 yarn install
+#install:
+#  - CC=gcc-4.9 CXX=g++-4.9 yarn install
 
-before_script:
-  - wget --no-check-certificate "https://download.cpy.re/ffmpeg/ffmpeg-release-4.0.3-64bit-static.tar.xz"
-  - tar xf ffmpeg-release-4.0.3-64bit-static.tar.xz
-  - mkdir -p $HOME/bin
-  - cp ffmpeg-*/{ffmpeg,ffprobe} $HOME/bin
-  - export PATH=$HOME/bin:$PATH
-  - psql -c "create user peertube with password 'peertube';" -U postgres
+#before_script:
+#  - wget --no-check-certificate "https://download.cpy.re/ffmpeg/ffmpeg-release-4.0.3-64bit-static.tar.xz"
+#  - tar xf ffmpeg-release-4.0.3-64bit-static.tar.xz
+#  - mkdir -p $HOME/bin
+#  - cp ffmpeg-*/{ffmpeg,ffprobe} $HOME/bin
+#  - export PATH=$HOME/bin:$PATH
+#  - psql -c "create user peertube with password 'peertube';" -U postgres
 
-matrix:
-  include:
-  - env: TEST_SUITE=misc
-  - env: TEST_SUITE=api-1
-  - env: TEST_SUITE=api-2
-  - env: TEST_SUITE=api-3
-  - env: TEST_SUITE=api-4
-  - env: TEST_SUITE=cli
-  - env: TEST_SUITE=lint
+#matrix:
+#  include:
+#  - env: TEST_SUITE=misc
+#  - env: TEST_SUITE=api-1
+#  - env: TEST_SUITE=api-2
+#  - env: TEST_SUITE=api-3
+#  - env: TEST_SUITE=api-4
+#  - env: TEST_SUITE=cli
+#  - env: TEST_SUITE=lint
 
 script:
-  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run ci -- "$TEST_SUITE"
-
-after_failure:
-  - cat test1/logs/peertube.log
-  - cat test2/logs/peertube.log
-  - cat test3/logs/peertube.log
-  - cat test4/logs/peertube.log
-  - cat test5/logs/peertube.log
-  - cat test6/logs/peertube.log
-
-after_success:
-  -
+#  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run ci -- "$TEST_SUITE"
+  - NODE_PENDING_JOB_WAIT=2000 travis_retry npm run openapi-clients
+#
+#after_failure:
+#  - cat test1/logs/peertube.log
+#  - cat test2/logs/peertube.log
+#  - cat test3/logs/peertube.log
+#  - cat test4/logs/peertube.log
+#  - cat test5/logs/peertube.log
+#  - cat test6/logs/peertube.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ git:
 #    - $HOME/.cache/yarn
 #    - $HOME/fixtures
 
-sudo: false
+#sudo: false
 
 services:
 #  - postgresql

--- a/openapi/go.yaml
+++ b/openapi/go.yaml
@@ -1,0 +1,1 @@
+packageName: peertube-api

--- a/openapi/kotlin.yaml
+++ b/openapi/kotlin.yaml
@@ -1,0 +1,1 @@
+packageName: peertube-api

--- a/openapi/python.yaml
+++ b/openapi/python.yaml
@@ -1,0 +1,3 @@
+packageName: peertube_api
+projectName: peertube-api
+

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ci": "scripty",
     "release": "scripty",
     "nightly": "scripty",
+    "openapi-clients": "scripty",
     "client-report": "scripty"
   },
   "husky": {

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -4,12 +4,18 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+OUT_DIR=dist/api/python
 
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -i /local/support/doc/api/openapi.yaml \
     -c /local/openapi/python.yaml
     -g python \
-    -o /local/dist/api/python
+    --git-user-id "${GIT_USER_ID}" \
+    --git-repo-id "${GIT_REPO_ID}" \
+    -o /local/$OUT_DIR
+
+# Docker uses root so we need to undo that
+sudo chown -R `id -u` $OUT_DIR
 
 # Will use #$GIT_USER $GIT_REPO_ID and $GIT_TOKEN to update repo upon build
 bash $OUT_DIR/git_push.sh "${GIT_USER_ID}" "${GIT_REPO_ID}"

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
+# Unofficial bash strict mode
+# https://web.archive.org/web/20190115051613/https://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
 
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -i /local/support/doc/api/openapi.yaml \
     -g python \
     -o /local/dist/api/python
+
+# Will use #$GIT_USER $GIT_REPO_ID and $GIT_TOKEN to update repo upon build
+dist/api/python/git_push.sh

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-    -i support/doc/api/openapi.yaml
+    -i /local/support/doc/api/openapi.yaml
     -l python \
     -o /local/out/python

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-    -i /local/support/doc/api/openapi.yaml
-    -l python \
-    -o /local/out/python
+    -i /local/support/doc/api/openapi.yaml \
+    -g python \
+    -o /local/dist/api/python

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -3,4 +3,5 @@
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -i support/doc/api/openapi.yaml
     -g python \
+    -l python \
     -o /local/out/python

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+# Required environment vars
+# =========================
+# API_LANGS
+#   A ':' delimited list of the client lib languages to be generated
+# API_GIT_USER
+#   The github username
+# API_REPO_PREFIX
+#   The prefix for the client lib repositories
+# GIT_TOKEN
+#   A personal access token for github for pushing to repos
+#   !!!This is a secret and shouldn't be logged publicly!!!
+
+# (Optional environment vars)
+# ===========================
+# API_COMMIT_MSG
+#   A message to use when committing to the lib repo
+
 # Unofficial bash strict mode
 # https://web.archive.org/web/20190115051613/https://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euvo pipefail

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 
 OUT_DIR=dist/api/python
 
+if ! [ -e $OUT_DIR ] ; then
+    git clone "https://github.com/${GIT_USER_ID}/${GIT_REPO_ID}.git" "$OUT_DIR"
+fi
+
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -i /local/support/doc/api/openapi.yaml \
     -c /local/openapi/python.yaml \
@@ -15,7 +19,9 @@ docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -o /local/$OUT_DIR
 
 # Docker uses root so we need to undo that
-sudo chown -R `id -u` $OUT_DIR
+sudo chown -R `id -u` "$OUT_DIR"
 
 # Will use #$GIT_USER $GIT_REPO_ID and $GIT_TOKEN to update repo upon build
-bash $OUT_DIR/git_push.sh "${GIT_USER_ID}" "${GIT_REPO_ID}"
+cd "$OUT_DIR"
+git remote set-url origin https://${GIT_USER_ID}:${GIT_TOKEN}@github.com/${GIT_USER_ID}/${GIT_REPO_ID}.git
+bash git_push.sh "${GIT_USER_ID}" "${GIT_REPO_ID}"

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -8,7 +8,7 @@ OUT_DIR=dist/api/python
 
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -i /local/support/doc/api/openapi.yaml \
-    -c /local/openapi/python.yaml
+    -c /local/openapi/python.yaml \
     -g python \
     --git-user-id "${GIT_USER_ID}" \
     --git-repo-id "${GIT_REPO_ID}" \

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -4,7 +4,7 @@
 set -euvo pipefail
 IFS=$'\n\t '
 
-for lang in ${API_LANGS} ; do
+for lang in ${API_LANGS//:/ } ; do
 (
     echo "Generating client API libs for $lang"
 

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -2,6 +2,5 @@
 
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -i support/doc/api/openapi.yaml
-    -g python \
     -l python \
     -o /local/out/python

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -8,11 +8,11 @@ for lang in ${API_LANGS} ; do
 (
     echo "Generating client API libs for $lang"
 
-    out_dir=dist/api/python
+    out_dir="dist/api/$lang"
     repo_id="${API_REPO_PREFIX}${lang}"
     git_remote="https://${API_GIT_USER}:${GIT_TOKEN}@github.com/${API_GIT_USER}/${repo_id}.git"
     if ! [ -e "$out_dir" ] ; then
-        git clone "https://github.com/${API_GIT_USER}/${repo_id}${lang}.git" "$out_dir"
+        git clone "https://github.com/${API_GIT_USER}/${repo_id}.git" "$out_dir"
     fi
 
     docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -7,8 +7,9 @@ IFS=$'\n\t'
 
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -i /local/support/doc/api/openapi.yaml \
+    -c /local/openapi/python.yaml
     -g python \
     -o /local/dist/api/python
 
 # Will use #$GIT_USER $GIT_REPO_ID and $GIT_TOKEN to update repo upon build
-bash dist/api/python/git_push.sh
+bash $OUT_DIR/git_push.sh "${GIT_USER_ID}" "${GIT_REPO_ID}"

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -11,4 +11,4 @@ docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
     -o /local/dist/api/python
 
 # Will use #$GIT_USER $GIT_REPO_ID and $GIT_TOKEN to update repo upon build
-dist/api/python/git_push.sh
+bash dist/api/python/git_push.sh

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
+    -i support/doc/api/openapi.yaml
+    -g python \
+    -o /local/out/python

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -47,7 +47,7 @@ for lang in ${API_LANGS//:/ } ; do
     cd "$out_dir"
     git remote set-url origin "$git_remote"
     # Make sure something has changed
-    if [[ `git status -c | wc -l` = 0 ]] ; then
+    if [[ `git status -s | wc -l` = 0 ]] ; then
         echo "No changes from previous version"
         continue
     fi

--- a/scripts/openapi-clients.sh
+++ b/scripts/openapi-clients.sh
@@ -46,6 +46,11 @@ for lang in ${API_LANGS//:/ } ; do
     # Commit and push changes to the remote
     cd "$out_dir"
     git remote set-url origin "$git_remote"
+    # Make sure something has changed
+    if [[ `git status -c | wc -l` = 0 ]] ; then
+        echo "No changes from previous version"
+        continue
+    fi
     git add .
     git commit -m "${API_COMMIT_MSG:-"Minor update"}"
     git push

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -13,6 +13,7 @@ info:
     altText: PeerTube Project Homepage
   description: |
     # Introduction
+
     The PeerTube API is built on HTTP(S). Our API is RESTful. It has predictable
     resource URLs. It returns HTTP response codes to indicate errors. It also
     accepts and returns JSON in the HTTP body. You can use your favorite
@@ -22,11 +23,13 @@ info:
     which generates a client SDK in the language of your choice.
 
     # Authentication
+
     When you sign up for an account, you are given the possibility to generate
     sessions, and authenticate using this session token. One session token can
     currently be used at a time.
 
     # Errors
+
     The API uses standard HTTP status codes to indicate the success or failure
     of the API call. The body of the response will be JSON in the following
     format.


### PR DESCRIPTION
Related to #2052 "Publish OpenAPI clients" this pullrequest introduces a `openapi` stage in `.travis.yaml` that can be triggered either forcefully or by pushing a tag.  

# Stages

The [travis doc on stages](https://docs.travis-ci.com/user/build-stages/) explains the concepts.

**test**

All previous jobs in the `matrix:` are now in the `jobs:` dict and have been put into this stage. It is **activated by default** but can be deactivated by **`NO_TESTING`**=true in the repository setting (or environment variable)

**openapi**

This stage will generate and then publish the clients passed to the job on travis. 

# Client lib generation

The repository setting (or environment var) **`API_LANGS`** is a `:` delimited list of client libs to generate.
A list of possible clients can be found [here](https://github.com/OpenAPITools/openapi-generator/wiki/API-client-generator-HOWTO).

**Requirements**

A parameter config in the `/openapi` folder for the client e.g `/openapi/python.yaml`. The params can be generated by running the docker openapi-cli (see `/scripts/openapi-clients.sh`) e.g `openapitools/openapi-generator-cli config-help -g python`

# Client lib publication

The client lib will be pushed to a github repository of the format `"https://github.com/${API_GIT_USER}/${API_REPO_PREFIX}${lang}.git"`.

See `/scripts/openapi-clients.sh` for the required environment variables.

# Examples

https://github.com/LoveIsGrief/peertube-api-kotlin

https://github.com/LoveIsGrief/peertube-api-go

https://github.com/LoveIsGrief/peertube-api-python

# TODO in down the line

- versioning: each package config can have a version (maybe the same as peertube?)
- the python template doesn't like a multi-lined description (see the repo above and it will be glaringly obvious)
- Modify the `.travis.yaml` of each published client lib to:

   - run tests
   - publish to their package index

- List each published package in the API documentation.