### PR TITLE
Fix: unregistring a plugin did not remove properly his hooks.

### DIFF
--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -50,9 +50,7 @@ let serverCommit: string
 async function getConfig (req: express.Request, res: express.Response) {
   const { allowed } = await Hooks.wrapPromiseFun(
     isSignupAllowed,
-    {
-      ip: req.ip
-    },
+    {},
     'filter:api.user.signup.allowed.result'
   )
 

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -50,7 +50,9 @@ let serverCommit: string
 async function getConfig (req: express.Request, res: express.Response) {
   const { allowed } = await Hooks.wrapPromiseFun(
     isSignupAllowed,
-    {},
+    {
+      ip: req.ip
+    },
     'filter:api.user.signup.allowed.result'
   )
 

--- a/server/lib/plugins/plugin-manager.ts
+++ b/server/lib/plugins/plugin-manager.ts
@@ -194,7 +194,7 @@ export class PluginManager implements ServerHook {
 
       // Remove hooks of this plugin
       for (const key of Object.keys(this.hooks)) {
-        this.hooks[key] = this.hooks[key].filter(h => h.pluginName !== npmName)
+        this.hooks[key] = this.hooks[key].filter(h => h.npmName !== npmName)
       }
 
       this.reinitVideoConstants(plugin.npmName)


### PR DESCRIPTION
I noticed that when developing a plugin, the hooks where called multiple times. Sometimes with old code. I found the issue here. It works with plugin under development. I did not try with plugins installed directory from npm, but I'm pretty sure it will be ok.