### PR TITLE
Add generated files to gitignore to have a clean git stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /node_modules/
 /server/tools/node_modules
 *npm-debug.log
+yarn-error.log
 
 # Testing
 /test1/
@@ -45,3 +46,4 @@
 /*.asc
 /server/tools/import-mediacore.ts
 /docker-volume/
+/init.mp4

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -4,6 +4,7 @@
 /stats.json
 /dll
 /.awcache
+/src/locale/pending_target/
 /src/locale/target/iso639_*.xml
 /src/locale/target/player_*.xml
 /src/locale/target/server_*.xml


### PR DESCRIPTION
I always have generated files on which I have to be careful not to commit them.

They are generated during development build.

This PR adds these files to `.gitignore`:

    yarn-error.log
    init.mp4
    client/src/locale/pending_target/
