### PR TITLE
Add DKIM to docker-compose

### DIFF
--- a/support/doc/docker.md
+++ b/support/doc/docker.md
@@ -114,6 +114,17 @@ peertube_1  | [example.com:443] 2019-11-16 04:26:06.082 info: Username: root
 peertube_1  | [example.com:443] 2019-11-16 04:26:06.083 info: User password: abcdefghijklmnop
 ```
 
+### Obtaining Your Automatically Generated DKIM DNS TXT Record
+[DKIM](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail) signature sending and RSA keys generation are enabled by the default Postfix image `mwader/postfix-relay` with [OpenDKIM](http://www.opendkim.org/).
+Run `cat ./docker-volume/opendkim/keys/*/*.txt` to display your DKIM DNS TXT Record containing the public key to configure to your domain : 
+```BASH
+user@s:~/peertube|master⚡ ⇒  cat ./docker-volume/opendkim/keys/*/*.txt
+
+peertube._domainkey.mydomain.tld.	IN	TXT	( "v=DKIM1; h=sha256; k=rsa; "
+	  "p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Dx7wLGPFVaxVQ4TGym/eF89aQ8oMxS9v5BCc26Hij91t2Ci8Fl12DHNVqZoIPGm+9tTIoDVDFEFrlPhMOZl8i4jU9pcFjjaIISaV2+qTa8uV1j3MyByogG8pu4o5Ill7zaySYFsYB++cHJ9pjbFSC42dddCYMfuVgrBsLNrvEi3dLDMjJF5l92Uu8YeswFe26PuHX3Avr261n"
+	  "j5joTnYwat4387VEUyGUnZ0aZxCERi+ndXv2/wMJ0tizq+a9+EgqIb+7lkUc2XciQPNuTujM25GhrQBEKznvHyPA6fHsFheymOuB763QpkmnQQLCxyLygAY9mE/5RY+5Q6J9oDOQIDAQAB" )  ; ----- DKIM key peertube for mydomain.tld
+```
+
 ### What now?
 
 See the production guide ["What now" section](/support/doc/production.md#what-now). 

--- a/support/docker/production/.env
+++ b/support/docker/production/.env
@@ -20,6 +20,9 @@ PEERTUBE_SMTP_TLS=false
 PEERTUBE_SMTP_DISABLE_STARTTLS=false
 PEERTUBE_ADMIN_EMAIL=<MY EMAIL ADDRESS>
 POSTFIX_myhostname=<MY DOMAIN>
+# If you need to generate a list of sub/DOMAIN keys
+# pass them as a whitespace separated string <DOMAIN>=<selector>
+OPENDKIM_DOMAINS=<MY DOMAIN>=peertube
 TRAEFIK_ACME_EMAIL=<MY EMAIL ADDRESS>
 # If you need to obtain ACME certificates for more than one DOMAIN
 # pass them as a comma separated string

--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -70,6 +70,8 @@ services:
     image: mwader/postfix-relay
     env_file:
       - .env
+    volumes:
+      - ./docker-volume/opendkim/keys:/etc/opendkim/keys
     labels:
       traefik.enable: "false"
     restart: "always"


### PR DESCRIPTION
Issue: https://github.com/Chocobozzz/PeerTube/issues/2545

Add DKIM generation keys and DKIM signature sending with the current image `mwader/postfix-relay`.