### PR TITLE
Enhance jobs list displaying on smaller screens

### DIFF
--- a/client/src/app/+admin/system/jobs/job.service.ts
+++ b/client/src/app/+admin/system/jobs/job.service.ts
@@ -3,11 +3,11 @@ import { HttpClient, HttpParams } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 import { SortMeta } from 'primeng/api'
 import { Observable } from 'rxjs'
-import { JobType, ResultList } from '../../../../../../shared'
-import { JobState } from '../../../../../../shared/models'
+import { ResultList } from '../../../../../../shared'
 import { Job } from '../../../../../../shared/models/server/job.model'
 import { environment } from '../../../../environments/environment'
 import { RestExtractor, RestPagination, RestService } from '../../../shared'
+import { JobStateClient } from '../../../../types/job-state-client.type'
 import { JobTypeClient } from '../../../../types/job-type-client.type'
 
 @Injectable()
@@ -20,13 +20,13 @@ export class JobService {
     private restExtractor: RestExtractor
   ) {}
 
-  getJobs (state: JobState, jobType: JobTypeClient, pagination: RestPagination, sort: SortMeta): Observable<ResultList<Job>> {
+  getJobs (jobState: JobStateClient, jobType: JobTypeClient, pagination: RestPagination, sort: SortMeta): Observable<ResultList<Job>> {
     let params = new HttpParams()
     params = this.restService.addRestGetParams(params, pagination, sort)
 
     if (jobType !== 'all') params = params.append('jobType', jobType)
 
-    return this.authHttp.get<ResultList<Job>>(JobService.BASE_JOB_URL + '/' + state, { params })
+    return this.authHttp.get<ResultList<Job>>(JobService.BASE_JOB_URL + '/' + jobState, { params })
                .pipe(
                  map(res => {
                    return this.restExtractor.convertResultListDateToHuman(res, [ 'createdAt', 'processedOn', 'finishedOn' ])

--- a/client/src/app/+admin/system/jobs/jobs.component.html
+++ b/client/src/app/+admin/system/jobs/jobs.component.html
@@ -27,23 +27,23 @@
 >
   <ng-template pTemplate="header">
     <tr>
-      <th i18n style="max-width: 60px;">ID</th>
-      <th i18n style="max-width: 120px;">Type</th>
-      <th i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th i18n>State</th>
+      <th class="job-id" i18n>ID</th>
+      <th class="job-type" i18n>Type</th>
+      <th class="job-date" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th class="job-state" i18n>State</th>
     </tr>
   </ng-template>
 
   <ng-template pTemplate="body" let-expanded="expanded" let-job>
     <tr class="expander" [pRowToggler]="job">
-      <td style="max-width: 60px;">{{ job.id }}</td>
-      <td style="max-width: 120px;">{{ job.type }}</td>
-      <td>{{ job.createdAt }}</td>
-      <td *ngIf="job.state === 'delayed'" class="text-muted"><span class="glyphicon glyphicon-repeat"></span> <span i18n>Delayed.</span></td>
-      <td *ngIf="job.state === 'waiting'" class="text-warning"><span class="glyphicon glyphicon-hourglass"></span> <span i18n>Will start soon...</span></td>
-      <td *ngIf="job.state === 'active'" class="text-warning"><span class="glyphicon glyphicon-cog"></span> <span i18n>Running...</span></td>
-      <td *ngIf="job.state === 'completed'" class="text-success"><span class="glyphicon glyphicon-ok"></span> <span i18n>Finished</span></td>
-      <td *ngIf="job.state === 'failed'" class="text-danger"><span class="glyphicon glyphicon-remove"></span> <span i18n>Failed</span></td>
+      <td class="job-id" [title]="job.id">{{ job.id }}</td>
+      <td class="job-type">{{ job.type }}</td>
+      <td class="job-date">{{ job.createdAt }}</td>
+      <td class="job-state" *ngIf="job.state === 'delayed'" class="text-muted"><span class="glyphicon glyphicon-repeat"></span> <span i18n>Delayed.</span></td>
+      <td class="job-state" *ngIf="job.state === 'waiting'" class="text-warning"><span class="glyphicon glyphicon-hourglass"></span> <span i18n>Will start soon...</span></td>
+      <td class="job-state" *ngIf="job.state === 'active'" class="text-warning"><span class="glyphicon glyphicon-cog"></span> <span i18n>Running...</span></td>
+      <td class="job-state" *ngIf="job.state === 'completed'" class="text-success"><span class="glyphicon glyphicon-ok"></span> <span i18n>Finished</span></td>
+      <td class="job-state" *ngIf="job.state === 'failed'" class="text-danger"><span class="glyphicon glyphicon-remove"></span> <span i18n>Failed</span></td>
     </tr>
   </ng-template>
 

--- a/client/src/app/+admin/system/jobs/jobs.component.html
+++ b/client/src/app/+admin/system/jobs/jobs.component.html
@@ -2,7 +2,7 @@
   <div i18n class="form-sub-title">Jobs list</div>
 
   <div class="select-filter-block">
-    <label for="jobType">Job type</label>
+    <label for="jobType" i18n>Job type</label>
     <div class="peertube-select-container">
       <select id="jobType" name="jobType" [(ngModel)]="jobType" (ngModelChange)="onJobStateOrTypeChanged()">
         <option *ngFor="let jobType of jobTypes" [value]="jobType">{{ jobType }}</option>
@@ -11,7 +11,7 @@
   </div>
 
   <div class="select-filter-block">
-    <label for="jobState">Job state</label>
+    <label for="jobState" i18n>Job state</label>
     <div class="peertube-select-container">
       <select id="jobState" name="jobState" [(ngModel)]="jobState" (ngModelChange)="onJobStateOrTypeChanged()">
         <option *ngFor="let state of jobStates" [value]="state">{{ state }}</option>
@@ -23,43 +23,48 @@
 <p-table
   [value]="jobs" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" dataKey="uniqId"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" [first]="pagination.start"
+  [tableStyle]="{'table-layout':'auto'}"
 >
   <ng-template pTemplate="header">
     <tr>
-      <th style="width: 27px"></th>
-      <th i18n style="width: 60px">ID</th>
-      <th i18n style="width: 210px">Type</th>
-      <th i18n style="width: 130px">State</th>
-      <th i18n style="width: 250px" pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th i18n style="width: 250px">Processed on</th>
-      <th i18n style="width: 250px">Finished on</th>
+      <th i18n style="max-width: 60px;">ID</th>
+      <th i18n style="max-width: 120px;">Type</th>
+      <th i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th i18n>State</th>
     </tr>
   </ng-template>
 
   <ng-template pTemplate="body" let-expanded="expanded" let-job>
-    <tr>
-      <td class="expand-cell">
-        <span class="expander" [pRowToggler]="job">
-          <i [ngClass]="expanded ? 'glyphicon glyphicon-menu-down' : 'glyphicon glyphicon-menu-right'"></i>
-        </span>
-      </td>
-      <td>{{ job.id }}</td>
-      <td>{{ job.type }}</td>
-      <td>{{ job.state }}</td>
+    <tr class="expander" [pRowToggler]="job">
+      <td style="max-width: 60px;">{{ job.id }}</td>
+      <td style="max-width: 120px;">{{ job.type }}</td>
       <td>{{ job.createdAt }}</td>
-      <td>{{ job.processedOn }}</td>
-      <td>{{ job.finishedOn }}</td>
+      <td *ngIf="job.state === 'delayed'" class="text-muted"><span class="glyphicon glyphicon-repeat"></span> <span i18n>Delayed.</span></td>
+      <td *ngIf="job.state === 'waiting'" class="text-warning"><span class="glyphicon glyphicon-hourglass"></span> <span i18n>Will start soon...</span></td>
+      <td *ngIf="job.state === 'active'" class="text-warning"><span class="glyphicon glyphicon-cog"></span> <span i18n>Running...</span></td>
+      <td *ngIf="job.state === 'completed'" class="text-success"><span class="glyphicon glyphicon-ok"></span> <span i18n>Finished</span></td>
+      <td *ngIf="job.state === 'failed'" class="text-danger"><span class="glyphicon glyphicon-remove"></span> <span i18n>Failed</span></td>
     </tr>
   </ng-template>
 
   <ng-template pTemplate="rowexpansion" let-job>
     <tr>
-      <td colspan="7">
+      <td colspan="4">
+        <pre>{{ [
+          'Job: ' + job.id,
+          'Type: ' + job.type,
+          'Processed on ' + (job.processedOn || '-'),
+          'Finished on ' + (job.finishedOn || '-')
+        ].join('\n') }}</pre>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="4">
         <pre>{{ job.data }}</pre>
       </td>
     </tr>
     <tr class="job-error" *ngIf="job.error">
-      <td colspan="7">
+      <td colspan="4">
         <pre>{{ job.error }}</pre>
       </td>
     </tr>

--- a/client/src/app/+admin/system/jobs/jobs.component.scss
+++ b/client/src/app/+admin/system/jobs/jobs.component.scss
@@ -1,6 +1,22 @@
 @import '_variables';
 @import '_mixins';
 
+.job-id {
+  max-width: 30vw !important;
+}
+
+.job-type {
+  width: 150px !important;
+}
+
+.job-date {
+  width: 170px !important;
+}
+
+.job-state {
+  max-width: 60px;
+}
+
 .admin-sub-header {
   align-items: flex-end;
 

--- a/client/src/app/+admin/system/jobs/jobs.component.scss
+++ b/client/src/app/+admin/system/jobs/jobs.component.scss
@@ -19,6 +19,10 @@
   }
 }
 
+td .glyphicon {
+  margin-right: 10px;
+}
+
 pre {
   font-size: 11px;
 }

--- a/client/src/app/+admin/system/jobs/jobs.component.ts
+++ b/client/src/app/+admin/system/jobs/jobs.component.ts
@@ -7,6 +7,7 @@ import { JobState } from '../../../../../../shared/models'
 import { RestPagination, RestTable } from '../../../shared'
 import { JobService } from './job.service'
 import { I18n } from '@ngx-translate/i18n-polyfill'
+import { JobStateClient } from '../../../../types/job-state-client.type'
 import { JobTypeClient } from '../../../../types/job-type-client.type'
 
 @Component({
@@ -18,8 +19,8 @@ export class JobsComponent extends RestTable implements OnInit {
   private static JOB_STATE_LOCAL_STORAGE_STATE = 'jobs-list-state'
   private static JOB_STATE_LOCAL_STORAGE_TYPE = 'jobs-list-type'
 
-  jobState: JobState = 'waiting'
-  jobStates: JobState[] = [ 'active', 'completed', 'failed', 'waiting', 'delayed' ]
+  jobState: JobStateClient = 'waiting'
+  jobStates: JobStateClient[] = [ 'active', 'completed', 'failed', 'waiting', 'delayed' ]
 
   jobType: JobTypeClient = 'all'
   jobTypes: JobTypeClient[] = [

--- a/client/src/types/job-state-client.type.ts
+++ b/client/src/types/job-state-client.type.ts
@@ -1,0 +1,3 @@
+import { JobState } from '@shared/models'
+
+export type JobStateClient = JobState


### PR DESCRIPTION
Related issue: https://github.com/Chocobozzz/PeerTube/issues/1250

Jobs list, now:
![jobs](https://user-images.githubusercontent.com/1588144/71528348-b5bb7200-28df-11ea-8487-697d5d38ee1d.png)

Now, in dark theme:
![jobs-dark](https://user-images.githubusercontent.com/1588144/71528350-b81dcc00-28df-11ea-8f94-06340c4ffb9a.png)

This PR makes jobs list table less large so that it can fit in small screens.

- It removes columns `processedOn` and `finishedOn` because not always used, and put them in details instead (on toggle).
- It removes the arrow toggle and make the entire row clickable to open details.
- It moves job current state to the end and display with an icon and colored.
- It fixes columns width and responsiveness