### PR TITLE
Design suggestion for the action buttons row in video watch page

### DIFF
--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -124,7 +124,7 @@
                     <div
                       class="video-info-likes-dislikes-bar"
                     >
-                      <div class="likes-bar" [ngStyle]="{ 'width.%': video.likesPercent }"></div>
+                      <div class="likes-bar" [ngClass]="{ 'liked': userRating !== 'none' }" [ngStyle]="{ 'width.%': video.likesPercent }"></div>
                     </div>
                   </div>
                 </div>

--- a/client/src/app/videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/videos/+video-watch/video-watch.component.scss
@@ -220,66 +220,73 @@ $video-info-margin-left: 44px;
           .action-button:not(:first-child),
           .action-dropdown,
           my-video-actions-dropdown {
-            margin-left: 10px;
+            margin-left: 5px;
           }
 
-          .action-button {
+          ::ng-deep.action-button {
             @include peertube-button;
-            @include grey-button;
             @include button-with-icon(21px, 0, -1px);
-            @include apply-svg-color($grey-foreground-color);
+            @include apply-svg-color(var(--actionButtonColor));
 
-            font-size: 15px;
+            font-size: 100%;
             font-weight: $font-semibold;
             display: inline-block;
             padding: 0 10px 0 10px;
             white-space: nowrap;
+            background-color: transparent !important;
+            color: var(--actionButtonColor);
+            text-transform: uppercase;
 
             &::after {
               display: none;
             }
 
-            .action-button-like,
-            .action-button-dislike {
+            &:hover {
+              opacity: 0.9;
+            }
+
+            &.action-button-like,
+            &.action-button-dislike {
+              filter: brightness(120%);
+
               .count {
                 margin-right: 5px;
               }
             }
 
             &.action-button-like.activated {
-              background-color: $green;
-
               .count {
-                color: #fff;
+                color: $activated-action-button-color;
               }
 
               my-global-icon {
-                @include apply-svg-color(#fff);
+                @include apply-svg-color($activated-action-button-color);
               }
             }
 
             &.action-button-dislike.activated {
-              background-color: $red;
-
               .count {
-                color: #fff;
+                color: $activated-action-button-color;
               }
 
               my-global-icon {
-                @include apply-svg-color(#fff);
+                @include apply-svg-color($activated-action-button-color);
               }
             }
 
             &.action-button-support {
               color: var(--supportButtonColor);
-              background-color: var(--supportButtonBackgroundColor);
-
-              &:hover {
-                opacity: 0.9;
-              }
 
               my-global-icon {
                 @include apply-svg-color(var(--supportButtonColor));
+              }
+            }
+
+            &.action-button-support {
+              my-global-icon {
+                ::ng-deep path:first-child {
+                  fill: var(--supportButtonHeartColor) !important;
+                }
               }
             }
 
@@ -309,14 +316,18 @@ $video-info-margin-left: 44px;
           $likes-bar-height: 2px;
           height: $likes-bar-height;
           margin-top: -$likes-bar-height;
-          width: 186px;
-          background-color: $red;
+          width: 120px;
+          background-color: #ccc;
           position: relative;
           top: 10px;
 
           .likes-bar {
             height: 100%;
-            background-color: $green;
+            background-color: #909090;
+
+            &.liked {
+              background-color: $activated-action-button-color;
+            }
           }
         }
       }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -34,8 +34,10 @@ body {
   --inputColor: #{$input-background-color};
   --inputPlaceholderColor: #{$input-placeholder-color};
 
-  --supportButtonBackgroundColor: #{$support-button};
-  --supportButtonColor: #{$white};
+  --actionButtonColor: #{$grey-foreground-color};
+  --supportButtonBackgroundColor: #{transparent};
+  --supportButtonColor: #{var(--actionButtonColor)};
+  --supportButtonHeartColor: #{$support-button-heart};
 
   font-family: $main-fonts;
   font-weight: $font-regular;

--- a/client/src/sass/include/_variables.scss
+++ b/client/src/sass/include/_variables.scss
@@ -14,7 +14,8 @@ $grey-foreground-hover-color: #303030;
 $orange-color: #F1680D;
 $orange-hover-color: #F97D46;
 
-$support-button: #38981a;
+$support-button: inherit;
+$support-button-heart: #e83e8c;
 
 $bg-color: #fff;
 $fg-color: #000;
@@ -61,6 +62,8 @@ $input-placeholder-color: #898989;
 
 $sub-menu-margin-bottom: 30px;
 
+$activated-action-button-color: black;
+
 /*** map theme ***/
 
 // pass variables into a sass map,
@@ -78,8 +81,10 @@ $variables: (
   --inputColor: var(--inputColor),
   --inputPlaceholderColor: var(--inputPlaceholderColor),
 
+  --actionButtonColor: var(--actionButtonColor),
   --supportButtonColor: var(--supportButtonColor),
   --supportButtonBackgroundColor: var(--supportButtonBackgroundColor),
+  --supportButtonHeartColor: var(--supportButtonHeartColor),
 
   --embedForegroundColor: var(--embedForegroundColor),
   --embedBigPlayBackgroundColor: var(--embedBigPlayBackgroundColor)


### PR DESCRIPTION
I've been wondering about the look and feel of buttons in the watch page. To me, the row of buttons looks bulky in a part of the UI where visual space is scarce. The colors (especially with the support button adding yet another color) don't mix well with the gray of the buttons' background:
![Screenshot_2019-12-21 UWwVx62](https://user-images.githubusercontent.com/6329880/71308154-1ab32b80-23f9-11ea-88ba-535fa6a8b236.png)

Option 1: transparent background and inverted support button
![Screenshot_2019-12-20 UWwVx62(2)](https://user-images.githubusercontent.com/6329880/71305480-3a385d00-23d5-11ea-8032-efda6aa85c13.png)

Option 2: transparent background and normal support button that reverts back to the current design on hover
![Screenshot_2019-12-20 UWwVx62(3)](https://user-images.githubusercontent.com/6329880/71305479-3a385d00-23d5-11ea-9b23-7742abd3a9d6.png)

Option 3: (my preference and the current content of the PR) option 2 + neutralize the green/red of like/dislike buttons, and (resp.) use the main color and a darker shade of the foreground color.
![Screenshot_2019-12-20 UWwVx62(4)](https://user-images.githubusercontent.com/6329880/71305478-3a385d00-23d5-11ea-82c8-3c451b49969b.png)

Note I switched text to uppercase since it balances the lack of background in terms of noticeability of the buttons.