### PR TITLE
miniature duration visibility and overlay background opacity

### DIFF
--- a/client/src/app/shared/video/video-thumbnail.component.scss
+++ b/client/src/app/shared/video/video-thumbnail.component.scss
@@ -28,5 +28,6 @@
     border-radius: 3px;
     font-size: 12px;
     font-weight: $font-bold;
+    z-index: 1;
   }
 }

--- a/client/src/sass/include/_miniature.scss
+++ b/client/src/sass/include/_miniature.scss
@@ -45,7 +45,7 @@ $play-overlay-width: 18px;
     width: inherit;
     height: inherit;
     opacity: 0;
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(0, 0, 0, 0.3);
 
     &, .icon {
       transition: all $play-overlay-transition;


### PR DESCRIPTION
Initial state

![Screenshot from 2019-12-08 20-46-42](https://user-images.githubusercontent.com/6329880/70395123-f5d3b700-19fb-11ea-96ba-593807e19c9d.png)


Before/After

![image(3)](https://user-images.githubusercontent.com/6329880/70395011-e4d67600-19fa-11ea-8e14-d3fec0784821.png)

While having the duration show a bit better would by itself be sufficient, I thought that having the overlay a bit more transparent would be nice, since mouse focus on a video usually means one wants to see the thumbnail clearly.