### PR TITLE
Fixing user dropdown menu position for languages with long text

### DIFF
--- a/client/src/app/menu/menu.component.scss
+++ b/client/src/app/menu/menu.component.scss
@@ -88,18 +88,25 @@ menu {
         }
       }
 
-      .dropdown-item {
-        @include dropdown-with-icon-item;
-
-        my-global-icon {
-          width: 22px;
-          height: 22px;
-
-          &[iconName="sign-out"] {
-            position: relative;
-            right: -1px;
-            height: 21px;
-            width: 21px;
+      .dropdown-menu{
+        position: fixed!important;
+        top: 110px!important;
+        left: 50px!important;
+        will-change: unset !important;
+        transform: none !important;
+        .dropdown-item {
+          @include dropdown-with-icon-item;
+  
+          my-global-icon {
+            width: 22px;
+            height: 22px;
+  
+            &[iconName="sign-out"] {
+              position: relative;
+              right: -1px;
+              height: 21px;
+              width: 21px;
+            }
           }
         }
       }


### PR DESCRIPTION
This is the user dropdown menu if you open it in spanish version. This happens because the text in spanish is longer than english.
![dropdownMenuBroken](https://user-images.githubusercontent.com/34477436/74335040-2b49a780-4d93-11ea-82d4-f9d9463656c5.png)

I been working on a final solution (for all languages). This is the result in spanish
![dropdownMenuFixedES](https://user-images.githubusercontent.com/34477436/74335444-2b967280-4d94-11ea-9b79-a0453b52ecb2.png)

And this is the result in English
![dropdownMenuFixedEN](https://user-images.githubusercontent.com/34477436/74335473-3cdf7f00-4d94-11ea-8561-47a3d408d39a.png)

I'm using a fixed position just to be sure that this menu can overlap any other element in the DOM

