### PR TITLE
Add action hook, comments loaded

### DIFF
--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -130,6 +130,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
         this.componentPagination.totalItems = res.total
 
         this.onDataSubject.next(res.data)
+        this.hooks.runAction('action:video-watch.comments.loaded', 'video-watch', { data: this.componentPagination })
       },
 
       err => this.notifier.error(err.message)

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -130,7 +130,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
         this.componentPagination.totalItems = res.total
 
         this.onDataSubject.next(res.data)
-        this.hooks.runAction('action:video-watch.comments.loaded', 'video-watch', { data: this.componentPagination })
+        this.hooks.runAction('action:video-watch.video-threads.loaded', 'video-watch', { data: this.componentPagination })
       },
 
       err => this.notifier.error(err.message)

--- a/shared/models/plugins/client-hook.model.ts
+++ b/shared/models/plugins/client-hook.model.ts
@@ -66,7 +66,7 @@ export const clientActionHookObject = {
   // Fired when the player finished loading
   'action:video-watch.player.loaded': true,
   // Fired when the video watch page comments(threads) are loaded and load more comments on scroll
-  'action:video-watch.comments.loaded': true,
+  'action:video-watch.video-threads.loaded': true,
 
   // Fired when the search page is being initialized
   'action:search.init': true,

--- a/shared/models/plugins/client-hook.model.ts
+++ b/shared/models/plugins/client-hook.model.ts
@@ -65,6 +65,8 @@ export const clientActionHookObject = {
   'action:video-watch.video.loaded': true,
   // Fired when the player finished loading
   'action:video-watch.player.loaded': true,
+  // Fired when the video watch page comments(threads) are loaded and load more comments on scroll
+  'action:video-watch.comments.loaded': true,
 
   // Fired when the search page is being initialized
   'action:search.init': true,


### PR DESCRIPTION
I'm adding donate buttons to the comments via a plugin (peertube-plugin.bittube-airtime-module) 
![DonateButtonDark](https://user-images.githubusercontent.com/34477436/75966138-c41aa100-5ec1-11ea-8c8d-06bc899148be.png)

I needed to add a hook to know when the comments are loaded and when the load more comments on scroll is being triggered. Would be nice to add it to the Federation in order to keep my plugin compatible with it. I also may be usefull for somebody else. Feel free to make suggestions and thanks a lot!