### PR TITLE
Action hook: thread replies loaded

### DIFF
--- a/client/src/app/+video-channels/video-channels.component.ts
+++ b/client/src/app/+video-channels/video-channels.component.ts
@@ -34,7 +34,7 @@ export class VideoChannelsComponent implements OnInit, OnDestroy {
     private videoChannelService: VideoChannelService,
     private restExtractor: RestExtractor,
     private hotkeysService: HotkeysService,
-    private screenService: ScreenService
+    private screenService: ScreenService
   ) { }
 
   ngOnInit () {

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -100,7 +100,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
           
           if (highlightThread) {
             this.highlightedThread = new VideoComment(res.comment)
-            
+
             // Scroll to the highlighted thread
             setTimeout(() => this.commentHighlightBlock.nativeElement.scrollIntoView(), 0)
           }

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -96,7 +96,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
         res => {
           this.threadComments[commentId] = res
           this.threadLoading[commentId] = false
-          this.hooks.runAction('action:video-watch.video-threads.reply-loaded', 'video-watch', { data: res })
+          this.hooks.runAction('action:video-watch.video-thread-replies.loaded', 'video-watch', { data: res })
 
           if (highlightThread) {
             this.highlightedThread = new VideoComment(res.comment)

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -96,10 +96,11 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
         res => {
           this.threadComments[commentId] = res
           this.threadLoading[commentId] = false
-
+          this.hooks.runAction('action:video-watch.video-threads.reply-loaded', 'video-watch', { data: res })
+          
           if (highlightThread) {
             this.highlightedThread = new VideoComment(res.comment)
-
+            
             // Scroll to the highlighted thread
             setTimeout(() => this.commentHighlightBlock.nativeElement.scrollIntoView(), 0)
           }

--- a/client/src/app/videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/videos/+video-watch/comment/video-comments.component.ts
@@ -97,7 +97,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
           this.threadComments[commentId] = res
           this.threadLoading[commentId] = false
           this.hooks.runAction('action:video-watch.video-threads.reply-loaded', 'video-watch', { data: res })
-          
+
           if (highlightThread) {
             this.highlightedThread = new VideoComment(res.comment)
 
@@ -194,7 +194,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
     return this.authService.isLoggedIn()
   }
 
-  onNearOfBottom () {    
+  onNearOfBottom () { 
     if (hasMoreItems(this.componentPagination)) {
       this.componentPagination.currentPage++
       this.loadMoreThreads()

--- a/shared/models/plugins/client-hook.model.ts
+++ b/shared/models/plugins/client-hook.model.ts
@@ -67,6 +67,8 @@ export const clientActionHookObject = {
   'action:video-watch.player.loaded': true,
   // Fired when the video watch page comments(threads) are loaded and load more comments on scroll
   'action:video-watch.video-threads.loaded': true,
+  // Fired when a user click on 'View x replies' and they're loaded
+  'action:video-watch.video-threads.reply-loaded': true,
 
   // Fired when the search page is being initialized
   'action:search.init': true,

--- a/shared/models/plugins/client-hook.model.ts
+++ b/shared/models/plugins/client-hook.model.ts
@@ -68,7 +68,7 @@ export const clientActionHookObject = {
   // Fired when the video watch page comments(threads) are loaded and load more comments on scroll
   'action:video-watch.video-threads.loaded': true,
   // Fired when a user click on 'View x replies' and they're loaded
-  'action:video-watch.video-threads.reply-loaded': true,
+  'action:video-watch.video-thread-replies.loaded': true,
 
   // Fired when the search page is being initialized
   'action:search.init': true,


### PR DESCRIPTION
Hi!
As I did last week for comments, I added a donation button to comment replies (only if you have peertube-plugin-bittube-airtime-module)
![image](https://user-images.githubusercontent.com/34477436/76215416-9fe2fb00-6206-11ea-8702-644163a04a64.png)
In order to do this from my plugin, I needed to add this hook for comment replies loaded, returning the array of replies. I would be nice to keep my plugin compatible with the federation by adding this PR. It also may be useful for somebody else. Thanks in advance!