### PR TITLE
Fix CSP issue on WebFinger service

### DIFF
--- a/server/controllers/webfinger.ts
+++ b/server/controllers/webfinger.ts
@@ -1,8 +1,11 @@
+import * as cors from 'cors'
 import * as express from 'express'
 import { asyncMiddleware } from '../middlewares'
 import { webfingerValidator } from '../middlewares/validators'
 
 const webfingerRouter = express.Router()
+
+webfingerRouter.use(cors())
 
 webfingerRouter.get('/.well-known/webfinger',
   asyncMiddleware(webfingerValidator),
@@ -31,8 +34,6 @@ function webfingerController (req: express.Request, res: express.Response) {
       }
     ]
   }
-  
-  res.set('Access-Control-Allow-Origin', '*')
 
   return res.json(json)
 }

--- a/server/controllers/webfinger.ts
+++ b/server/controllers/webfinger.ts
@@ -31,6 +31,8 @@ function webfingerController (req: express.Request, res: express.Response) {
       }
     ]
   }
+  
+  res.set('Access-Control-Allow-Origin', '*')
 
   return res.json(json)
 }


### PR DESCRIPTION
Hey there,

while trying to remotely subscribe to a channel on [this instance](https://thinkerview.video/) (with an account on [this instance](https://skeptikon.fr/)) I noticed an error in my JS console which **halts the remote subscription process** :
```
Blocage d’une requête multiorigines (Cross-Origin Request) : la politique « Same Origin » ne permet pas de consulter la ressource distante située sur https://skeptikon.fr/.well-known/webfinger?resource=acct:zm_@skeptikon.fr. Raison : l’en-tête CORS « Access-Control-Allow-Origin » est manquant.
```

> A cross-origin request has been bloqued: « Same Origin » policy doesn't allow to fetch remote ressource at https://skeptikon.fr/.well-known/webfinger?resource=acct:zm_@skeptikon.fr. Reason: CORS header « Access-Control-Allow-Origin » is missing.

The WebFinger at skeptikon.fr (which runs PeerTube 2.1.1) works like a charm when [consulted directly](https://skeptikon.fr/.well-known/webfinger?resource=acct:zm_@skeptikon.fr). It is stated in [WebFinger RFC](https://tools.ietf.org/html/rfc7033#section-5) that CSP should allow any origin to access resource on a WebFinger service:

```
5.  Cross-Origin Resource Sharing (CORS)

   WebFinger resources might not be accessible from a web browser due to
   "Same-Origin" policies.  The current best practice is to make
   resources available to browsers through Cross-Origin Resource Sharing
   (CORS) [7], and servers MUST include the Access-Control-Allow-Origin
   HTTP header in responses.  Servers SHOULD support the least
   restrictive setting by allowing any domain access to the WebFinger
   resource:

      Access-Control-Allow-Origin: *
```

To solve the problem I think the missing header shall be added to the `webfinger` endpoint's responses (cf. `server/controllers/webfinger.ts`).