### PR TITLE
Simplify Dockerfile and slim Docker image

### DIFF
--- a/support/docker/production/Dockerfile.stretch
+++ b/support/docker/production/Dockerfile.stretch
@@ -1,35 +1,19 @@
-FROM node:10-stretch
+FROM node:10-stretch-slim
 
 # Allow to pass extra options to the npm run build
 # eg: --light --light-fr to not build all client languages
 #     (speed up build time if i18n is not required)
 ARG NPM_RUN_BUILD_OPTS
 
-RUN set -ex; \
-    if ! command -v gpg > /dev/null; then \
-      apt update; \
-      apt install -y --no-install-recommends \
-        gnupg \
-        dirmngr \
-      ; \
-      rm -rf /var/lib/apt/lists/*; \
-fi
-
 # Install dependencies
 RUN apt update \
-    && apt -y install ffmpeg \
-    && rm /var/lib/apt/lists/* -fR
+ && apt install -y --no-install-recommends ffmpeg gnupg gosu \
+ && gosu nobody true \
+ && rm /var/lib/apt/lists/* -fR
 
 # Add peertube user
 RUN groupadd -r peertube \
     && useradd -r -g peertube -m peertube
-
-# grab gosu for easy step-down from root
-RUN set -eux; \
-	apt update; \
-	apt install -y gosu; \
-	rm -rf /var/lib/apt/lists/*; \
-	gosu nobody true
 
 # Install PeerTube
 WORKDIR /app


### PR DESCRIPTION
I was playing around with the Docker image, and noticed that is a lot of potential to save space, even without switching to Alpine or otherwise losing any functionality. The image from this Dockerfile has 850 mb, compared to 1.9 gb to the official release image. 

For a short explanation of the changes:
- switched to the slim image variant, because I think it is a waste of space and bandwidth to use the 330 mb stretch image when the 50 mb stretch-slim image has all the necessary tools
- there were several seperate apt install commands for no reason, and one of them was missing the --no-install-recommends flag
- the package dirmngr is not referenced anywhere in the repo, so it seems unused

On a side note, the `chocobozzz/peertube:v2.0.0-stretch` image from Docker Hub contains a 300 mb folder at `/app/.yarn-cache` which I'm not getting in my builds. Any idea where thats coming from? Afaik it should be removed by the `yarn cache clean` step.