### PR TITLE
Add Nginx configuration to redirect videos to their CDN location

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -156,6 +156,14 @@ server {
 
     root /var/www/peertube/storage;
 
+    # Use this in tandem with fuse-mounting i.e. https://docs.joinpeertube.org/#/admin-remote-storage
+    # to serve files directly from a public bucket without proxying.
+    # Assumes you have buckets named after the storage subdirectories, i.e. 'videos', 'redundancy', etc.
+    #set $cdn <your S3-compatiable bucket public url mounted via fuse>;
+    #rewrite ^/static/webseed/(.*)$ $cdn/videos/$1 redirect;
+    #rewrite ^/static/redundancy/(.*)$ $cdn/redundancy/$1 redirect;
+    #rewrite ^/static/streaming-playlists/(.*)$ $cdn/streaming-playlists/$1 redirect;
+
     rewrite ^/static/webseed/(.*)$ /videos/$1 break;
     rewrite ^/static/redundancy/(.*)$ /redundancy/$1 break;
     rewrite ^/static/streaming-playlists/(.*)$ /streaming-playlists/$1 break;


### PR DESCRIPTION
Using fuse storage as per #147, and assuming all videos are then in the bucket/container, this allows to make clients directly download from it instead of using PeerTube as a proxy = massive direct bandwidth reduction.

TODO:
- [x] test with Minio
- [ ] test with AWS S3
- [ ] test with Wasabi

HOW TO USE

Just uncomment lines 162-165, and set the `$cdn` variable to your base storage bucket url.