### PR TITLE
Add overview of a user's actions in user-edit

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -579,7 +579,7 @@
                         i18n-labelText labelText="Allow additional extensions"
                       >
                         <ng-container ngProjectAs="description">
-                          <span i18n>Allow your users to upload .mkv, .mov, .avi and .flv videos.</span>
+                          <span i18n>Allows users to upload .mkv, .mov, .avi and .flv videos.</span>
                         </ng-container>
                       </my-peertube-checkbox>
                     </div>
@@ -590,7 +590,7 @@
                         i18n-labelText labelText="Allow audio files upload"
                       >
                         <ng-container ngProjectAs="description">
-                          <span i18n>Allow your users to upload audio files that will be merged with the preview file on upload.</span>
+                          <span i18n>Allows users to upload audio files that will be merged with the preview file on upload.</span>
                         </ng-container>
                       </my-peertube-checkbox>
                     </div>

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.scss
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.scss
@@ -50,6 +50,7 @@ input[type=submit] {
 textarea {
   @include peertube-textarea(500px, 150px);
 
+  max-width: 100%;
   display: block;
 
   &.small {
@@ -71,6 +72,10 @@ my-markdown-textarea ::ng-deep {
   .root {
     @media screen and (max-width: 1400px) {
       flex-direction: column !important;
+    }
+
+    textarea {
+      max-width: 100%;
     }
   }
 }

--- a/client/src/app/+admin/users/user-edit/user-create.component.ts
+++ b/client/src/app/+admin/users/user-edit/user-create.component.ts
@@ -8,6 +8,7 @@ import { FormValidatorService } from '@app/shared/forms/form-validators/form-val
 import { UserValidatorsService } from '@app/shared/forms/form-validators/user-validators.service'
 import { ConfigService } from '@app/+admin/config/shared/config.service'
 import { UserService } from '@app/shared'
+import { ScreenService } from '@app/shared/misc/screen.service'
 
 @Component({
   selector: 'my-user-create',
@@ -21,6 +22,7 @@ export class UserCreateComponent extends UserEdit implements OnInit {
     protected serverService: ServerService,
     protected formValidatorService: FormValidatorService,
     protected configService: ConfigService,
+    protected screenService: ScreenService,
     protected auth: AuthService,
     private userValidatorsService: UserValidatorsService,
     private route: ActivatedRoute,

--- a/client/src/app/+admin/users/user-edit/user-edit.component.html
+++ b/client/src/app/+admin/users/user-edit/user-edit.component.html
@@ -1,14 +1,14 @@
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item">
-      <a routerLink="/admin/users">Users</a>
+      <a routerLink="/admin/users" i18n>Users</a>
     </li>
 
     <ng-container *ngIf="isCreation()">
-      <li class="breadcrumb-item active">Create</li>
+      <li class="breadcrumb-item active" i18n>Create</li>
     </ng-container>
     <ng-container *ngIf="!isCreation()">
-      <li class="breadcrumb-item">Edit</li>
+      <li class="breadcrumb-item active" i18n>Edit</li>
       <li class="breadcrumb-item active" aria-current="page">
         <a *ngIf="user" [routerLink]="[ '/accounts', user?.username ]">{{ user?.username }}</a>
       </li>

--- a/client/src/app/+admin/users/user-edit/user-edit.component.html
+++ b/client/src/app/+admin/users/user-edit/user-edit.component.html
@@ -16,50 +16,52 @@
   </ol>
 </nav>
 
+<ng-template #dashboard>
+  <div *ngIf="!isCreation() && user" class="dashboard">
+    <div>
+      <a>
+        <div class="dashboard-num">{{ user.videosCount }} ({{ user.videoQuotaUsed | bytes: 0 }})</div>
+        <div class="dashboard-label" i18n>{user.videosCount, plural, =1 {Video} other {Videos}}</div>
+      </a>
+    </div>
+    <div>
+      <a>
+        <div class="dashboard-num">{{ user.videoChannels.length || 0 }}</div>
+        <div class="dashboard-label" i18n>{user.videoChannels.length, plural, =1 {Channel} other {Channels}}</div>
+      </a>
+    </div>
+    <div>
+      <a>
+        <div class="dashboard-num">{{ subscribersCount }}</div>
+        <div class="dashboard-label" i18n>{subscribersCount, plural, =1 {Subscriber} other {Subscribers}}</div>
+      </a>
+    </div>
+    <div>
+      <a>
+        <div class="dashboard-num">{{ user.videoAbusesCount }}</div>
+        <div class="dashboard-label" i18n>Incriminated in reports</div>
+      </a>
+    </div>
+    <div>
+      <a>
+        <div class="dashboard-num">{{ user.videoAbusesAcceptedCount }} / {{ user.videoAbusesCreatedCount }}</div>
+        <div class="dashboard-label" i18n>Authored reports accepted</div>
+      </a>
+    </div>
+    <div>
+      <a>
+        <div class="dashboard-num">{{ user.videoCommentsCount }}</div>
+        <div class="dashboard-label" i18n>{user.videoCommentsCount, plural, =1 {Comment} other {Comments}}</div>
+      </a>
+    </div>
+  </div>
+</ng-template>
+
 <div class="form-row">
   <div class="col-12 col-xl-3"></div>
 
   <div class="form-group-right col-12 col-xl-9">
-
-    <div *ngIf="!isCreation() && user" class="dashboard">
-      <div>
-        <a>
-          <div class="dashboard-num">{{ user.videoCount }} ({{ user.videoQuotaUsed | bytes: 0 }})</div>
-          <div class="dashboard-label" i18n>{user.videoCount, plural, =1 {Video} other {Videos}}</div>
-        </a>
-      </div>
-      <div>
-        <a>
-          <div class="dashboard-num">{{ user.videoChannels.length || 0 }}</div>
-          <div class="dashboard-label" i18n>{user.videoChannels.length, plural, =1 {Channel} other {Channels}}</div>
-        </a>
-      </div>
-      <div>
-        <a>
-          <div class="dashboard-num">{{ subscribersCount }}</div>
-          <div class="dashboard-label" i18n>{subscribersCount, plural, =1 {Subscriber} other {Subscribers}}</div>
-        </a>
-      </div>
-      <div>
-        <a>
-          <div class="dashboard-num">{{ user.videoAbuseCount }}</div>
-          <div class="dashboard-label" i18n>Incriminated in reports</div>
-        </a>
-      </div>
-      <div>
-        <a>
-          <div class="dashboard-num">{{ user.videoAbuseAcceptedCount }} / {{ user.videoAbuseCreatedCount }}</div>
-          <div class="dashboard-label" i18n>Authored reports accepted</div>
-        </a>
-      </div>
-      <div>
-        <a>
-          <div class="dashboard-num">{{ user.videoCommentCount }}</div>
-          <div class="dashboard-label" i18n>{user.videoCommentCount, plural, =1 {Comment} other {Comments}}</div>
-        </a>
-      </div>
-    </div>
-
+    <ng-template *ngTemplateOutlet="dashboard"></ng-template>
   </div>
 </div>
 

--- a/client/src/app/+admin/users/user-edit/user-edit.component.html
+++ b/client/src/app/+admin/users/user-edit/user-edit.component.html
@@ -76,7 +76,7 @@
     </div>
   </div>
 
-  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9 form-row">
+  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9" [ngClass]="{ 'form-row': isInBigView() }">
 
     <form role="form" (ngSubmit)="formValidated()" [formGroup]="form" [ngClass]="{ 'col-5': isInBigView() }">
       <div class="form-group" *ngIf="isCreation()">
@@ -182,11 +182,11 @@
 
 <div *ngIf="!isCreation() && user" class="form-row mt-4"> <!-- danger zone grid -->
   <div class="form-group col-12 col-lg-4 col-xl-3">
-    <div class="anchor" id="user"></div> <!-- danger zone anchor -->
+    <div class="anchor" id="danger"></div> <!-- danger zone anchor -->
     <div i18n class="account-title">DANGER ZONE</div>
   </div>
 
-  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9">
+  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9" [ngClass]="{ 'form-row': isInBigView() }">
 
     <div class="danger-zone">
       <div class="form-group reset-password-email">

--- a/client/src/app/+admin/users/user-edit/user-edit.component.html
+++ b/client/src/app/+admin/users/user-edit/user-edit.component.html
@@ -1,112 +1,198 @@
-<div i18n class="form-sub-title" *ngIf="isCreation() === true">Create user</div>
-<div i18n class="form-sub-title" *ngIf="isCreation() === false">Edit user {{ username }}</div>
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <a routerLink="/admin/users">Users</a>
+    </li>
+
+    <ng-container *ngIf="isCreation()">
+      <li class="breadcrumb-item active">Create</li>
+    </ng-container>
+    <ng-container *ngIf="!isCreation()">
+      <li class="breadcrumb-item">Edit</li>
+      <li class="breadcrumb-item active" aria-current="page">
+        <a *ngIf="user" [routerLink]="[ '/accounts', user?.username ]">{{ user?.username }}</a>
+      </li>
+    </ng-container>
+  </ol>
+</nav>
+
+<div class="form-row">
+  <div class="col-12 col-xl-3"></div>
+
+  <div class="form-group-right col-12 col-xl-9">
+
+    <div *ngIf="!isCreation() && user" class="dashboard">
+      <div>
+        <a>
+          <div class="dashboard-num">{{ user.videoCount }} ({{ user.videoQuotaUsed | bytes: 0 }})</div>
+          <div class="dashboard-label" i18n>{user.videoCount, plural, =1 {Video} other {Videos}}</div>
+        </a>
+      </div>
+      <div>
+        <a>
+          <div class="dashboard-num">{{ user.videoChannels.length || 0 }}</div>
+          <div class="dashboard-label" i18n>{user.videoChannels.length, plural, =1 {Channel} other {Channels}}</div>
+        </a>
+      </div>
+      <div>
+        <a>
+          <div class="dashboard-num">{{ subscribersCount }}</div>
+          <div class="dashboard-label" i18n>{subscribersCount, plural, =1 {Subscriber} other {Subscribers}}</div>
+        </a>
+      </div>
+      <div>
+        <a>
+          <div class="dashboard-num">{{ user.videoAbuseCount }}</div>
+          <div class="dashboard-label" i18n>Incriminated in reports</div>
+        </a>
+      </div>
+      <div>
+        <a>
+          <div class="dashboard-num">{{ user.videoAbuseAcceptedCount }} / {{ user.videoAbuseCreatedCount }}</div>
+          <div class="dashboard-label" i18n>Authored reports accepted</div>
+        </a>
+      </div>
+      <div>
+        <a>
+          <div class="dashboard-num">{{ user.videoCommentCount }}</div>
+          <div class="dashboard-label" i18n>{user.videoCommentCount, plural, =1 {Comment} other {Comments}}</div>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</div>
 
 <div *ngIf="error" class="alert alert-danger">{{ error }}</div>
 
-<form role="form" (ngSubmit)="formValidated()" [formGroup]="form">
-  <div class="form-group" *ngIf="isCreation()">
-    <label i18n for="username">Username</label>
-    <input
-      type="text" id="username" i18n-placeholder placeholder="john"
-      formControlName="username" [ngClass]="{ 'input-error': formErrors['username'] }"
-    >
-    <div *ngIf="formErrors.username" class="form-error">
-      {{ formErrors.username }}
+<div class="form-row mt-4"> <!-- user grid -->
+  <div class="form-group col-12 col-lg-4 col-xl-3">
+    <div class="anchor" id="user"></div> <!-- user anchor -->
+    <div *ngIf="isCreation()" i18n class="account-title">NEW USER</div>
+    <div *ngIf="!isCreation() && user" class="account-title">
+      <my-actor-avatar-info [actor]="user.account"></my-actor-avatar-info>
     </div>
   </div>
 
-  <div class="form-group">
-    <label i18n for="email">Email</label>
-    <input
-      type="text" id="email" i18n-placeholder placeholder="mail@example.com"
-      formControlName="email" [ngClass]="{ 'input-error': formErrors['email'] }"
-      autocomplete="off"
-    >
-    <div *ngIf="formErrors.email" class="form-error">
-      {{ formErrors.email }}
-    </div>
+  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9">
+
+    <form role="form" (ngSubmit)="formValidated()" [formGroup]="form">
+      <div class="form-group" *ngIf="isCreation()">
+        <label i18n for="username">Username</label>
+        <input
+          type="text" id="username" i18n-placeholder placeholder="john"
+          formControlName="username" [ngClass]="{ 'input-error': formErrors['username'] }"
+        >
+        <div *ngIf="formErrors.username" class="form-error">
+          {{ formErrors.username }}
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label i18n for="email">Email</label>
+        <input
+          type="text" id="email" i18n-placeholder placeholder="mail@example.com"
+          formControlName="email" [ngClass]="{ 'input-error': formErrors['email'] }"
+          autocomplete="off"
+        >
+        <div *ngIf="formErrors.email" class="form-error">
+          {{ formErrors.email }}
+        </div>
+      </div>
+
+      <div class="form-group" *ngIf="isCreation()">
+        <label i18n for="password">Password</label>
+        <my-help *ngIf="isPasswordOptional()">
+          <ng-template ptTemplate="customHtml">
+            <ng-container i18n>
+              If you leave the password empty, an email will be sent to the user.
+            </ng-container>
+          </ng-template>
+        </my-help>
+        <input
+          type="password" id="password" autocomplete="new-password"
+          formControlName="password" [ngClass]="{ 'input-error': formErrors['password'] }"
+        >
+        <div *ngIf="formErrors.password" class="form-error">
+          {{ formErrors.password }}
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label i18n for="role">Role</label>
+        <div class="peertube-select-container">
+            <select id="role" formControlName="role">
+              <option *ngFor="let role of roles" [value]="role.value">
+               {{ role.label }}
+              </option>
+            </select>
+        </div>
+
+        <div *ngIf="formErrors.role" class="form-error">
+          {{ formErrors.role }}
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label i18n for="videoQuota">Video quota</label>
+        <div class="peertube-select-container">
+          <select id="videoQuota" formControlName="videoQuota">
+            <option *ngFor="let videoQuotaOption of videoQuotaOptions" [value]="videoQuotaOption.value">
+              {{ videoQuotaOption.label }}
+            </option>
+          </select>
+        </div>
+
+        <div i18n class="transcoding-information" *ngIf="isTranscodingInformationDisplayed()">
+          Transcoding is enabled. The video quota only takes into account <strong>original</strong> video size. <br />
+          At most, this user could upload ~ {{ computeQuotaWithTranscoding() | bytes: 0 }}.
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label i18n for="videoQuotaDaily">Daily video quota</label>
+        <div class="peertube-select-container">
+          <select id="videoQuotaDaily" formControlName="videoQuotaDaily">
+            <option *ngFor="let videoQuotaDailyOption of videoQuotaDailyOptions" [value]="videoQuotaDailyOption.value">
+              {{ videoQuotaDailyOption.label }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <my-peertube-checkbox
+          inputName="byPassAutoBlacklist" formControlName="byPassAutoBlacklist"
+          i18n-labelText labelText="Doesn't need review before a video goes public"
+        ></my-peertube-checkbox>
+      </div>
+
+      <input type="submit" value="{{ getFormButtonTitle() }}" [disabled]="!form.valid">
+    </form>
+
+  </div>
+</div>
+
+
+<div *ngIf="!isCreation() && user" class="form-row mt-4"> <!-- danger zone grid -->
+  <div class="form-group col-12 col-lg-4 col-xl-3">
+    <div class="anchor" id="user"></div> <!-- danger zone anchor -->
+    <div i18n class="account-title">DANGER ZONE</div>
   </div>
 
-  <div class="form-group" *ngIf="isCreation()">
-    <label i18n for="password">Password</label>
-    <my-help *ngIf="isPasswordOptional()">
-      <ng-template ptTemplate="customHtml">
-        <ng-container i18n>
-          If you leave the password empty, an email will be sent to the user.
-        </ng-container>
-      </ng-template>
-    </my-help>
-    <input
-      type="password" id="password" autocomplete="new-password"
-      formControlName="password" [ngClass]="{ 'input-error': formErrors['password'] }"
-    >
-    <div *ngIf="formErrors.password" class="form-error">
-      {{ formErrors.password }}
-    </div>
-  </div>
+  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9">
 
-  <div class="form-group">
-    <label i18n for="role">Role</label>
-    <div class="peertube-select-container">
-      <select id="role" formControlName="role">
-        <option *ngFor="let role of roles" [value]="role.value">
-          {{ role.label }}
-        </option>
-      </select>
+    <div class="danger-zone">
+      <div class="form-group reset-password-email">
+        <label i18n>Send a link to reset the password by email to the user</label>
+        <button (click)="resetPassword()" i18n>Ask for new password</button>
+      </div>
+
+      <div class="form-group">
+        <label i18n>Manually set the user password</label>
+        <my-user-password [userId]="user.id"></my-user-password>
+      </div>
     </div>
 
-    <div *ngIf="formErrors.role" class="form-error">
-      {{ formErrors.role }}
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label i18n for="videoQuota">Video quota</label>
-    <div class="peertube-select-container">
-      <select id="videoQuota" formControlName="videoQuota">
-        <option *ngFor="let videoQuotaOption of videoQuotaOptions" [value]="videoQuotaOption.value">
-          {{ videoQuotaOption.label }}
-        </option>
-      </select>
-    </div>
-
-    <div i18n class="transcoding-information" *ngIf="isTranscodingInformationDisplayed()">
-      Transcoding is enabled on server. The video quota only take in account <strong>original</strong> video. <br />
-      At most, this user could use ~ {{ computeQuotaWithTranscoding() | bytes: 0 }}.
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label i18n for="videoQuotaDaily">Daily video quota</label>
-    <div class="peertube-select-container">
-      <select id="videoQuotaDaily" formControlName="videoQuotaDaily">
-        <option *ngFor="let videoQuotaDailyOption of videoQuotaDailyOptions" [value]="videoQuotaDailyOption.value">
-          {{ videoQuotaDailyOption.label }}
-        </option>
-      </select>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <my-peertube-checkbox
-      inputName="byPassAutoBlacklist" formControlName="byPassAutoBlacklist"
-      i18n-labelText labelText="Bypass video auto blacklist"
-    ></my-peertube-checkbox>
-  </div>
-
-  <input type="submit" value="{{ getFormButtonTitle() }}" [disabled]="!form.valid">
-</form>
-
-<div *ngIf="!isCreation()" class="danger-zone">
-  <div class="account-title" i18n>Danger Zone</div>
-
-  <div class="form-group reset-password-email">
-    <label i18n>Send a link to reset the password by email to the user</label>
-    <button (click)="resetPassword()" i18n>Ask for new password</button>
-  </div>
-
-  <div class="form-group">
-    <label i18n>Manually set the user password</label>
-    <my-user-password [userId]="userId"></my-user-password>
   </div>
 </div>

--- a/client/src/app/+admin/users/user-edit/user-edit.component.html
+++ b/client/src/app/+admin/users/user-edit/user-edit.component.html
@@ -57,7 +57,7 @@
   </div>
 </ng-template>
 
-<div class="form-row">
+<div class="form-row" *ngIf="!isInBigView()"> <!-- hidden on large screens, as it is then displayed on the right side of the form -->
   <div class="col-12 col-xl-3"></div>
 
   <div class="form-group-right col-12 col-xl-9">
@@ -70,15 +70,15 @@
 <div class="form-row mt-4"> <!-- user grid -->
   <div class="form-group col-12 col-lg-4 col-xl-3">
     <div class="anchor" id="user"></div> <!-- user anchor -->
-    <div *ngIf="isCreation()" i18n class="account-title">NEW USER</div>
+    <div *ngIf="isCreation()" class="account-title" i18n>NEW USER</div>
     <div *ngIf="!isCreation() && user" class="account-title">
       <my-actor-avatar-info [actor]="user.account"></my-actor-avatar-info>
     </div>
   </div>
 
-  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9">
+  <div class="form-group form-group-right col-12 col-lg-8 col-xl-9 form-row">
 
-    <form role="form" (ngSubmit)="formValidated()" [formGroup]="form">
+    <form role="form" (ngSubmit)="formValidated()" [formGroup]="form" [ngClass]="{ 'col-5': isInBigView() }">
       <div class="form-group" *ngIf="isCreation()">
         <label i18n for="username">Username</label>
         <input
@@ -89,7 +89,7 @@
           {{ formErrors.username }}
         </div>
       </div>
-
+  
       <div class="form-group">
         <label i18n for="email">Email</label>
         <input
@@ -101,7 +101,7 @@
           {{ formErrors.email }}
         </div>
       </div>
-
+  
       <div class="form-group" *ngIf="isCreation()">
         <label i18n for="password">Password</label>
         <my-help *ngIf="isPasswordOptional()">
@@ -119,7 +119,7 @@
           {{ formErrors.password }}
         </div>
       </div>
-
+  
       <div class="form-group">
         <label i18n for="role">Role</label>
         <div class="peertube-select-container">
@@ -129,12 +129,12 @@
               </option>
             </select>
         </div>
-
+  
         <div *ngIf="formErrors.role" class="form-error">
           {{ formErrors.role }}
         </div>
       </div>
-
+  
       <div class="form-group">
         <label i18n for="videoQuota">Video quota</label>
         <div class="peertube-select-container">
@@ -144,13 +144,13 @@
             </option>
           </select>
         </div>
-
+  
         <div i18n class="transcoding-information" *ngIf="isTranscodingInformationDisplayed()">
           Transcoding is enabled. The video quota only takes into account <strong>original</strong> video size. <br />
           At most, this user could upload ~ {{ computeQuotaWithTranscoding() | bytes: 0 }}.
         </div>
       </div>
-
+  
       <div class="form-group">
         <label i18n for="videoQuotaDaily">Daily video quota</label>
         <div class="peertube-select-container">
@@ -161,16 +161,20 @@
           </select>
         </div>
       </div>
-
+  
       <div class="form-group">
         <my-peertube-checkbox
           inputName="byPassAutoBlacklist" formControlName="byPassAutoBlacklist"
           i18n-labelText labelText="Doesn't need review before a video goes public"
         ></my-peertube-checkbox>
       </div>
-
+  
       <input type="submit" value="{{ getFormButtonTitle() }}" [disabled]="!form.valid">
     </form>
+
+    <div *ngIf="isInBigView()" class="col-7">
+      <ng-template *ngTemplateOutlet="dashboard"></ng-template>
+    </div>
 
   </div>
 </div>

--- a/client/src/app/+admin/users/user-edit/user-edit.component.scss
+++ b/client/src/app/+admin/users/user-edit/user-edit.component.scss
@@ -1,8 +1,13 @@
 @import '_variables';
 @import '_mixins';
 
-.form-sub-title {
-  margin-bottom: 30px;
+label {
+  font-weight: $font-regular;
+  font-size: 100%;
+}
+
+.account-title {
+  @include settings-big-title;
 }
 
 input:not([type=submit]) {
@@ -26,22 +31,30 @@ input[type=submit], button {
   font-size: 11px;
 }
 
-.account-title {
-  @include in-content-small-title;
-
-  margin-top: 55px;
-  margin-bottom: 30px;
-}
-
 .danger-zone {
   .reset-password-email {
     margin-bottom: 30px;
-    padding-bottom: 30px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 
     button {
       display: block;
       margin-top: 0;
     }
+  }
+}
+
+.breadcrumb {
+  @include breadcrumb;
+}
+
+.dashboard {
+  @include dashboard;
+  max-width: 900px;
+}
+
+my-actor-avatar-info ::ng-deep {
+  .actor-img-edit-container,
+  .actor-info-followers,
+  .actor-info-username {
+    display: none;
   }
 }

--- a/client/src/app/+admin/users/user-edit/user-edit.ts
+++ b/client/src/app/+admin/users/user-edit/user-edit.ts
@@ -4,12 +4,13 @@ import { ServerConfig, USER_ROLE_LABELS, UserRole, VideoResolution } from '../..
 import { ConfigService } from '@app/+admin/config/shared/config.service'
 import { UserAdminFlag } from '@shared/models/users/user-flag.model'
 import { OnInit } from '@angular/core'
+import { User } from '@app/shared/users/user.model'
 
 export abstract class UserEdit extends FormReactive implements OnInit {
   videoQuotaOptions: { value: string, label: string }[] = []
   videoQuotaDailyOptions: { value: string, label: string }[] = []
   username: string
-  userId: number
+  user: User
 
   roles: { value: string, label: string }[] = []
 

--- a/client/src/app/+admin/users/user-edit/user-edit.ts
+++ b/client/src/app/+admin/users/user-edit/user-edit.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@app/+admin/config/shared/config.service'
 import { UserAdminFlag } from '@shared/models/users/user-flag.model'
 import { OnInit } from '@angular/core'
 import { User } from '@app/shared/users/user.model'
+import { ScreenService } from '@app/shared/misc/screen.service'
 
 export abstract class UserEdit extends FormReactive implements OnInit {
   videoQuotaOptions: { value: string, label: string }[] = []
@@ -18,6 +19,7 @@ export abstract class UserEdit extends FormReactive implements OnInit {
 
   protected abstract serverService: ServerService
   protected abstract configService: ConfigService
+  protected abstract screenService: ScreenService
   protected abstract auth: AuthService
   abstract isCreation (): boolean
   abstract getFormButtonTitle (): string
@@ -38,6 +40,10 @@ export abstract class UserEdit extends FormReactive implements OnInit {
       ? this.user.videoChannels.map(c => c.followersCount).reduce((a, b) => a + b, 0)
       : 0
     return forAccount + forChannels
+  }
+
+  isInBigView () {
+    return this.screenService.getWindowInnerWidth() > 1600
   }
 
   buildRoles () {

--- a/client/src/app/+admin/users/user-edit/user-edit.ts
+++ b/client/src/app/+admin/users/user-edit/user-edit.ts
@@ -30,6 +30,16 @@ export abstract class UserEdit extends FormReactive implements OnInit {
     this.buildRoles()
   }
 
+  get subscribersCount () {
+    const forAccount = this.user
+      ? this.user.account.followersCount
+      : 0
+    const forChannels = this.user
+      ? this.user.videoChannels.map(c => c.followersCount).reduce((a, b) => a + b, 0)
+      : 0
+    return forAccount + forChannels
+  }
+
   buildRoles () {
     const authUser = this.auth.getUser()
 

--- a/client/src/app/+admin/users/user-edit/user-password.component.ts
+++ b/client/src/app/+admin/users/user-edit/user-password.component.ts
@@ -23,8 +23,6 @@ export class UserPasswordComponent extends FormReactive implements OnInit {
   constructor (
     protected formValidatorService: FormValidatorService,
     private userValidatorsService: UserValidatorsService,
-    private route: ActivatedRoute,
-    private router: Router,
     private notifier: Notifier,
     private userService: UserService,
     private i18n: I18n

--- a/client/src/app/+admin/users/user-edit/user-update.component.ts
+++ b/client/src/app/+admin/users/user-edit/user-update.component.ts
@@ -45,7 +45,12 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
   ngOnInit () {
     super.ngOnInit()
 
-    const defaultValues = { role: UserRole.USER.toString(), videoQuota: '-1', videoQuotaDaily: '-1' }
+    const defaultValues = {
+      role: UserRole.USER.toString(),
+      videoQuota: '-1',
+      videoQuotaDaily: '-1'
+    }
+
     this.buildForm({
       email: this.userValidatorsService.USER_EMAIL,
       role: this.userValidatorsService.USER_ROLE,
@@ -80,7 +85,7 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
 
     this.userService.updateUser(this.user.id, userUpdate).subscribe(
       () => {
-        this.notifier.success(this.i18n('User {{username}} updated.', { username: this.user.username }))
+        this.notifier.success(this.i18n('User {{user.username}} updated.', { username: this.user.username }))
         this.router.navigate([ '/admin/users/list' ])
       },
 

--- a/client/src/app/+admin/users/user-edit/user-update.component.ts
+++ b/client/src/app/+admin/users/user-edit/user-update.component.ts
@@ -61,7 +61,7 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
 
     this.paramsSub = this.route.params.subscribe(routeParams => {
       const userId = routeParams['id']
-      this.userService.getUser(userId).subscribe(
+      this.userService.getUser(userId, true).subscribe(
         user => this.onUserFetched(user),
 
         err => this.error = err.message

--- a/client/src/app/+admin/users/user-edit/user-update.component.ts
+++ b/client/src/app/+admin/users/user-edit/user-update.component.ts
@@ -12,8 +12,7 @@ import { ConfigService } from '@app/+admin/config/shared/config.service'
 import { UserService } from '@app/shared'
 import { UserAdminFlag } from '@shared/models/users/user-flag.model'
 import { User } from '@app/shared/users/user.model'
-import { Account } from '@app/shared/account/account.model'
-import { VideoChannel } from '@app/shared/video-channel/video-channel.model'
+import { ScreenService } from '@app/shared/misc/screen.service'
 
 @Component({
   selector: 'my-user-update',
@@ -29,6 +28,7 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
     protected formValidatorService: FormValidatorService,
     protected serverService: ServerService,
     protected configService: ConfigService,
+    protected screenService: ScreenService,
     protected auth: AuthService,
     private userValidatorsService: UserValidatorsService,
     private route: ActivatedRoute,

--- a/client/src/app/+admin/users/user-edit/user-update.component.ts
+++ b/client/src/app/+admin/users/user-edit/user-update.component.ts
@@ -4,13 +4,16 @@ import { Subscription } from 'rxjs'
 import { AuthService, Notifier } from '@app/core'
 import { ServerService } from '../../../core'
 import { UserEdit } from './user-edit'
-import { User, UserUpdate } from '../../../../../../shared'
+import { User as UserType, UserUpdate, UserRole } from '../../../../../../shared'
 import { I18n } from '@ngx-translate/i18n-polyfill'
 import { FormValidatorService } from '@app/shared/forms/form-validators/form-validator.service'
 import { UserValidatorsService } from '@app/shared/forms/form-validators/user-validators.service'
 import { ConfigService } from '@app/+admin/config/shared/config.service'
 import { UserService } from '@app/shared'
 import { UserAdminFlag } from '@shared/models/users/user-flag.model'
+import { User } from '@app/shared/users/user.model'
+import { Account } from '@app/shared/account/account.model'
+import { VideoChannel } from '@app/shared/video-channel/video-channel.model'
 
 @Component({
   selector: 'my-user-update',
@@ -19,9 +22,6 @@ import { UserAdminFlag } from '@shared/models/users/user-flag.model'
 })
 export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
   error: string
-  userId: number
-  userEmail: string
-  username: string
 
   private paramsSub: Subscription
 
@@ -45,7 +45,7 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
   ngOnInit () {
     super.ngOnInit()
 
-    const defaultValues = { videoQuota: '-1', videoQuotaDaily: '-1' }
+    const defaultValues = { role: UserRole.USER.toString(), videoQuota: '-1', videoQuotaDaily: '-1' }
     this.buildForm({
       email: this.userValidatorsService.USER_EMAIL,
       role: this.userValidatorsService.USER_ROLE,
@@ -78,9 +78,9 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
     userUpdate.videoQuota = parseInt(this.form.value['videoQuota'], 10)
     userUpdate.videoQuotaDaily = parseInt(this.form.value['videoQuotaDaily'], 10)
 
-    this.userService.updateUser(this.userId, userUpdate).subscribe(
+    this.userService.updateUser(this.user.id, userUpdate).subscribe(
       () => {
-        this.notifier.success(this.i18n('User {{username}} updated.', { username: this.username }))
+        this.notifier.success(this.i18n('User {{username}} updated.', { username: this.user.username }))
         this.router.navigate([ '/admin/users/list' ])
       },
 
@@ -101,10 +101,10 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
   }
 
   resetPassword () {
-    this.userService.askResetPassword(this.userEmail).subscribe(
+    this.userService.askResetPassword(this.user.email).subscribe(
       () => {
         this.notifier.success(
-          this.i18n('An email asking for password reset has been sent to {{username}}.', { username: this.username })
+          this.i18n('An email asking for password reset has been sent to {{username}}.', { username: this.user.username })
         )
       },
 
@@ -112,14 +112,12 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
     )
   }
 
-  private onUserFetched (userJson: User) {
-    this.userId = userJson.id
-    this.username = userJson.username
-    this.userEmail = userJson.email
+  private onUserFetched (userJson: UserType) {
+    this.user = new User(userJson)
 
     this.form.patchValue({
       email: userJson.email,
-      role: userJson.role,
+      role: userJson.role.toString(),
       videoQuota: userJson.videoQuota,
       videoQuotaDaily: userJson.videoQuotaDaily,
       byPassAutoBlacklist: userJson.adminFlags & UserAdminFlag.BY_PASS_VIDEO_AUTO_BLACKLIST

--- a/client/src/app/+my-account/my-account.module.ts
+++ b/client/src/app/+my-account/my-account.module.ts
@@ -15,7 +15,6 @@ import { MyAccountProfileComponent } from '@app/+my-account/my-account-settings/
 import { MyAccountVideoChannelsComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channels.component'
 import { MyAccountVideoChannelCreateComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channel-create.component'
 import { MyAccountVideoChannelUpdateComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channel-update.component'
-import { ActorAvatarInfoComponent } from '@app/+my-account/shared/actor-avatar-info.component'
 import { MyAccountVideoImportsComponent } from '@app/+my-account/my-account-video-imports/my-account-video-imports.component'
 import { MyAccountDangerZoneComponent } from '@app/+my-account/my-account-settings/my-account-danger-zone'
 import { MyAccountSubscriptionsComponent } from '@app/+my-account/my-account-subscriptions/my-account-subscriptions.component'
@@ -63,7 +62,6 @@ import { MyAccountChangeEmailComponent } from '@app/+my-account/my-account-setti
     MyAccountVideoChannelsComponent,
     MyAccountVideoChannelCreateComponent,
     MyAccountVideoChannelUpdateComponent,
-    ActorAvatarInfoComponent,
     MyAccountVideoImportsComponent,
     MyAccountDangerZoneComponent,
     MyAccountSubscriptionsComponent,

--- a/client/src/app/+my-account/shared/actor-avatar-info.component.html
+++ b/client/src/app/+my-account/shared/actor-avatar-info.component.html
@@ -1,13 +1,16 @@
 <ng-container *ngIf="actor">
   <div class="actor">
-    <img [src]="actor.avatarUrl" alt="Avatar" />
+    <div class="d-flex">
+      <img [src]="actor.avatarUrl" alt="Avatar" />
 
-    <div class="actor-img-edit-container">
-      <div class="actor-img-edit-button" [ngbTooltip]="'(extensions: '+ avatarExtensions +', '+ maxSizeText +': '+ maxAvatarSizeInBytes +')'" placement="right" container="body">
-        <my-global-icon iconName="edit"></my-global-icon>
-        <input #avatarfileInput type="file" title=" " name="avatarfile" id="avatarfile" [accept]="avatarExtensions" (change)="onAvatarChange()"/>
+      <div class="actor-img-edit-container">
+        <div class="actor-img-edit-button" [ngbTooltip]="'(extensions: '+ avatarExtensions +', '+ maxSizeText +': '+ maxAvatarSizeInBytes +')'" placement="right" container="body">
+          <my-global-icon iconName="edit"></my-global-icon>
+          <input #avatarfileInput type="file" title=" " name="avatarfile" id="avatarfile" [accept]="avatarExtensions" (change)="onAvatarChange()"/>
+        </div>
       </div>
     </div>
+
 
     <div class="actor-info">
       <div class="actor-info-names">

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -106,6 +106,7 @@ import { InputSwitchModule } from 'primeng/inputswitch'
 
 import { MyAccountVideoSettingsComponent } from '@app/+my-account/my-account-settings/my-account-video-settings'
 import { MyAccountInterfaceSettingsComponent } from '@app/+my-account/my-account-settings/my-account-interface'
+import { ActorAvatarInfoComponent } from '@app/+my-account/shared/actor-avatar-info.component'
 
 @NgModule({
   imports: [
@@ -189,7 +190,8 @@ import { MyAccountInterfaceSettingsComponent } from '@app/+my-account/my-account
     PreviewUploadComponent,
 
     MyAccountVideoSettingsComponent,
-    MyAccountInterfaceSettingsComponent
+    MyAccountInterfaceSettingsComponent,
+    ActorAvatarInfoComponent
   ],
 
   exports: [
@@ -270,7 +272,8 @@ import { MyAccountInterfaceSettingsComponent } from '@app/+my-account/my-account
     VideoDurationPipe,
 
     MyAccountVideoSettingsComponent,
-    MyAccountInterfaceSettingsComponent
+    MyAccountInterfaceSettingsComponent,
+    ActorAvatarInfoComponent
   ],
 
   providers: [

--- a/client/src/app/shared/users/user.model.ts
+++ b/client/src/app/shared/users/user.model.ts
@@ -51,11 +51,11 @@ export class User implements UserServerModel {
   videoQuotaDaily: number
   videoQuotaUsed?: number
   videoQuotaUsedDaily?: number
-  videoCount?: number
-  videoAbuseCount?: number
-  videoAbuseAcceptedCount?: number
-  videoAbuseCreatedCount?: number
-  videoCommentCount?: number
+  videosCount?: number
+  videoAbusesCount?: number
+  videoAbusesAcceptedCount?: number
+  videoAbusesCreatedCount?: number
+  videoCommentsCount?: number
 
   theme: string
 
@@ -84,11 +84,11 @@ export class User implements UserServerModel {
     this.videoQuotaDaily = hash.videoQuotaDaily
     this.videoQuotaUsed = hash.videoQuotaUsed
     this.videoQuotaUsedDaily = hash.videoQuotaUsedDaily
-    this.videoCount = hash.videoCount
-    this.videoAbuseCount = hash.videoAbuseCount
-    this.videoAbuseAcceptedCount = hash.videoAbuseAcceptedCount
-    this.videoAbuseCreatedCount = hash.videoAbuseCreatedCount
-    this.videoCommentCount = hash.videoCommentCount
+    this.videosCount = hash.videosCount
+    this.videoAbusesCount = hash.videoAbusesCount
+    this.videoAbusesAcceptedCount = hash.videoAbusesAcceptedCount
+    this.videoAbusesCreatedCount = hash.videoAbusesCreatedCount
+    this.videoCommentsCount = hash.videoCommentsCount
 
     this.nsfwPolicy = hash.nsfwPolicy
     this.webTorrentEnabled = hash.webTorrentEnabled

--- a/client/src/app/shared/users/user.model.ts
+++ b/client/src/app/shared/users/user.model.ts
@@ -51,6 +51,11 @@ export class User implements UserServerModel {
   videoQuotaDaily: number
   videoQuotaUsed?: number
   videoQuotaUsedDaily?: number
+  videoCount?: number
+  videoAbuseCount?: number
+  videoAbuseAcceptedCount?: number
+  videoAbuseCreatedCount?: number
+  videoCommentCount?: number
 
   theme: string
 
@@ -79,6 +84,11 @@ export class User implements UserServerModel {
     this.videoQuotaDaily = hash.videoQuotaDaily
     this.videoQuotaUsed = hash.videoQuotaUsed
     this.videoQuotaUsedDaily = hash.videoQuotaUsedDaily
+    this.videoCount = hash.videoCount
+    this.videoAbuseCount = hash.videoAbuseCount
+    this.videoAbuseAcceptedCount = hash.videoAbuseAcceptedCount
+    this.videoAbuseCreatedCount = hash.videoAbuseCreatedCount
+    this.videoCommentCount = hash.videoCommentCount
 
     this.nsfwPolicy = hash.nsfwPolicy
     this.webTorrentEnabled = hash.webTorrentEnabled

--- a/client/src/app/shared/users/user.service.ts
+++ b/client/src/app/shared/users/user.service.ts
@@ -234,8 +234,9 @@ export class UserService {
     return this.userCache[userId]
   }
 
-  getUser (userId: number) {
-    return this.authHttp.get<UserServerModel>(UserService.BASE_USERS_URL + userId)
+  getUser (userId: number, withStats = false) {
+    const params = new HttpParams().append('withStats', withStats + '')
+    return this.authHttp.get<UserServerModel>(UserService.BASE_USERS_URL + userId, { params })
                .pipe(catchError(err => this.restExtractor.handleError(err)))
   }
 

--- a/client/src/app/shared/video/modals/video-report.component.html
+++ b/client/src/app/shared/video/modals/video-report.component.html
@@ -7,8 +7,7 @@
   <div class="modal-body">
 
     <div i18n class="information">
-      Your report will be sent to moderators of {{ currentHost }}.
-      <ng-container *ngIf="isRemoteVideo()"> It will be forwarded to origin instance {{ originHost }} too.</ng-container>
+      Your report will be sent to moderators of {{ currentHost }}<ng-container *ngIf="isRemoteVideo()"> and will be forwarded to the video origin ({{ originHost }}) too</ng-container>.
     </div>
 
     <form novalidate [formGroup]="form" (ngSubmit)="report()">

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -621,3 +621,83 @@
     }
   }
 }
+
+@mixin breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  list-style: none;
+  background-color: var(--submenuColor);
+  border-radius: 0.25rem;
+
+  .breadcrumb-item {
+    a {
+      color: var(--mainColor);
+    }
+
+    & + .breadcrumb-item {
+      padding-left: 0.5rem;
+      &::before {
+        display: inline-block;
+        padding-right: 0.5rem;
+        color: #6c757d;
+        content: "/";
+      }
+    }
+
+    &.active {
+      color: #6c757d;
+    }
+  }
+}
+
+@mixin dashboard {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -5px;
+
+  & > div {
+    box-sizing: border-box;
+    flex: 0 0 percentage(1/3);
+    padding: 0 5px;
+    margin-bottom: 10px;
+
+    & > a {
+      text-decoration: none;
+      color: inherit;
+      display: block;
+      font-size: 18px;
+
+      &:active,
+      &:focus,
+      &:hover {
+        opacity: .8;
+      }
+    }
+
+    & > a,
+    & > div {
+      padding: 20px;
+      background: var(--submenuColor);
+      border-radius: 4px;
+      box-sizing: border-box;
+      height: 100%;
+    }
+  }
+
+  .dashboard-num, .dashboard-text {
+    text-align: center;
+    font-size: 130%;
+    line-height: 21px;
+    color: var(--mainForegroundColor);
+    line-height: 30px;
+    margin-bottom: 20px;
+  }
+
+  .dashboard-label {
+    font-size: 90%;
+    color: var(--inputPlaceholderColor);
+    text-align: center;
+  }
+}

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -632,6 +632,8 @@
   border-radius: 0.25rem;
 
   .breadcrumb-item {
+    display: flex;
+
     a {
       color: var(--mainColor);
     }

--- a/server/middlewares/validators/users.ts
+++ b/server/middlewares/validators/users.ts
@@ -1,6 +1,6 @@
 import * as Bluebird from 'bluebird'
 import * as express from 'express'
-import { body, param } from 'express-validator'
+import { body, param, query } from 'express-validator'
 import { omit } from 'lodash'
 import { isIdOrUUIDValid, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
 import {
@@ -256,12 +256,13 @@ const usersUpdateMeValidator = [
 
 const usersGetValidator = [
   param('id').isInt().not().isEmpty().withMessage('Should have a valid id'),
+  query('withStats').optional().isBoolean().withMessage('Should have a valid stats flag'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersGet parameters', { parameters: req.params })
 
     if (areValidationErrors(req, res)) return
-    if (!await checkUserIdExist(req.params.id, res)) return
+    if (!await checkUserIdExist(req.params.id, res, req.query.withStats)) return
 
     return next()
   }
@@ -460,9 +461,9 @@ export {
 
 // ---------------------------------------------------------------------------
 
-function checkUserIdExist (idArg: number | string, res: express.Response) {
+function checkUserIdExist (idArg: number | string, res: express.Response, withStats = false) {
   const id = parseInt(idArg + '', 10)
-  return checkUserExist(() => UserModel.loadById(id), res)
+  return checkUserExist(() => UserModel.loadById(id, withStats), res)
 }
 
 function checkUserEmailExist (email: string, res: express.Response, abortResponse = true) {

--- a/server/models/account/user.ts
+++ b/server/models/account/user.ts
@@ -726,13 +726,9 @@ export class UserModel extends Model<UserModel> {
     const videoQuotaUsed = this.get('videoQuotaUsed')
     const videoQuotaUsedDaily = this.get('videoQuotaUsedDaily')
     const videosCount = this.get('videosCount')
-    const videoAbusesCount = this.get('videoAbusesCount') as string
+    const [ videoAbusesCount, videoAbusesAcceptedCount ] = (this.get('videoAbusesCount') as string).split(':')
     const videoAbusesCreatedCount = this.get('videoAbusesCreatedCount')
     const videoCommentsCount = this.get('videoCommentsCount')
-
-    function parseAbuseCount (videoAbusesCount: string, position: number) {
-      return videoAbusesCount.split(':').map(x => parseInt(x, 10))[position]
-    }
 
     const json: User = {
       id: this.id,
@@ -765,11 +761,11 @@ export class UserModel extends Model<UserModel> {
       videosCount: videosCount !== undefined
         ? parseInt(videosCount + '', 10)
         : undefined,
-      videoAbusesCount: videoAbusesCount !== undefined
-        ? parseAbuseCount(videoAbusesCount, 0)
+      videoAbusesCount: videoAbusesCount
+        ? parseInt(videoAbusesCount, 10)
         : undefined,
-      videoAbusesAcceptedCount: videoAbusesCount !== undefined
-        ? parseAbuseCount(videoAbusesCount, 1)
+      videoAbusesAcceptedCount: videoAbusesAcceptedCount
+        ? parseInt(videoAbusesAcceptedCount, 10)
         : undefined,
       videoAbusesCreatedCount: videoAbusesCreatedCount !== undefined
         ? parseInt(videoAbusesCreatedCount + '', 10)

--- a/server/models/account/user.ts
+++ b/server/models/account/user.ts
@@ -726,7 +726,7 @@ export class UserModel extends Model<UserModel> {
     const videoQuotaUsed = this.get('videoQuotaUsed')
     const videoQuotaUsedDaily = this.get('videoQuotaUsedDaily')
     const videosCount = this.get('videosCount')
-    const [ videoAbusesCount, videoAbusesAcceptedCount ] = (this.get('videoAbusesCount') as string).split(':')
+    const [ videoAbusesCount, videoAbusesAcceptedCount ] = (this.get('videoAbusesCount') as string || ':').split(':')
     const videoAbusesCreatedCount = this.get('videoAbusesCreatedCount')
     const videoCommentsCount = this.get('videoCommentsCount')
 

--- a/server/tests/api/users/users.ts
+++ b/server/tests/api/users/users.ts
@@ -254,7 +254,7 @@ describe('Test users', function () {
       const res1 = await getMyUserInformation(server.url, accessTokenUser)
       const userMe: MyUser = res1.body
 
-      const res2 = await getUserInformation(server.url, server.accessToken, userMe.id)
+      const res2 = await getUserInformation(server.url, server.accessToken, userMe.id, true)
       const userGet: User = res2.body
 
       for (const user of [ userMe, userGet ]) {
@@ -273,6 +273,16 @@ describe('Test users', function () {
 
       expect(userMe.specialPlaylists).to.have.lengthOf(1)
       expect(userMe.specialPlaylists[0].type).to.equal(VideoPlaylistType.WATCH_LATER)
+
+      // Check stats are included with withStats
+      expect(userGet.videosCount).to.be.a('number')
+      expect(userGet.videosCount).to.equal(0)
+      expect(userGet.videoCommentsCount).to.be.a('number')
+      expect(userGet.videoCommentsCount).to.equal(0)
+      expect(userGet.videoAbusesCount).to.be.a('number')
+      expect(userGet.videoAbusesCount).to.equal(0)
+      expect(userGet.videoAbusesAcceptedCount).to.be.a('number')
+      expect(userGet.videoAbusesAcceptedCount).to.equal(0)
     })
   })
 

--- a/server/tests/api/users/users.ts
+++ b/server/tests/api/users/users.ts
@@ -633,7 +633,6 @@ describe('Test users', function () {
   })
 
   describe('Updating another user', function () {
-
     it('Should be able to update another user', async function () {
       await updateUser({
         url: server.url,
@@ -679,6 +678,19 @@ describe('Test users', function () {
 
       user.password = 'password updated'
       accessTokenUser = await userLogin(server, user)
+    })
+  })
+
+  describe('Overview of a user', function () {
+    it('Should have correct statistics about a user', async function () {
+      const res = await getUserInformation(server.url, accessToken, userId)
+      const user: User = res.body
+
+      // Check stats are correct with withStats
+      expect(user.videosCount).to.equal(0)
+      expect(user.videoCommentsCount).to.equal(0)
+      expect(user.videoAbusesCount).to.equal(0)
+      expect(user.videoAbusesAcceptedCount).to.equal(0)
     })
   })
 

--- a/shared/extra-utils/users/users.ts
+++ b/shared/extra-utils/users/users.ts
@@ -130,11 +130,12 @@ function getMyUserVideoQuotaUsed (url: string, accessToken: string, specialStatu
           .expect('Content-Type', /json/)
 }
 
-function getUserInformation (url: string, accessToken: string, userId: number) {
+function getUserInformation (url: string, accessToken: string, userId: number, withStats = false) {
   const path = '/api/v1/users/' + userId
 
   return request(url)
     .get(path)
+    .query({ withStats })
     .set('Accept', 'application/json')
     .set('Authorization', 'Bearer ' + accessToken)
     .expect(200)

--- a/shared/models/users/user.model.ts
+++ b/shared/models/users/user.model.ts
@@ -31,6 +31,11 @@ export interface User {
   videoQuotaDaily: number
   videoQuotaUsed?: number
   videoQuotaUsedDaily?: number
+  videoCount?: number
+  videoAbuseCount?: number
+  videoAbuseAcceptedCount?: number
+  videoAbuseCreatedCount?: number
+  videoCommentCount? : number
 
   theme: string
 

--- a/shared/models/users/user.model.ts
+++ b/shared/models/users/user.model.ts
@@ -31,11 +31,11 @@ export interface User {
   videoQuotaDaily: number
   videoQuotaUsed?: number
   videoQuotaUsedDaily?: number
-  videoCount?: number
-  videoAbuseCount?: number
-  videoAbuseAcceptedCount?: number
-  videoAbuseCreatedCount?: number
-  videoCommentCount? : number
+  videosCount?: number
+  videoAbusesCount?: number
+  videoAbusesAcceptedCount?: number
+  videoAbusesCreatedCount?: number
+  videoCommentsCount? : number
 
   theme: string
 


### PR DESCRIPTION
The PR adds common stats to have an easier overview of a user's actions. It also uses the new layout for settings, and displays a user's avatar and display name. I use breadcrumbs to distinguish edit/create user views, and help for navigation within future listings related to a user.

![Screenshot_2020-03-15 Update a user - PeerTube](https://user-images.githubusercontent.com/6329880/76704184-68c58b80-66d7-11ea-8493-6ad69cf1a40d.png)
