### PR TITLE
Soft delete comments so that entire thread is not deleted

### DIFF
--- a/client/src/app/videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.html
@@ -1,22 +1,45 @@
 <div class="root-comment">
-  <img [src]="comment.accountAvatarUrl" alt="Avatar" />
+  <img
+    *ngIf="!comment.isDeleted"
+    class="comment-avatar"
+    [src]="comment.accountAvatarUrl"
+    alt="Avatar"
+  />
+
+  <span
+    *ngIf="comment.isDeleted"
+    class="comment-avatar"
+  ></span>
 
   <div class="comment">
-    <div *ngIf="highlightedComment === true" class="highlighted-comment" i18n>Highlighted comment</div>
+    <ng-container *ngIf="!comment.isDeleted">
+      <div *ngIf="highlightedComment === true" class="highlighted-comment" i18n>Highlighted comment</div>
 
-    <div class="comment-account-date">
-      <a [href]="comment.account.url"  target="_blank" rel="noopener noreferrer" class="comment-account">{{ comment.by }}</a>
-      <a [routerLink]="['/videos/watch', video.uuid, { 'threadId': comment.threadId }]" class="comment-date">{{ comment.createdAt | myFromNow }}</a>
-    </div>
-    <div class="comment-html" [innerHTML]="sanitizedCommentHTML"></div>
+      <div class="comment-account-date">
+        <a [href]="comment.account.url"  target="_blank" rel="noopener noreferrer" class="comment-account">{{ comment.by }}</a>
+        <a [routerLink]="['/videos/watch', video.uuid, { 'threadId': comment.threadId }]" class="comment-date">{{ comment.createdAt | myFromNow }}</a>
+      </div>
+      <div class="comment-html" [innerHTML]="sanitizedCommentHTML"></div>
 
-    <div class="comment-actions">
-      <div *ngIf="isUserLoggedIn()" (click)="onWantToReply()" class="comment-action-reply" i18n>Reply</div>
-      <div *ngIf="isRemovableByUser()" (click)="onWantToDelete()" class="comment-action-delete" i18n>Delete</div>
-    </div>
+      <div class="comment-actions">
+        <div *ngIf="isUserLoggedIn()" (click)="onWantToReply()" class="comment-action-reply" i18n>Reply</div>
+        <div *ngIf="isRemovableByUser()" (click)="onWantToDelete()" class="comment-action-delete" i18n>Delete</div>
+      </div>
+    </ng-container>
+
+    <ng-container *ngIf="comment.isDeleted">
+      <div class="comment-account-date">
+        <span class="comment-account" i18n>Deleted</span>
+        <a [routerLink]="['/videos/watch', video.uuid, { 'threadId': comment.threadId }]" class="comment-date">{{ comment.createdAt | myFromNow }}</a>
+      </div>
+
+      <div *ngIf="comment.isDeleted" class="comment-html comment-html-deleted">
+        <i i18n>This comment has been deleted</i>
+      </div>
+    </ng-container>
 
     <my-video-comment-add
-      *ngIf="isUserLoggedIn() && inReplyToCommentId === comment.id"
+      *ngIf="!comment.isDeleted && isUserLoggedIn() && inReplyToCommentId === comment.id"
       [user]="user"
       [video]="video"
       [parentComment]="comment"

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.scss
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.scss
@@ -5,7 +5,7 @@
   font-size: 15px;
   display: flex;
 
-  img {
+  .comment-avatar {
     @include avatar(36px);
 
     margin-top: 5px;
@@ -48,6 +48,7 @@
 
     .comment-html {
       @include peertube-word-wrap;
+      margin-bottom: 10px;
 
       // Mentions
       ::ng-deep a {
@@ -61,10 +62,14 @@
         }
 
       }
+
+      &.comment-html-deleted {
+        color: $grey-foreground-color;
+      }
     }
 
     .comment-actions {
-      margin: 10px 0;
+      margin-bottom: 10px;
       display: flex;
 
       .comment-action-reply,
@@ -100,7 +105,7 @@
   }
 
   .root-comment {
-    img { margin-right: 10px; }
+    .comment-avatar { margin-right: 10px; }
   }
 }
 

--- a/client/src/app/videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comment.component.ts
@@ -78,7 +78,7 @@ export class VideoCommentComponent implements OnInit, OnChanges {
   }
 
   isRemovableByUser () {
-    return this.isUserLoggedIn() &&
+    return this.comment.account && this.isUserLoggedIn() &&
       (
         this.user.account.id === this.comment.account.id ||
         this.user.hasRight(UserRight.REMOVE_ANY_VIDEO_COMMENT)

--- a/client/src/app/videos/+video-watch/comment/video-comment.model.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comment.model.ts
@@ -12,6 +12,8 @@ export class VideoComment implements VideoCommentServerModel {
   videoId: number
   createdAt: Date | string
   updatedAt: Date | string
+  deletedAt: Date | string
+  isDeleted: boolean
   account: AccountInterface
   totalReplies: number
   by: string
@@ -28,14 +30,18 @@ export class VideoComment implements VideoCommentServerModel {
     this.videoId = hash.videoId
     this.createdAt = new Date(hash.createdAt.toString())
     this.updatedAt = new Date(hash.updatedAt.toString())
+    this.deletedAt = hash.deletedAt ? new Date(hash.deletedAt.toString()) : null
+    this.isDeleted = hash.isDeleted
     this.account = hash.account
     this.totalReplies = hash.totalReplies
 
-    this.by = Actor.CREATE_BY_STRING(this.account.name, this.account.host)
-    this.accountAvatarUrl = Actor.GET_ACTOR_AVATAR_URL(this.account)
+    if (this.account) {
+      this.by = Actor.CREATE_BY_STRING(this.account.name, this.account.host)
+      this.accountAvatarUrl = Actor.GET_ACTOR_AVATAR_URL(this.account)
 
-    const absoluteAPIUrl = getAbsoluteAPIUrl()
-    const thisHost = new URL(absoluteAPIUrl).host
-    this.isLocal = this.account.host.trim() === thisHost
+      const absoluteAPIUrl = getAbsoluteAPIUrl()
+      const thisHost = new URL(absoluteAPIUrl).host
+      this.isLocal = this.account.host.trim() === thisHost
+    }
   }
 }

--- a/server/controllers/activitypub/client.ts
+++ b/server/controllers/activitypub/client.ts
@@ -308,13 +308,16 @@ async function videoCommentController (req: express.Request, res: express.Respon
 
   const threadParentComments = await VideoCommentModel.listThreadParentComments(videoComment, undefined)
   const isPublic = true // Comments are always public
-  const audience = getAudience(videoComment.Account.Actor, isPublic)
+  let videoCommentObject = videoComment.toActivityPubObject(threadParentComments)
 
-  const videoCommentObject = audiencify(videoComment.toActivityPubObject(threadParentComments), audience)
+  if (videoComment.Account) {
+    const audience = getAudience(videoComment.Account.Actor, isPublic)
+    videoCommentObject = audiencify(videoCommentObject, audience)
 
-  if (req.path.endsWith('/activity')) {
-    const data = buildCreateActivity(videoComment.url, videoComment.Account.Actor, videoCommentObject, audience)
-    return activityPubResponse(activityPubContextify(data), res)
+    if (req.path.endsWith('/activity')) {
+      const data = buildCreateActivity(videoComment.url, videoComment.Account.Actor, videoCommentObject, audience)
+      return activityPubResponse(activityPubContextify(data), res)
+    }
   }
 
   return activityPubResponse(activityPubContextify(videoCommentObject), res)

--- a/server/helpers/custom-validators/activitypub/video-comments.ts
+++ b/server/helpers/custom-validators/activitypub/video-comments.ts
@@ -3,10 +3,27 @@ import { ACTIVITY_PUB } from '../../../initializers/constants'
 import { exists, isArray, isDateValid } from '../misc'
 import { isActivityPubUrlValid } from './misc'
 
+function isTypeValid (comment: any): boolean {
+  if (comment.type === 'Note') return true
+
+  if (comment.type === 'Tombstone' && comment.formerType === 'Note') return true
+
+  return false
+}
+
 function sanitizeAndCheckVideoCommentObject (comment: any) {
-  if (!comment || comment.type !== 'Note') return false
+  if (!comment) return false
+
+  if (!isTypeValid(comment)) return false
 
   normalizeComment(comment)
+
+  if (comment.type === 'Tombstone') {
+    return isActivityPubUrlValid(comment.id) &&
+      isDateValid(comment.published) &&
+      isDateValid(comment.deleted) &&
+      isActivityPubUrlValid(comment.url)
+  }
 
   return isActivityPubUrlValid(comment.id) &&
     isCommentContentValid(comment.content) &&

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -14,7 +14,7 @@ import { CONFIG, registerConfigChangedHandler } from './config'
 
 // ---------------------------------------------------------------------------
 
-const LAST_MIGRATION_VERSION = 445
+const LAST_MIGRATION_VERSION = 450
 
 // ---------------------------------------------------------------------------
 

--- a/server/initializers/migrations/0450-soft-delete-video-comments.ts
+++ b/server/initializers/migrations/0450-soft-delete-video-comments.ts
@@ -1,0 +1,36 @@
+import * as Sequelize from 'sequelize'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction,
+  queryInterface: Sequelize.QueryInterface,
+  sequelize: Sequelize.Sequelize,
+  db: any
+}): Promise<void> {
+  {
+    const data = {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      defaultValue: null
+    }
+
+    await utils.queryInterface.changeColumn('videoComment', 'accountId', data)
+  }
+
+  {
+    const data = {
+      type: Sequelize.DATE,
+      allowNull: true,
+      defaultValue: null
+    }
+    await utils.queryInterface.addColumn('videoComment', 'deletedAt', data)
+  }
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export {
+  up,
+  down
+}

--- a/server/lib/video-comment.ts
+++ b/server/lib/video-comment.ts
@@ -73,9 +73,16 @@ function buildFormattedCommentTree (resultList: ResultList<VideoCommentModel>): 
   return thread
 }
 
+function markCommentAsDeleted (comment: MCommentOwnerVideoReply): void {
+  comment.text = ''
+  comment.deletedAt = new Date()
+  comment.accountId = null
+}
+
 // ---------------------------------------------------------------------------
 
 export {
   createVideoComment,
-  buildFormattedCommentTree
+  buildFormattedCommentTree,
+  markCommentAsDeleted
 }

--- a/server/models/account/account.ts
+++ b/server/models/account/account.ts
@@ -201,7 +201,7 @@ export class AccountModel extends Model<AccountModel> {
 
   @HasMany(() => VideoCommentModel, {
     foreignKey: {
-      allowNull: false
+      allowNull: true
     },
     onDelete: 'cascade',
     hooks: true

--- a/server/models/video/video-comment.ts
+++ b/server/models/video/video-comment.ts
@@ -507,17 +507,6 @@ export class VideoCommentModel extends Model<VideoCommentModel> {
   }
 
   toActivityPubObject (this: MCommentAP, threadParentComments: MCommentOwner[]): VideoCommentObject | ActivityTombstoneObject {
-    if (this.isDeleted()) {
-      return {
-        id: this.url,
-        type: 'Tombstone',
-        formerType: 'Note',
-        published: this.createdAt.toISOString(),
-        updated: this.updatedAt.toISOString(),
-        deleted: this.deletedAt.toISOString()
-      }
-    }
-
     let inReplyTo: string
     // New thread, so in AS we reply to the video
     if (this.inReplyToCommentId === null) {
@@ -526,8 +515,22 @@ export class VideoCommentModel extends Model<VideoCommentModel> {
       inReplyTo = this.InReplyToVideoComment.url
     }
 
+    if (this.isDeleted()) {
+      return {
+        id: this.url,
+        type: 'Tombstone',
+        formerType: 'Note',
+        inReplyTo,
+        published: this.createdAt.toISOString(),
+        updated: this.updatedAt.toISOString(),
+        deleted: this.deletedAt.toISOString()
+      }
+    }
+
     const tag: ActivityTagObject[] = []
     for (const parentComment of threadParentComments) {
+      if (!parentComment.Account) continue
+
       const actor = parentComment.Account.Actor
 
       tag.push({

--- a/server/tests/api/videos/multiple-servers.ts
+++ b/server/tests/api/videos/multiple-servers.ts
@@ -15,6 +15,7 @@ import {
   createUser,
   dateIsValid,
   doubleFollow,
+  flushAndRunServer,
   flushAndRunMultipleServers,
   getLocalVideos,
   getVideo,
@@ -938,7 +939,51 @@ describe('Test multiple servers', function () {
       }
     })
 
+    it('Should retrieve all comments when subscribing to a new server', async function () {
+      this.timeout(120000)
+
+      const newServer = await flushAndRunServer(4)
+
+      await setAccessTokensToServers([newServer])
+      await doubleFollow(newServer, servers[0])
+      await doubleFollow(newServer, servers[2])
+      await waitJobs([newServer, ...servers])
+
+      const res = await getVideoCommentThreads(newServer.url, videoUUID, 0, 5)
+
+      expect(res.body.total).to.equal(2)
+      expect(res.body.data).to.be.an('array')
+      expect(res.body.data).to.have.lengthOf(2)
+
+      {
+        const comment: VideoComment = res.body.data[0]
+        expect(comment).to.not.be.undefined
+        expect(comment.inReplyToCommentId).to.be.null
+        expect(comment.account.name).to.equal('root')
+        expect(comment.account.host).to.equal('localhost:' + servers[2].port)
+        expect(comment.totalReplies).to.equal(0)
+        expect(dateIsValid(comment.createdAt as string)).to.be.true
+        expect(dateIsValid(comment.updatedAt as string)).to.be.true
+      }
+
+      {
+        const deletedComment: VideoComment = res.body.data[1]
+        expect(deletedComment).to.not.be.undefined
+        expect(deletedComment.isDeleted).to.be.true
+        expect(deletedComment.deletedAt).to.not.be.null
+        expect(deletedComment.text).to.equal('')
+        expect(deletedComment.inReplyToCommentId).to.be.null
+        expect(deletedComment.account).to.be.null
+        expect(deletedComment.totalReplies).to.equal(3)
+        expect(dateIsValid(deletedComment.createdAt as string)).to.be.true
+        expect(dateIsValid(deletedComment.updatedAt as string)).to.be.true
+        expect(dateIsValid(deletedComment.deletedAt as string)).to.be.true
+      }
+    })
+
     it('Should delete a remote thread by the origin server', async function () {
+      this.timeout(5000)
+
       const res = await getVideoCommentThreads(servers[ 0 ].url, videoUUID, 0, 5)
       const threadId = res.body.data.find(c => c.text === 'my super second comment').id
       await deleteVideoComment(servers[ 0 ].url, servers[ 0 ].accessToken, videoUUID, threadId)

--- a/server/tests/api/videos/video-comments.ts
+++ b/server/tests/api/videos/video-comments.ts
@@ -172,7 +172,7 @@ describe('Test video comments', function () {
 
     const tree: VideoCommentThreadTree = res.body
     expect(tree.comment.text).equal('my super first comment')
-    expect(tree.children).to.have.lengthOf(1)
+    expect(tree.children).to.have.lengthOf(2)
 
     const firstChild = tree.children[0]
     expect(firstChild.comment.text).to.equal('my super answer to thread 1')
@@ -181,20 +181,32 @@ describe('Test video comments', function () {
     const childOfFirstChild = firstChild.children[0]
     expect(childOfFirstChild.comment.text).to.equal('my super answer to answer of thread 1')
     expect(childOfFirstChild.children).to.have.lengthOf(0)
+
+    const deletedChildOfFirstChild = tree.children[1]
+    expect(deletedChildOfFirstChild.comment.text).to.equal('')
+    expect(deletedChildOfFirstChild.comment.isDeleted).to.be.true
+    expect(deletedChildOfFirstChild.comment.deletedAt).to.not.be.null
+    expect(deletedChildOfFirstChild.comment.account).to.be.null
+    expect(deletedChildOfFirstChild.children).to.have.lengthOf(0)
   })
 
   it('Should delete a complete thread', async function () {
     await deleteVideoComment(server.url, server.accessToken, videoId, threadId)
 
     const res = await getVideoCommentThreads(server.url, videoUUID, 0, 5, 'createdAt')
-    expect(res.body.total).to.equal(2)
+    expect(res.body.total).to.equal(3)
     expect(res.body.data).to.be.an('array')
-    expect(res.body.data).to.have.lengthOf(2)
+    expect(res.body.data).to.have.lengthOf(3)
 
-    expect(res.body.data[0].text).to.equal('super thread 2')
-    expect(res.body.data[0].totalReplies).to.equal(0)
-    expect(res.body.data[1].text).to.equal('super thread 3')
+    expect(res.body.data[0].text).to.equal('')
+    expect(res.body.data[0].isDeleted).to.be.true
+    expect(res.body.data[0].deletedAt).to.not.be.null
+    expect(res.body.data[0].account).to.be.null
+    expect(res.body.data[0].totalReplies).to.equal(3)
+    expect(res.body.data[1].text).to.equal('super thread 2')
     expect(res.body.data[1].totalReplies).to.equal(0)
+    expect(res.body.data[2].text).to.equal('super thread 3')
+    expect(res.body.data[2].totalReplies).to.equal(0)
   })
 
   after(async function () {

--- a/shared/models/activitypub/objects/common-objects.ts
+++ b/shared/models/activitypub/objects/common-objects.ts
@@ -74,3 +74,14 @@ export interface ActivityPubAttributedTo {
   type: 'Group' | 'Person'
   id: string
 }
+
+export interface ActivityTombstoneObject {
+  '@context'?: any
+  id: string
+  type: 'Tombstone'
+  name?: string
+  formerType?: string
+  published: string
+  updated: string
+  deleted: string
+}

--- a/shared/models/activitypub/objects/common-objects.ts
+++ b/shared/models/activitypub/objects/common-objects.ts
@@ -78,9 +78,11 @@ export interface ActivityPubAttributedTo {
 export interface ActivityTombstoneObject {
   '@context'?: any
   id: string
+  url?: string
   type: 'Tombstone'
   name?: string
   formerType?: string
+  inReplyTo?: string
   published: string
   updated: string
   deleted: string

--- a/shared/models/videos/video-comment.model.ts
+++ b/shared/models/videos/video-comment.model.ts
@@ -9,6 +9,8 @@ export interface VideoComment {
   videoId: number
   createdAt: Date | string
   updatedAt: Date | string
+  deletedAt: Date | string
+  isDeleted: boolean
   totalReplies: number
   account: Account
 }


### PR DESCRIPTION
Related to #507 

Currently, when deleting a comment that have replies, the comment and all the replies were removed.

This PR only soft deleted comments so that replies stay visible.

![Screenshot_2019-11-25 date-toggle-demo](https://user-images.githubusercontent.com/1588144/69550079-b5575080-0f9a-11ea-9488-75732b69fa5c.png)

- [x] Back: Update tests to assert comment is still there, but marked as deleted
- [x] Back: Update server to soft delete comment instead of destroy
- [x] Back: Update API to no longer returns comment text and account if soft deleted
- [x] Back: Migration to make `comment.accountId` optional and add the `deletedAt` column
- [x] Federation: Replace deleted comments with a `Tombstone` object
- [x] Federation: Handle comment deletion federation requests by marking comments as deleted
- [x] Federation: Handle deleted comments when following a new instance and fetching all comments for the first time
- [x] Front: Display deleted comment as deleted on page load
- [x] Front: Display deleted comment as deleted dynamically when clicking on Delete

