### PR TITLE
Fix instance statistics display in dark theme

### DIFF
--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -125,6 +125,11 @@ ngb-tabset.bootstrap {
   border-bottom: none;
 }
 
+.card {
+  background-color: var(--mainBackgroundColor);
+  border-color: #dee2e6;
+}
+
 .collapse-transition {
   // Animation when we show/hide the filters
   transition: max-height 0.3s;


### PR DESCRIPTION
In dark theme, instance stats (at the bottom of the page `/about`) are displayed white on white.

This PR makes bootstrap `.card` use foreground and background colors from theme.

### Before

![image](https://user-images.githubusercontent.com/1588144/68530069-21805600-0305-11ea-8eec-e7945fd5841f.png)

### After

![image](https://user-images.githubusercontent.com/1588144/68530079-407ee800-0305-11ea-8921-48cda5bbe04e.png)

