### PR TITLE
Fix tsconfig path in require

### DIFF
--- a/server/helpers/register-ts-paths.ts
+++ b/server/helpers/register-ts-paths.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path'
 const tsConfigPaths = require('tsconfig-paths')
 
-const tsConfig = require('../../tsconfig.json')
+const tsConfig = require('../../../tsconfig.json')
 
 function registerTSPaths () {
   // Thanks: https://github.com/dividab/tsconfig-paths/issues/75#issuecomment-458936883


### PR DESCRIPTION
I have this error when starting develoment environment:

```
[1] [0] [nodemon] starting `node dist/server`
[1] [0] internal/modules/cjs/loader.js:638
[1] [0]     throw err;
[1] [0]     ^
[1] [0] 
[1] [0] Error: Cannot find module '../../tsconfig.json'
[1] [0]     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
[1] [0]     at Function.Module._load (internal/modules/cjs/loader.js:562:25)
[1] [0]     at Module.require (internal/modules/cjs/loader.js:692:17)
[1] [0]     at require (internal/modules/cjs/helpers.js:25:18)
[1] [0]     at Object.<anonymous> (/var/www/PeerTube/dist/server/helpers/register-ts-paths.js:5:18)
[1] [0]     at Module._compile (internal/modules/cjs/loader.js:778:30)
[1] [0]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
[1] [0]     at Module.load (internal/modules/cjs/loader.js:653:32)
[1] [0]     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
[1] [0]     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
[1] [0] [nodemon] app crashed - waiting for file changes before starting...
```

It seems to be related to this change: https://github.com/Chocobozzz/PeerTube/commit/2aaa1a3fdc49be77aec5309dab5507865c38d392#diff-71213cd24dacb14b6df5f88885f07479R4

Not sure if the way to start development environment has changed, but this PR fixes it, I can now run development environment with `npm run dev` or `yarn dev`.