### PR TITLE
Fixing load more comments on infinite scroll

### DIFF
--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -218,7 +218,6 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
       this.componentPagination.totalItems = null
 
       this.syndicationItems = this.videoCommentService.getVideoCommentsFeeds(this.video.uuid)
-      
       this.loadMoreThreads()
     }
   }

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -192,11 +192,10 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
     return this.authService.isLoggedIn()
   }
 
-  onNearOfBottom () {
-    this.componentPagination.currentPage++
-
+  onNearOfBottom () {    
     if (hasMoreItems(this.componentPagination)) {
       this.loadMoreThreads()
+      this.componentPagination.currentPage++
     }
   }
 
@@ -219,7 +218,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
       this.componentPagination.totalItems = null
 
       this.syndicationItems = this.videoCommentService.getVideoCommentsFeeds(this.video.uuid)
-
+      
       this.loadMoreThreads()
     }
   }

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -194,8 +194,8 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
 
   onNearOfBottom () {    
     if (hasMoreItems(this.componentPagination)) {
-      this.loadMoreThreads()
       this.componentPagination.currentPage++
+      this.loadMoreThreads()
     }
   }
 


### PR DESCRIPTION
Fix for issue #2532 (https://github.com/Chocobozzz/PeerTube/issues/2532)

I saw that 'onNearOfBottom' function is incrementing the current comments page before check if it 'hasMoreItems'. This is getting an uncomplete comments set because it skip always last comments page. Another approach would be set the default value of 'this.componentPagination.currentPage' to 0 instead of 1. But, in my opinion, this is more reliable.