### PR TITLE
Add python-dev and ca-certificates to docker build

### DIFF
--- a/support/docker/production/Dockerfile.buster
+++ b/support/docker/production/Dockerfile.buster
@@ -7,7 +7,7 @@ ARG NPM_RUN_BUILD_OPTS
 
 # Install dependencies
 RUN apt update \
- && apt install -y --no-install-recommends openssl ffmpeg gnupg gosu \
+ && apt install -y --no-install-recommends openssl python-dev ca-certificates ffmpeg gnupg gosu \
  && gosu nobody true \
  && rm /var/lib/apt/lists/* -fR
 


### PR DESCRIPTION
Tested and running on my instance.  
Fixes #2491

After I added `python-dev` (like it is found in [the dependencies page](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/dependencies.md#debian--ubuntu-and-derivatives)) the missing python in env was fixed.

Also had to install ca-certificates or I'd get certificate errors.