### PR TITLE
Downsample to the closest divisor standard framerate

### DIFF
--- a/server/controllers/api/videos/index.ts
+++ b/server/controllers/api/videos/index.ts
@@ -12,7 +12,8 @@ import {
   VIDEO_CATEGORIES,
   VIDEO_LANGUAGES,
   VIDEO_LICENCES,
-  VIDEO_PRIVACIES
+  VIDEO_PRIVACIES,
+  VIDEO_TRANSCODING_FPS
 } from '../../../initializers/constants'
 import {
   changeVideoChannelShare,

--- a/server/helpers/logger.ts
+++ b/server/helpers/logger.ts
@@ -5,7 +5,7 @@ import * as winston from 'winston'
 import { FileTransportOptions } from 'winston/lib/winston/transports'
 import { CONFIG } from '../initializers/config'
 import { omit } from 'lodash'
-import { LOG_FILENAME } from '@server/initializers/constants'
+import { LOG_FILENAME } from '../initializers/constants'
 
 const label = CONFIG.WEBSERVER.HOSTNAME + ':' + CONFIG.WEBSERVER.PORT
 

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -309,6 +309,8 @@ let CONTACT_FORM_LIFETIME = 60000 * 60 // 1 hour
 
 const VIDEO_TRANSCODING_FPS: VideoTranscodingFPS = {
   MIN: 10,
+  STANDARD: [24, 25, 30],
+  HD_STANDARD: [50, 60],
   AVERAGE: 30,
   MAX: 60,
   KEEP_ORIGIN_FPS_RESOLUTION_MIN: 720 // We keep the original FPS on high resolutions (720 minimum)

--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -81,7 +81,7 @@ const videosAddValidator = getCommonVideoEditAttributes().concat([
       duration = await getDurationFromVideoFile(videoFile.path)
     } catch (err) {
       logger.error('Invalid input file in videosAddValidator.', { err })
-      res.status(400)
+      res.status(422)
          .json({ error: 'Invalid input file.' })
 
       return cleanUpReqFiles(req)

--- a/shared/extra-utils/miscs/miscs.ts
+++ b/shared/extra-utils/miscs/miscs.ts
@@ -104,6 +104,28 @@ async function generateHighBitrateVideo () {
   return tempFixturePath
 }
 
+async function generateVideoWithFramerate (fps = 60) {
+  const tempFixturePath = buildAbsoluteFixturePath(`video_${fps}fps.mp4`, true)
+
+  await ensureDir(dirname(tempFixturePath))
+
+  const exists = await pathExists(tempFixturePath)
+  if (!exists) {
+    return new Promise<string>(async (res, rej) => {
+      ffmpeg()
+        .outputOptions([ '-f rawvideo', '-video_size 320x240', '-i /dev/urandom' ])
+        .outputOptions([ '-ac 2', '-f s16le', '-i /dev/urandom', '-t 10' ])
+        .outputOptions([ `-r ${fps}` ])
+        .output(tempFixturePath)
+        .on('error', rej)
+        .on('end', () => res(tempFixturePath))
+        .run()
+    })
+  }
+
+  return tempFixturePath
+}
+
 // ---------------------------------------------------------------------------
 
 export {
@@ -115,5 +137,6 @@ export {
   testImage,
   buildAbsoluteFixturePath,
   root,
-  generateHighBitrateVideo
+  generateHighBitrateVideo,
+  generateVideoWithFramerate
 }

--- a/shared/models/videos/video-transcoding-fps.model.ts
+++ b/shared/models/videos/video-transcoding-fps.model.ts
@@ -1,6 +1,8 @@
 export type VideoTranscodingFPS = {
-  MIN: number,
-  AVERAGE: number,
-  MAX: number,
+  MIN: number
+  STANDARD: number[]
+  HD_STANDARD: number[]
+  AVERAGE: number
+  MAX: number
   KEEP_ORIGIN_FPS_RESOLUTION_MIN: number
 }

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -977,6 +977,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VideoUploadResponse'
+        '403':
+          description: 'The user video quota is exceeded with this video.'
+        '408':
+          description: 'Upload has timed out'
+        '422':
+          description: 'Invalid input file.'
       requestBody:
         content:
           multipart/form-data:


### PR DESCRIPTION
resolves #2350

The PR defines two sets of acceptable framerates: standard and hd standard framerates, which are used to check a video's conformance to player standards. If a video uses a non-standard framerate, we check if even downsampling is possible before rejecting.