### PR TITLE
Adding the request ip for hook filter:api.user.signup.allowed.result

### DIFF
--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -51,7 +51,7 @@ async function getConfig (req: express.Request, res: express.Response) {
   const { allowed } = await Hooks.wrapPromiseFun(
     isSignupAllowed,
     {
-      req.ip
+      ip: req.ip
     },
     'filter:api.user.signup.allowed.result'
   )

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -50,7 +50,9 @@ let serverCommit: string
 async function getConfig (req: express.Request, res: express.Response) {
   const { allowed } = await Hooks.wrapPromiseFun(
     isSignupAllowed,
-    {},
+    {
+      req.ip
+    },
     'filter:api.user.signup.allowed.result'
   )
 


### PR DESCRIPTION
The `filter:api.user.signup.allowed.result` hook is called in two places : on the register form submit, and in getConfig.
I propose passing the request IP in the getConfig call too.
The reason why: I'm developing a plugin that will allow/disallow the registration for some countries. So I can test before the form submit if I want. 
The plugin can still know if we are in getConfig or on the form submit, by testing `params.body`.