### PR TITLE
Account identifier text description

### DIFF
--- a/client/src/app/+signup/+register/register-step-user.component.html
+++ b/client/src/app/+signup/+register/register-step-user.component.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="name-information" i18n>
-      The username is a unique identifier of your account on this instance. It's like an address mail, so other people can find you.
+      The username is a unique identifier of your account on this and all the other instances. It's as unique as an email address, which makes it easy for other people to find it.
     </div>
 
     <div *ngIf="formErrors.username" class="form-error">


### PR DESCRIPTION
>  The username is a unique identifier of your account on this and all the other instances.

this is true if we consider "john@domain.com" as "an account". If by "an account" you only mean "john" then the text needs to be changed to something like:

> The username is a unique identifier of your account on this instances. Together with the domain name - it becomes unique across all instances.

In any case, English native speakers I'm open to suggestions on how to improve this :)