### PR TITLE
Fix link for account creation on another instance

### DIFF
--- a/client/src/app/login/login.component.html
+++ b/client/src/app/login/login.component.html
@@ -19,7 +19,7 @@
           or create an account
         </a>
 
-        <a i18n *ngIf="signupAllowed === false" href="https://joinpeertube.org/en/#instances-list" target="_blank" title="Click here to see a list of instances where to register" class="create-an-account">
+        <a i18n *ngIf="signupAllowed === false" href="https://joinpeertube.org/instances#instances-list" target="_blank" title="Click here to see a list of instances where to register" class="create-an-account">
           or create an account on another instance
         </a>
 


### PR DESCRIPTION
The link currently points to https://joinpeertube.org/en/#instances-list , but the instance list has been moved to https://joinpeertube.org/instances#instances-list