### PR TITLE
Extend build commands

### DIFF
--- a/scripts/build/client.sh
+++ b/scripts/build/client.sh
@@ -39,8 +39,52 @@ post_build_hook
 
 # Don't build other languages if --light arg is provided
 if [ -z ${1+x} ] || [ "$1" != "--light" ]; then
-    if [ ! -z ${1+x} ] && [ "$1" == "--light-fr" ]; then
+    if [ ! -z ${1+x} ] && [ "$1" == "--light-hu" ]; then
+        languages=(["hu"]="hu-HU")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-th" ]; then
+        languages=(["th"]="th-TH")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-fi" ]; then
+        languages=(["fi"]="fi-FI")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-nl" ]; then
+        languages=(["nl"]="nl-NL")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-gd" ]; then
+        languages=(["gd"]="gd")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-el" ]; then
+        languages=(["el"]="el-GR")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-es" ]; then
+        languages=(["es"]="es-ES")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-oc" ]; then
+        languages=(["oc"]="oc")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-pt" ]; then
+        languages=(["pt"]="pt-BR")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-pt-PT" ]; then
+        languages=(["pt-PT"]="pt-PT")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-sv" ]; then
+        languages=(["sv"]="sv-SE")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-pl" ]; then
+        languages=(["pl"]="pl-PL")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-ru" ]; then
+        languages=(["ru"]="ru-RU")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-zh-Hans" ]; then
+        languages=(["zh-Hans"]="zh-Hans-CN")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-zh-Hant" ]; then
+        languages=(["zh-Hant"]="zh-Hant-TW")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-fr" ]; then
         languages=(["fr"]="fr-FR")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-ja" ]; then
+        languages=(["ja"]="ja-JP")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-eu" ]; then
+        languages=(["eu"]="eu-ES")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-ca" ]; then
+        languages=(["ca"]="ca-ES")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-cs" ]; then
+        languages=(["cs"]="cs-CZ")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-eo" ]; then
+        languages=(["eo"]="eo")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-de" ]; then
+        languages=(["de"]="de-DE")
+    elif [ ! -z ${1+x} ] && [ "$1" == "--light-it" ]; then
+        languages=(["it"]="it-IT")
     else
         # Supported languages
         languages=(


### PR DESCRIPTION
Hello! 
I had CSS issues for a specific language (Spanish) and I needed to add a '--light-es' parameter to the client.sh in order to test it without losing 20 minutes for each compilation. It can be useful to have a --light parameter for each language so when developers face problems for a specific languages they don't need to  build the entire project.