### PR TITLE
Add 'Most liked videos' page

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -218,6 +218,7 @@
             <select id="instanceDefaultClientRoute" formControlName="defaultClientRoute">
               <option i18n value="/videos/overview">Videos Discover</option>
               <option i18n value="/videos/trending">Videos Trending</option>
+              <option i18n value="/videos/most-liked">Most Liked Videos</option>
               <option i18n value="/videos/recently-added">Videos Recently Added</option>
               <option i18n value="/videos/local">Local videos</option>
             </select>

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -71,6 +71,11 @@
           <ng-container i18n>Trending</ng-container>
         </a>
 
+        <a routerLink="/videos/most-liked" routerLinkActive="active">
+          <my-global-icon iconName="like"></my-global-icon>
+          <ng-container i18n>Most liked</ng-container>
+        </a>
+
         <a routerLink="/videos/recently-added" routerLinkActive="active">
           <my-global-icon iconName="recently-added"></my-global-icon>
           <ng-container i18n>Recently added</ng-container>

--- a/client/src/app/videos/video-list/index.ts
+++ b/client/src/app/videos/video-list/index.ts
@@ -1,3 +1,4 @@
 export * from './video-local.component'
 export * from './video-recently-added.component'
 export * from './video-trending.component'
+export * from './video-most-liked.component'

--- a/client/src/app/videos/video-list/video-most-liked.component.ts
+++ b/client/src/app/videos/video-list/video-most-liked.component.ts
@@ -1,0 +1,71 @@
+import { Component, OnInit } from '@angular/core'
+import { ActivatedRoute, Router } from '@angular/router'
+import { immutableAssign } from '@app/shared/misc/utils'
+import { AuthService } from '../../core/auth'
+import { AbstractVideoList } from '../../shared/video/abstract-video-list'
+import { VideoSortField } from '../../shared/video/sort-field.type'
+import { VideoService } from '../../shared/video/video.service'
+import { I18n } from '@ngx-translate/i18n-polyfill'
+import { ScreenService } from '@app/shared/misc/screen.service'
+import { Notifier, ServerService } from '@app/core'
+import { HooksService } from '@app/core/plugins/hooks.service'
+
+@Component({
+  selector: 'my-videos-most-liked',
+  styleUrls: [ '../../shared/video/abstract-video-list.scss' ],
+  templateUrl: '../../shared/video/abstract-video-list.html'
+})
+export class VideoMostLikedComponent extends AbstractVideoList implements OnInit {
+  titlePage: string
+  defaultSort: VideoSortField = '-likes'
+
+  useUserVideoLanguagePreferences = true
+
+  constructor (
+    protected i18n: I18n,
+    protected router: Router,
+    protected serverService: ServerService,
+    protected route: ActivatedRoute,
+    protected notifier: Notifier,
+    protected authService: AuthService,
+    protected screenService: ScreenService,
+    private videoService: VideoService,
+    private hooks: HooksService
+  ) {
+    super()
+  }
+
+  ngOnInit () {
+    super.ngOnInit()
+
+    this.generateSyndicationList()
+
+    this.serverService.configLoaded.subscribe(
+      () => {
+        this.titlePage = this.i18n('Most liked videos')
+        this.titleTooltip = this.i18n('Videos that have the higher number of likes.')
+      })
+  }
+
+  getVideosObservable (page: number) {
+    const newPagination = immutableAssign(this.pagination, { currentPage: page })
+    const params = {
+      videoPagination: newPagination,
+      sort: this.sort,
+      categoryOneOf: this.categoryOneOf,
+      languageOneOf: this.languageOneOf
+    }
+
+    return this.hooks.wrapObsFun(
+      this.videoService.getVideos.bind(this.videoService),
+      params,
+      'common',
+      'filter:api.most-liked-videos.videos.list.params',
+      'filter:api.most-liked-videos.videos.list.result'
+    )
+  }
+
+  generateSyndicationList () {
+    this.syndicationItems = this.videoService.getVideoFeedUrls(this.sort, undefined, this.categoryOneOf)
+  }
+}

--- a/client/src/app/videos/videos-routing.module.ts
+++ b/client/src/app/videos/videos-routing.module.ts
@@ -4,6 +4,7 @@ import { VideoLocalComponent } from '@app/videos/video-list/video-local.componen
 import { MetaGuard } from '@ngx-meta/core'
 import { VideoRecentlyAddedComponent } from './video-list/video-recently-added.component'
 import { VideoTrendingComponent } from './video-list/video-trending.component'
+import { VideoMostLikedComponent } from './video-list/video-most-liked.component'
 import { VideosComponent } from './videos.component'
 import { VideoUserSubscriptionsComponent } from '@app/videos/video-list/video-user-subscriptions.component'
 import { VideoOverviewComponent } from '@app/videos/video-list/video-overview.component'
@@ -33,6 +34,19 @@ const videosRoutes: Routes = [
           reuse: {
             enabled: true,
             key: 'trending-videos-list'
+          }
+        }
+      },
+      {
+        path: 'most-liked',
+        component: VideoMostLikedComponent,
+        data: {
+          meta: {
+            title: 'Most liked videos'
+          },
+          reuse: {
+            enabled: true,
+            key: 'most-liked-videos-list'
           }
         }
       },

--- a/client/src/app/videos/videos.module.ts
+++ b/client/src/app/videos/videos.module.ts
@@ -3,6 +3,7 @@ import { VideoLocalComponent } from '@app/videos/video-list/video-local.componen
 import { SharedModule } from '../shared'
 import { VideoRecentlyAddedComponent } from './video-list/video-recently-added.component'
 import { VideoTrendingComponent } from './video-list/video-trending.component'
+import { VideoMostLikedComponent } from './video-list/video-most-liked.component'
 import { VideosRoutingModule } from './videos-routing.module'
 import { VideosComponent } from './videos.component'
 import { VideoUserSubscriptionsComponent } from '@app/videos/video-list/video-user-subscriptions.component'
@@ -18,6 +19,7 @@ import { VideoOverviewComponent } from '@app/videos/video-list/video-overview.co
     VideosComponent,
 
     VideoTrendingComponent,
+    VideoMostLikedComponent,
     VideoRecentlyAddedComponent,
     VideoLocalComponent,
     VideoUserSubscriptionsComponent,

--- a/shared/models/plugins/client-hook.model.ts
+++ b/shared/models/plugins/client-hook.model.ts
@@ -5,6 +5,10 @@ export const clientFilterHookObject = {
   'filter:api.trending-videos.videos.list.params': true,
   'filter:api.trending-videos.videos.list.result': true,
 
+  // Filter params/result of the function that fetch videos of the trending page
+  'filter:api.most-liked-videos.videos.list.params': true,
+  'filter:api.most-liked-videos.videos.list.result': true,
+
   // Filter params/result of the function that fetch videos of the local page
   'filter:api.local-videos.videos.list.params': true,
   'filter:api.local-videos.videos.list.result': true,


### PR DESCRIPTION
Related to #2095 

![Capture d’écran - 2019-10-01 à 23 08 23](https://user-images.githubusercontent.com/1588144/66001052-fc482e80-e4a0-11e9-963a-8014b476d36d.png)

This PR adds a "Most liked videos" page. It can be accessed from main menu.

Videos listed in this page are retrieved from the already existing API endpoint:

`/api/v1/videos/?sort=-likes`

- [x] Most liked video page
- [x] Menu entry
- [x] Allow to set Most liked video page as Default client route
