### PR TITLE
Fix subscribe via RSS button

### DIFF
--- a/client/src/app/shared/user-subscription/subscribe-button.component.html
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.html
@@ -46,7 +46,7 @@
       <div class="dropdown-divider"></div>
 
       <h6 class="dropdown-header" i18n>Using a syndication feed</h6>
-      <button (click)="rssOpen()" class="dropdown-item" i18n>Subscribe via RSS</button>
+      <a [href]="rssUri" target="_blank" class="dropdown-item" i18n>Subscribe via RSS</a>
 
     </div>
   </div>

--- a/client/src/app/shared/user-subscription/subscribe-button.component.ts
+++ b/client/src/app/shared/user-subscription/subscribe-button.component.ts
@@ -36,6 +36,14 @@ export class SubscribeButtonComponent implements OnInit {
     return this.videoChannel.url
   }
 
+  get rssUri () {
+    const rssFeed = this.videoService
+                      .getVideoChannelFeedUrls(this.videoChannel.id)
+                      .find(i => i.format === FeedFormat.RSS)
+
+    return rssFeed.url
+  }
+
   ngOnInit () {
     if (this.isUserLoggedIn()) {
       this.userSubscriptionService.doesSubscriptionExist(this.channelHandle)
@@ -99,13 +107,5 @@ export class SubscribeButtonComponent implements OnInit {
 
   gotoLogin () {
     this.router.navigate([ '/login' ])
-  }
-
-  rssOpen () {
-    const rssFeed = this.videoService
-                      .getVideoChannelFeedUrls(this.videoChannel.id)
-                      .find(i => i.format === FeedFormat.RSS)
-
-    window.open(rssFeed.url)
   }
 }


### PR DESCRIPTION
Currently the button to subscribe via RSS to a channel is not working when using the Firefox browser. This is due to the automatic content-disposition Firefox assigns on links ending with file extensions (.xml and .atom), resulting in a download modal instead of showing it inline in a browser window or tab.

<img src="https://user-images.githubusercontent.com/673542/53042502-b47f1480-3486-11e9-9ba3-b105e9cf2141.png" alt="A screenshot of the RSS dropdown on PeerTube" width="250" />

This pull request does not fix the automatic content-disposition, but makes the button into a link, so that Firefox users can at least use the right-click context menu and copy the link location.

This problem was already mentioned in issue #1648 , but not fixed and further discussion let it to be labeled as a future enhancement. I suggest to implement this fix now and leave the future enhancement (adding Subscribe via Atom and Subscribe via JSON) for later.