### PR TITLE
improve video-watch title display on small screens

### DIFF
--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -39,70 +39,82 @@
     <div class="video-info">
       <div class="video-info-first-row">
         <div>
-          <div class="d-block d-md-none"> <!-- only shown on medium devices, has its conterpart for larger viewports below -->
+          <div class="d-block d-md-none"> <!-- only shown on medium devices, has its counterpart for larger viewports below -->
             <h1 class="video-info-name">{{ video.name }}</h1>
+
             <div i18n class="video-info-date-views">
               Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle> <span class="views"> - {{ video.views | myNumberFormatter }} views</span>
             </div>
           </div>
 
-          <div class="d-flex justify-content-between align-items-md-end">
+          <div class="d-flex justify-content-between flex-direction-column">
             <div class="d-none d-md-block">
               <h1 class="video-info-name">{{ video.name }}</h1>
-
-              <div i18n class="video-info-date-views">
-                Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle> <span class="views"> - {{ video.views | myNumberFormatter }} views</span>
-              </div>
             </div>
 
-            <div class="video-actions-rates">
-              <div class="video-actions fullWidth justify-content-end">
-                <div
-                  [ngbPopover]="getRatePopoverText()" [ngClass]="{ 'activated': userRating === 'like' }" (click)="setLike()"
-                  class="action-button action-button-like" role="button" [attr.aria-pressed]="userRating === 'like'"
-                  i18n-title title="Like this video"
-                >
-                  <my-global-icon iconName="like"></my-global-icon>
-                  <span *ngIf="video.likes" class="count">{{ video.likes }}</span>
-                </div>
+            <div class="video-info-first-row-bottom">
+              <div i18n class="d-none d-md-block video-info-date-views">
+                Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle> <span class="views"> - {{ video.views | myNumberFormatter }} views</span>
+              </div>
 
-                <div
-                  [ngbPopover]="getRatePopoverText()" [ngClass]="{ 'activated': userRating === 'dislike' }" (click)="setDislike()"
-                  class="action-button action-button-dislike" role="button" [attr.aria-pressed]="userRating === 'dislike'"
-                  i18n-title title="Dislike this video"
-                >
-                  <my-global-icon iconName="dislike"></my-global-icon>
-                  <span *ngIf="video.dislikes" class="count">{{ video.dislikes }}</span>
-                </div>
-
-                <div *ngIf="video.support" (click)="showSupportModal()" class="action-button action-button-support">
-                  <my-global-icon iconName="support"></my-global-icon>
-                  <span class="icon-text" i18n>Support</span>
-                </div>
-
-                <div (click)="showShareModal()" class="action-button" role="button">
-                  <my-global-icon iconName="share"></my-global-icon>
-                  <span class="icon-text" i18n>Share</span>
-                </div>
-
-                <div
-                  class="action-dropdown" ngbDropdown placement="top" role="button" autoClose="outside"
-                   *ngIf="isUserLoggedIn()" (openChange)="addContent.openChange($event)"
-                >
-                  <div class="action-button action-button-save" ngbDropdownToggle role="button">
-                    <my-global-icon iconName="playlist-add"></my-global-icon>
-                    <span class="icon-text" i18n>Save</span>
+              <div class="video-actions-rates">
+                <div class="video-actions fullWidth justify-content-end">
+                  <div
+                    [ngbPopover]="getRatePopoverText()" [ngClass]="{ 'activated': userRating === 'like' }" (click)="setLike()"
+                    class="action-button action-button-like" role="button" [attr.aria-pressed]="userRating === 'like'"
+                    i18n-title title="Like this video"
+                  >
+                    <my-global-icon iconName="like"></my-global-icon>
+                    <span *ngIf="video.likes" class="count">{{ video.likes }}</span>
                   </div>
 
-                  <div ngbDropdownMenu>
-                    <my-video-add-to-playlist #addContent [video]="video"></my-video-add-to-playlist>
+                  <div
+                    [ngbPopover]="getRatePopoverText()" [ngClass]="{ 'activated': userRating === 'dislike' }" (click)="setDislike()"
+                    class="action-button action-button-dislike" role="button" [attr.aria-pressed]="userRating === 'dislike'"
+                    i18n-title title="Dislike this video"
+                  >
+                    <my-global-icon iconName="dislike"></my-global-icon>
+                    <span *ngIf="video.dislikes" class="count">{{ video.dislikes }}</span>
                   </div>
+  
+                  <div *ngIf="video.support" (click)="showSupportModal()" class="action-button">
+                    <my-global-icon iconName="heart"></my-global-icon>
+                    <span class="icon-text" i18n>Support</span>
+                  </div>
+  
+                  <div (click)="showShareModal()" class="action-button" role="button">
+                    <my-global-icon iconName="share"></my-global-icon>
+                    <span class="icon-text" i18n>Share</span>
+                  </div>
+  
+                  <div
+                    class="action-dropdown" ngbDropdown placement="top" role="button" autoClose="outside"
+                     *ngIf="isUserLoggedIn()" (openChange)="addContent.openChange($event)"
+                  >
+                    <div class="action-button action-button-save" ngbDropdownToggle role="button">
+                      <my-global-icon iconName="playlist-add"></my-global-icon>
+                      <span class="icon-text" i18n>Save</span>
+                    </div>
+  
+                    <div ngbDropdownMenu>
+                      <my-video-add-to-playlist #addContent [video]="video"></my-video-add-to-playlist>
+                    </div>
+                  </div>
+  
+                  <my-video-actions-dropdown
+                    placement="top" buttonDirection="horizontal" [buttonStyled]="true" [video]="video"
+                    (videoRemoved)="onVideoRemoved()" (modalOpened)="onModalOpened()"
+                  ></my-video-actions-dropdown>
                 </div>
-
-                <my-video-actions-dropdown
-                  placement="top" buttonDirection="horizontal" [buttonStyled]="true" [video]="video"
-                  (videoRemoved)="onVideoRemoved()" (modalOpened)="onModalOpened()"
-                ></my-video-actions-dropdown>
+  
+                <div
+                  class="video-info-likes-dislikes-bar"
+                  *ngIf="video.likes !== 0 || video.dislikes !== 0"
+                  [ngbTooltip]="likesBarTooltipText"
+                  placement="bottom"
+                >
+                  <div class="likes-bar" [ngStyle]="{ 'width.%': video.likesPercent }"></div>
+                </div>
               </div>
 
               <div

--- a/client/src/app/videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/videos/+video-watch/video-watch.component.scss
@@ -108,6 +108,10 @@ $player-factor: 1.7; // 16/9
   border-radius: 0;
 }
 
+.flex-direction-column {
+  flex-direction: column;
+}
+
 #video-not-found {
   height: 300px;
   line-height: 300px;
@@ -140,6 +144,13 @@ $player-factor: 1.7; // 16/9
         font-size: 27px;
         font-weight: $font-semibold;
         flex-grow: 1;
+      }
+
+      .video-info-first-row-bottom {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        width: 100%;
       }
 
       .video-info-date-views {
@@ -209,8 +220,9 @@ $player-factor: 1.7; // 16/9
       }
 
       .video-actions-rates {
-        margin: 20px 0 10px 0;
+        margin: 0 0 10px 0;
         align-items: start;
+        width: max-content;
 
         .video-actions {
           height: 40px; // Align with the title


### PR DESCRIPTION
This PR is only modifying css/html for the video-watch page, and only regarding the title block and the recommendations block. Its aim is to improve:

- long title display on small screens
- space taken when no recommendation is available

Below, on a 1100px-wide viewport before the PR, and after the PR:

![Screenshot_2019-12-03 Soutenons notre Internet(2)](https://user-images.githubusercontent.com/6329880/70086762-4ff70580-1613-11ea-99a2-4742ac84ad6b.png)


![Screenshot_2019-12-03 Soutenons notre Internet(3)](https://user-images.githubusercontent.com/6329880/70086749-45d50700-1613-11ea-8b2d-4e3b79d64da9.png)

