### PR TITLE
Add manage buttons for own channels and account, video counts

### DIFF
--- a/client/src/app/+accounts/accounts.component.html
+++ b/client/src/app/+accounts/accounts.component.html
@@ -33,7 +33,7 @@
       </div>
 
       <div class="right-buttons">
-        <a *ngIf="isManageable" routerLink="/my-account" class="btn btn-outline-primary mr-2" i18n>Manage</a>
+        <a *ngIf="isManageable" routerLink="/my-account" class="btn btn-outline-tertiary mr-2" i18n>Manage</a>
         <my-subscribe-button *ngIf="videoChannels" [account]="account" [videoChannels]="videoChannels"></my-subscribe-button>
       </div>
     </div>

--- a/client/src/app/+accounts/accounts.component.html
+++ b/client/src/app/+accounts/accounts.component.html
@@ -25,15 +25,17 @@
           <my-user-moderation-dropdown
             buttonSize="small" [account]="account" [user]="user" placement="bottom-right auto"
             (userChanged)="onUserChanged()" (userDeleted)="onUserDeleted()"
-          >
-          </my-user-moderation-dropdown>
+          ></my-user-moderation-dropdown>
         </div>
         <div class="actor-followers" i18n-title [title]="subscribersDisplayFor(account.followersCount) + ' to the account actor'">
           {{ subscribersDisplayFor(naiveAggregatedSubscribers) }}
         </div>
       </div>
 
-      <my-subscribe-button *ngIf="videoChannels" [account]="account" [videoChannels]="videoChannels"></my-subscribe-button>
+      <div class="right-buttons">
+        <a *ngIf="isManageable" routerLink="/my-account" class="btn btn-outline-primary mr-2" i18n>Manage</a>
+        <my-subscribe-button *ngIf="videoChannels" [account]="account" [videoChannels]="videoChannels"></my-subscribe-button>
+      </div>
     </div>
 
     <div class="links">

--- a/client/src/app/+accounts/accounts.component.scss
+++ b/client/src/app/+accounts/accounts.component.scss
@@ -9,10 +9,21 @@
   }
 }
 
-my-subscribe-button {
+.right-buttons {
+  display: flex;
   height: max-content;
   margin-left: auto;
   margin-top: 20px;
+
+  a {
+    @include peertube-button-outline;
+    height: auto;
+    line-height: 32px;
+  }
+
+  my-subscribe-button {
+    height: min-content;
+  }
 }
 
 my-user-moderation-dropdown,

--- a/client/src/app/+accounts/accounts.component.ts
+++ b/client/src/app/+accounts/accounts.component.ts
@@ -65,6 +65,11 @@ export class AccountsComponent implements OnInit, OnDestroy {
     )
   }
 
+  get isManageable () {
+    if (!this.authService.isLoggedIn()) return false
+    return this.user.id === this.authService.getUser().id
+  }
+
   onUserChanged () {
     this.getUserIfNeeded(this.account)
   }

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
@@ -1,3 +1,7 @@
+<div>
+  <h4 i18n>Playlists <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h4>
+</div>
+
 <div class="video-playlists-header">
   <input type="text" placeholder="Search your playlists" i18n-placeholder [(ngModel)]="videoPlaylistsSearch" (ngModelChange)="onVideoPlaylistSearchChanged()" />
 

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
@@ -1,3 +1,7 @@
+<div>
+  <h4 i18n>Videos <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h4>
+</div>
+
 <div class="videos-header">
   <input type="text" placeholder="Search your videos" i18n-placeholder [(ngModel)]="videosSearch" (ngModelChange)="onVideosSearchChanged()" />
 </div>

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.ts
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.ts
@@ -86,6 +86,9 @@ export class MyAccountVideosComponent implements OnInit, DisableForReuseHook {
     const newPagination = immutableAssign(this.pagination, { currentPage: page })
 
     return this.videoService.getMyVideos(newPagination, sort, this.videosSearch)
+      .pipe(
+        tap(res => this.pagination.totalItems = res.total)
+      )
   }
 
   async deleteSelectedVideos () {

--- a/client/src/app/+video-channels/video-channels.component.html
+++ b/client/src/app/+video-channels/video-channels.component.html
@@ -16,7 +16,7 @@
           </div>
 
           <div class="right-buttons">
-            <a *ngIf="isManageable" [routerLink]="[ '/my-account/video-channels/update', videoChannel.nameWithHost ]" class="btn btn-outline-primary mr-2" i18n>Manage</a>
+            <a *ngIf="isManageable" [routerLink]="[ '/my-account/video-channels/update', videoChannel.nameWithHost ]" class="btn btn-outline-tertiary mr-2" i18n>Manage</a>
             <my-subscribe-button #subscribeButton [videoChannels]="[videoChannel]"></my-subscribe-button>
           </div>
         </div>

--- a/client/src/app/+video-channels/video-channels.component.html
+++ b/client/src/app/+video-channels/video-channels.component.html
@@ -15,7 +15,10 @@
             </button>
           </div>
 
-          <my-subscribe-button #subscribeButton [videoChannels]="[videoChannel]"></my-subscribe-button>
+          <div class="right-buttons">
+            <a *ngIf="isManageable" [routerLink]="[ '/my-account/video-channels/update', videoChannel.nameWithHost ]" class="btn btn-outline-primary mr-2" i18n>Manage</a>
+            <my-subscribe-button #subscribeButton [videoChannels]="[videoChannel]"></my-subscribe-button>
+          </div>
         </div>
         <div i18n class="actor-followers">{{ videoChannel.followersCount }} subscribers</div>
 

--- a/client/src/app/+video-channels/video-channels.component.scss
+++ b/client/src/app/+video-channels/video-channels.component.scss
@@ -18,3 +18,19 @@
     }
   }
 }
+
+.right-buttons {
+  display: flex;
+  height: max-content;
+  margin-left: auto;
+  margin-top: 20px;
+
+  a {
+    @include peertube-button-outline;
+    line-height: 1.8;
+  }
+
+  my-subscribe-button {
+    height: min-content;
+  }
+}

--- a/client/src/app/+video-channels/video-channels.component.ts
+++ b/client/src/app/+video-channels/video-channels.component.ts
@@ -64,6 +64,11 @@ export class VideoChannelsComponent implements OnInit, OnDestroy {
     return this.authService.isLoggedIn()
   }
 
+  get isManageable () {
+    if (!this.isUserLoggedIn()) return false
+    return this.videoChannel.ownerAccount.userId === this.authService.getUser().id
+  }
+
   activateCopiedMessage () {
     this.notifier.success(this.i18n('Username copied'))
   }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -26,6 +26,7 @@ body {
   --mainHoverColor: #{$orange-hover-color};
   --mainBackgroundColor: #{$bg-color};
   --mainForegroundColor: #{$fg-color};
+  --secondaryColor: #{$cyan-color};
 
   --menuBackgroundColor: #{$menu-background};
   --menuForegroundColor: #{$menu-color};

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -170,3 +170,13 @@ ngb-tabset.bootstrap {
 ngb-modal-backdrop {
   z-index: 10000 !important;
 }
+
+.btn-outline-tertiary {
+	color: var(--secondaryColor);
+  border-color: var(--secondaryColor);
+  
+  &:hover {
+    color: var(--mainBackgroundColor);
+    background-color: var(--secondaryColor);
+  }
+}

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -179,6 +179,15 @@
   @include peertube-button;
 }
 
+@mixin peertube-button-outline {
+  display: inline-block;
+
+  @include disable-default-a-behaviour;
+  @include peertube-button;
+
+  border: 1px solid;
+}
+
 @mixin button-with-icon($width: 20px, $margin-right: 3px, $top: -1px) {
   my-global-icon {
     position: relative;
@@ -453,7 +462,7 @@
 }
 
 @mixin sub-menu-with-actor {
-  height: 160px;
+  height: max-content;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/client/src/sass/include/_variables.scss
+++ b/client/src/sass/include/_variables.scss
@@ -14,6 +14,8 @@ $grey-foreground-hover-color: #303030;
 $orange-color: #F1680D;
 $orange-hover-color: #F97D46;
 
+$cyan-color: hsl(187, 77%, 34%);
+
 $support-button: inherit;
 $support-button-heart: #e83e8c;
 
@@ -73,6 +75,7 @@ $variables: (
   --mainHoverColor: var(--mainHoverColor),
   --mainBackgroundColor: var(--mainBackgroundColor),
   --mainForegroundColor: var(--mainForegroundColor),
+  --secondaryColor: var(--secondaryColor),
 
   --menuBackgroundColor: var(--menuBackgroundColor),
   --menuForegroundColor: var(--menuForegroundColor),


### PR DESCRIPTION
Own channels/account "Manage" buttons for quick access to administration:

![Screenshot_2020-01-19 Video channel videos - PeerTube](https://user-images.githubusercontent.com/6329880/72683088-8c53c780-3ad4-11ea-9cba-f16251c7ab20.png)
![Screenshot_2020-01-19 Account video channels - PeerTube](https://user-images.githubusercontent.com/6329880/72683089-8c53c780-3ad4-11ea-9c23-251533239e7a.png)

Video counts:

![Screenshot_2020-01-19 Account videos - PeerTube](https://user-images.githubusercontent.com/6329880/72683054-4860c280-3ad4-11ea-9850-60aacf3c1fb8.png)
![Screenshot_2020-01-19 Account playlists - PeerTube](https://user-images.githubusercontent.com/6329880/72683053-4860c280-3ad4-11ea-9665-ce932694cc07.png)