### PR TITLE
Allow to toggle video publication date to display absolute date

### DIFF
--- a/client/src/app/shared/date/date-toggle.component.html
+++ b/client/src/app/shared/date/date-toggle.component.html
@@ -1,0 +1,6 @@
+<span
+  class="date-toggle"
+  [title]="getTitle()"
+  [innerHtml]="getContent()"
+  (click)="toggle()"
+></span>

--- a/client/src/app/shared/date/date-toggle.component.scss
+++ b/client/src/app/shared/date/date-toggle.component.scss
@@ -1,0 +1,5 @@
+.date-toggle {
+  &:hover {
+    cursor: default
+  }
+}

--- a/client/src/app/shared/date/date-toggle.component.ts
+++ b/client/src/app/shared/date/date-toggle.component.ts
@@ -1,0 +1,47 @@
+import { Component, Input, OnInit, OnChanges } from '@angular/core'
+import { DatePipe } from '@angular/common'
+import { FromNowPipe } from '../angular/from-now.pipe'
+
+@Component({
+  selector: 'my-date-toggle',
+  templateUrl: './date-toggle.component.html',
+  styleUrls: [ './date-toggle.component.scss' ],
+  providers: [ DatePipe, FromNowPipe ]
+})
+export class DateToggleComponent implements OnInit, OnChanges {
+  @Input() date: Date
+  @Input() toggled = false
+
+  dateRelative: string
+  dateAbsolute: string
+
+  constructor (
+    private datePipe: DatePipe,
+    private fromNowPipe: FromNowPipe
+  ) { }
+
+  ngOnInit () {
+    this.updateDates()
+  }
+
+  ngOnChanges () {
+    this.updateDates()
+  }
+
+  toggle () {
+    this.toggled = !this.toggled
+  }
+
+  getTitle () {
+    return this.toggled ? this.dateRelative : this.dateAbsolute
+  }
+
+  getContent () {
+    return this.toggled ? this.dateAbsolute : this.dateRelative
+  }
+
+  private updateDates () {
+    this.dateRelative = this.fromNowPipe.transform(this.date)
+    this.dateAbsolute = this.datePipe.transform(this.date, 'long')
+  }
+}

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -73,6 +73,7 @@ import { UserNotificationsComponent } from '@app/shared/users/user-notifications
 import { InstanceService } from '@app/shared/instance/instance.service'
 import { HtmlRendererService, LinkifierService, MarkdownService } from '@app/shared/renderer'
 import { ConfirmComponent } from '@app/shared/confirm/confirm.component'
+import { DateToggleComponent } from '@app/shared/date/date-toggle.component'
 import { SmallLoaderComponent } from '@app/shared/misc/small-loader.component'
 import { VideoPlaylistService } from '@app/shared/video-playlist/video-playlist.service'
 import { PreviewUploadComponent } from '@app/shared/images/preview-upload.component'
@@ -165,6 +166,7 @@ import { FeatureBooleanComponent } from '@app/shared/instance/feature-boolean.co
     TopMenuDropdownComponent,
     UserNotificationsComponent,
     ConfirmComponent,
+    DateToggleComponent,
 
     GlobalIconComponent,
     PreviewUploadComponent
@@ -232,6 +234,7 @@ import { FeatureBooleanComponent } from '@app/shared/instance/feature-boolean.co
     TopMenuDropdownComponent,
     UserNotificationsComponent,
     ConfirmComponent,
+    DateToggleComponent,
 
     GlobalIconComponent,
     PreviewUploadComponent,

--- a/client/src/app/shared/video/video-miniature.component.html
+++ b/client/src/app/shared/video/video-miniature.component.html
@@ -17,7 +17,7 @@
       </a>
 
       <span class="video-miniature-created-at-views">
-        <ng-container *ngIf="displayOptions.date">{{ video.publishedAt | myFromNow }}</ng-container>
+        <my-date-toggle *ngIf="displayOptions.date" [date]="video.publishedAt"></my-date-toggle>
         <ng-container *ngIf="displayOptions.date && displayOptions.views"> - </ng-container>
         <ng-container i18n *ngIf="displayOptions.views">{{ video.views | myNumberFormatter }} views</ng-container>
       </span>

--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -42,7 +42,7 @@
           <div class="d-block d-md-none"> <!-- only shown on medium devices, has its conterpart for larger viewports below -->
             <h1 class="video-info-name">{{ video.name }}</h1>
             <div i18n class="video-info-date-views">
-              Published {{ video.publishedAt | myFromNow }} - {{ video.views | myNumberFormatter }} views
+              Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle> - {{ video.views | myNumberFormatter }} views
             </div>
           </div>
 
@@ -51,7 +51,7 @@
               <h1 class="video-info-name">{{ video.name }}</h1>
 
               <div i18n class="video-info-date-views">
-                Published {{ video.publishedAt | myFromNow }} - {{ video.views | myNumberFormatter }} views
+                Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle> - {{ video.views | myNumberFormatter }} views
               </div>
             </div>
 


### PR DESCRIPTION
Related to #1695 

Allows to display full video published date/time by clicking on it, or hovering date.

![video-to-gif](https://user-images.githubusercontent.com/1588144/66768748-9d78b100-eeb3-11e9-9a29-b98463523635.gif)