### PR TITLE
Channel identifier text description

### DIFF
--- a/client/src/app/+signup/+register/register-step-channel.component.html
+++ b/client/src/app/+signup/+register/register-step-channel.component.html
@@ -40,7 +40,7 @@
     </div>
 
     <div class="name-information" i18n>
-      The channel name is a unique identifier of your channel on this instance. It's like an address mail, so other people can find your channel.
+      The channel name is a unique identifier of your channel on this and all the other instances. It's as unique as an email address, which makes it easy for other people to find it.
     </div>
 
     <div *ngIf="formErrors.name" class="form-error">


### PR DESCRIPTION
>  The channel name is a unique identifier of your channel on this and all the other instances.

this is true if we consider "cats@domain.com" as "a channel". If by "a channel" you only mean "cats" then the text needs to be changed to something like:

> The channel name is a unique identifier of your channel on this instance. Together with the domain name - it becomes unique across all instances.

In any case, English native speakers I'm open to suggestions on how to improve this :)