### PR TITLE
Update postgres/redis in docker-compose 

### DIFF
--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -54,6 +54,13 @@ services:
     restart: "always"
     labels:
       traefik.enable: "false"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    shm_size: 64M
 
   redis:
     image: redis:5-alpine
@@ -62,6 +69,9 @@ services:
     restart: "always"
     labels:
       traefik.enable: "false"
+    healthcheck:
+    environment:
+      test: ["CMD", "redis-cli", "ping"]
 
   postfix:
     image: mwader/postfix-relay

--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     restart: "always"
 
   postgres:
-    image: postgres:10-alpine
+    image: postgres:12
     env_file:
       - .env
     volumes:
@@ -56,7 +56,7 @@ services:
       traefik.enable: "false"
 
   redis:
-    image: redis:4-alpine
+    image: redis:5-alpine
     volumes:
       - ./docker-volume/redis:/data
     restart: "always"


### PR DESCRIPTION
Redis 5 is backwards compatible with 4.
Postgres 12 needs additional testing, but I've installed without issue on my test.