### PR TITLE
lighter box-shadow for .dropdown-menu

### DIFF
--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -16,7 +16,7 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
 
 .dropdown-menu {
   border-radius: 3px;
-  box-shadow: 0 3px 6px;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
   font-size: 15px;
 
   .dropdown-item {


### PR DESCRIPTION
Before/After

![image(2)](https://user-images.githubusercontent.com/6329880/70394702-b60ad080-19f7-11ea-93e8-e33a813f7597.png)
