### PR TITLE
Add missing downloadEnabled option

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -878,6 +878,9 @@ paths:
                 commentsEnabled:
                   description: Enable or disable comments for this video
                   type: string
+                downloadEnabled:
+                  description: Enable or disable download for this video
+                  type: string
                 originallyPublishedAt:
                   description: Date when the content was originally published
                   type: string
@@ -1087,6 +1090,9 @@ paths:
                 commentsEnabled:
                   description: Enable or disable comments for this video
                   type: string
+                downloadEnabled:
+                  description: Enable or disable download for this video
+                  type: string
                 originallyPublishedAt:
                   description: Date when the content was originally published
                   type: string
@@ -1208,6 +1214,9 @@ paths:
                     maxLength: 30
                 commentsEnabled:
                   description: Enable or disable comments for this video
+                  type: string
+                downloadEnabled:
+                  description: Enable or disable download for this video
                   type: string
                 scheduleUpdate:
                   $ref: '#/components/schemas/VideoScheduledUpdate'


### PR DESCRIPTION
Added the downloadEnabled option to the OpenAPI doc, but did not define a default value (see below), because posted value can be any 'truthy' or 'falsey' string, as far as I know.

```yaml
downloadEnabled:
  description: Enable or disable download for this video
  type: string
  default: 'true'
```