### PR TITLE
View stats for channels

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,7 @@
     "@ngx-loading-bar/router": "^4.2.0",
     "@ngx-meta/core": "^8.0.2",
     "@ngx-translate/i18n-polyfill": "^1.0.0",
+    "@types/chart.js": "^2.9.16",
     "@types/core-js": "^2.5.2",
     "@types/debug": "^4.1.5",
     "@types/hls.js": "^0.12.4",

--- a/client/src/app/+my-account/my-account-routing.module.ts
+++ b/client/src/app/+my-account/my-account-routing.module.ts
@@ -5,9 +5,6 @@ import { LoginGuard } from '../core'
 import { MyAccountComponent } from './my-account.component'
 import { MyAccountSettingsComponent } from './my-account-settings/my-account-settings.component'
 import { MyAccountVideosComponent } from './my-account-videos/my-account-videos.component'
-import { MyAccountVideoChannelsComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channels.component'
-import { MyAccountVideoChannelCreateComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channel-create.component'
-import { MyAccountVideoChannelUpdateComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channel-update.component'
 import { MyAccountVideoImportsComponent } from '@app/+my-account/my-account-video-imports/my-account-video-imports.component'
 import { MyAccountSubscriptionsComponent } from '@app/+my-account/my-account-subscriptions/my-account-subscriptions.component'
 import { MyAccountOwnershipComponent } from '@app/+my-account/my-account-ownership/my-account-ownership.component'
@@ -49,30 +46,7 @@ const myAccountRoutes: Routes = [
 
       {
         path: 'video-channels',
-        component: MyAccountVideoChannelsComponent,
-        data: {
-          meta: {
-            title: 'Account video channels'
-          }
-        }
-      },
-      {
-        path: 'video-channels/create',
-        component: MyAccountVideoChannelCreateComponent,
-        data: {
-          meta: {
-            title: 'Create new video channel'
-          }
-        }
-      },
-      {
-        path: 'video-channels/update/:videoChannelId',
-        component: MyAccountVideoChannelUpdateComponent,
-        data: {
-          meta: {
-            title: 'Update video channel'
-          }
-        }
+        loadChildren: () => import('./my-account-video-channels/my-account-video-channels.module').then(m => m.MyAccountVideoChannelsModule)
       },
 
       {

--- a/client/src/app/+my-account/my-account-video-channels/my-account-video-channels-routing.module.ts
+++ b/client/src/app/+my-account/my-account-video-channels/my-account-video-channels-routing.module.ts
@@ -1,0 +1,41 @@
+import { NgModule } from '@angular/core'
+import { RouterModule, Routes } from '@angular/router'
+import { MyAccountVideoChannelUpdateComponent } from './my-account-video-channel-update.component'
+import { MyAccountVideoChannelCreateComponent } from './my-account-video-channel-create.component'
+import { MyAccountVideoChannelsComponent } from './my-account-video-channels.component'
+
+const myAccountVideoChannelsRoutes: Routes = [
+  {
+    path: '',
+    component: MyAccountVideoChannelsComponent,
+    data: {
+      meta: {
+        title: 'Account video channels'
+      }
+    }
+  },
+  {
+    path: 'create',
+    component: MyAccountVideoChannelCreateComponent,
+    data: {
+      meta: {
+        title: 'Create new video channel'
+      }
+    }
+  },
+  {
+    path: 'update/:videoChannelId',
+    component: MyAccountVideoChannelUpdateComponent,
+    data: {
+      meta: {
+        title: 'Update video channel'
+      }
+    }
+  }
+]
+
+@NgModule({
+  imports: [ RouterModule.forChild(myAccountVideoChannelsRoutes) ],
+  exports: [ RouterModule ]
+})
+export class MyAccountVideoChannelsRoutingModule {}

--- a/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.html
+++ b/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="video-channels">
-  <div *ngFor="let videoChannel of videoChannels" class="video-channel">
+  <div *ngFor="let videoChannel of videoChannels; let i = index" class="video-channel">
     <a [routerLink]="[ '/video-channels', videoChannel.nameWithHost ]">
       <img [src]="videoChannel.avatarUrl" alt="Avatar" />
     </a>
@@ -17,13 +17,16 @@
         <div class="video-channel-name">{{ videoChannel.nameWithHost }}</div>
       </a>
 
-      <div i18n class="video-channel-followers">{{ videoChannel.followersCount }} subscribers</div>
+      <div i18n class="video-channel-followers">{videoChannel.followersCount, plural, =1 {1 subscriber} other {{{ videoChannel.followersCount }} subscribers}}</div>
+
+      <div *ngIf="!isInSmallView" class="w-100 d-flex justify-content-end">
+        <p-chart *ngIf="videoChannelsData && videoChannelsData[i]" type="line" [data]="videoChannelsData[i]" [options]="chartOptions" width="40vw" height="100px"></p-chart>
+      </div>
     </div>
 
     <div class="video-channel-buttons">
-      <my-delete-button (click)="deleteVideoChannel(videoChannel)"></my-delete-button>
-
       <my-edit-button [routerLink]="[ 'update', videoChannel.nameWithHost ]"></my-edit-button>
+      <my-delete-button (click)="deleteVideoChannel(videoChannel)"></my-delete-button>
     </div>
   </div>
 </div>

--- a/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.html
+++ b/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.html
@@ -20,7 +20,7 @@
       <div i18n class="video-channel-followers">{videoChannel.followersCount, plural, =1 {1 subscriber} other {{{ videoChannel.followersCount }} subscribers}}</div>
 
       <div *ngIf="!isInSmallView" class="w-100 d-flex justify-content-end">
-        <p-chart *ngIf="videoChannelsData && videoChannelsData[i]" type="line" [data]="videoChannelsData[i]" [options]="chartOptions" width="40vw" height="100px"></p-chart>
+        <p-chart *ngIf="videoChannelsChartData && videoChannelsChartData[i]" type="line" [data]="videoChannelsChartData[i]" [options]="chartOptions" width="40vw" height="100px"></p-chart>
       </div>
     </div>
 

--- a/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.scss
+++ b/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.scss
@@ -6,13 +6,14 @@
 }
 
 ::ng-deep .action-button {
-  &.action-button-delete {
+  &.action-button-edit {
     margin-right: 10px;
   }
 }
 
 .video-channel {
   @include row-blocks;
+  padding-bottom: 0;
 
   img {
     @include avatar(80px);
@@ -56,6 +57,11 @@
 .video-channels-header {
   text-align: right;
   margin: 20px 0 50px;
+}
+
+::ng-deep .chartjs-render-monitor {
+  position: relative;
+  top: 1px;
 }
 
 @media screen and (max-width: $small-view) {

--- a/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.ts
+++ b/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.ts
@@ -57,7 +57,7 @@ export class MyAccountVideoChannelsComponent implements OnInit {
             min: Math.max(0, this.videoChannelsMinimumDailyViews - (3 * this.videoChannelsMaximumDailyViews / 100)),
             max: this.videoChannelsMaximumDailyViews
           }
-        }],
+        }]
       },
       layout: {
         padding: {
@@ -68,7 +68,7 @@ export class MyAccountVideoChannelsComponent implements OnInit {
         }
       },
       elements: {
-        point:{
+        point: {
           radius: 0
         }
       },
@@ -76,14 +76,12 @@ export class MyAccountVideoChannelsComponent implements OnInit {
         mode: 'index',
         intersect: false,
         custom: function (tooltip: any) {
-          if (!tooltip) return;
-          // disable displaying the color box;
-          tooltip.displayColors = false;
+          if (!tooltip) return
+          // disable displaying the color box
+          tooltip.displayColors = false
         },
         callbacks: {
-          label: function (tooltip: any, data: any) {
-            return `${tooltip.value} views`;
-          }
+          label: (tooltip: any, data: any) => `${tooltip.value} views`
         }
       },
       hover: {
@@ -124,7 +122,7 @@ export class MyAccountVideoChannelsComponent implements OnInit {
 
   private loadVideoChannels () {
     this.authService.userInformationLoaded
-        .pipe(flatMap(() => this.videoChannelService.listAccountVideoChannels(this.user.account)))
+        .pipe(flatMap(() => this.videoChannelService.listAccountVideoChannels(this.user.account, null, true)))
         .subscribe(res => {
           this.videoChannels = res.data
           this.videoChannelsData = this.videoChannels.map(v => ({

--- a/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.module.ts
+++ b/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core'
+import { ChartModule } from 'primeng/chart'
+import { MyAccountVideoChannelsRoutingModule } from './my-account-video-channels-routing.module'
+import { MyAccountVideoChannelsComponent } from './my-account-video-channels.component'
+import { MyAccountVideoChannelCreateComponent } from './my-account-video-channel-create.component'
+import { MyAccountVideoChannelUpdateComponent } from './my-account-video-channel-update.component'
+import { SharedModule } from '@app/shared'
+
+@NgModule({
+  imports: [
+    MyAccountVideoChannelsRoutingModule,
+    SharedModule,
+    ChartModule
+  ],
+
+  declarations: [
+    MyAccountVideoChannelsComponent,
+    MyAccountVideoChannelCreateComponent,
+    MyAccountVideoChannelUpdateComponent
+  ],
+
+  exports: [],
+  providers: []
+})
+export class MyAccountVideoChannelsModule { }

--- a/client/src/app/+my-account/my-account.module.ts
+++ b/client/src/app/+my-account/my-account.module.ts
@@ -1,7 +1,8 @@
-import { TableModule } from 'primeng/table'
 import { NgModule } from '@angular/core'
+import { TableModule } from 'primeng/table'
 import { AutoCompleteModule } from 'primeng/autocomplete'
 import { InputSwitchModule } from 'primeng/inputswitch'
+import { ChartModule } from 'primeng/chart'
 import { SharedModule } from '../shared'
 import { MyAccountRoutingModule } from './my-account-routing.module'
 import { MyAccountChangePasswordComponent } from './my-account-settings/my-account-change-password/my-account-change-password.component'
@@ -44,7 +45,8 @@ import { MyAccountChangeEmailComponent } from '@app/+my-account/my-account-setti
     SharedModule,
     TableModule,
     InputSwitchModule,
-    DragDropModule
+    DragDropModule,
+    ChartModule
   ],
 
   declarations: [

--- a/client/src/app/+my-account/my-account.module.ts
+++ b/client/src/app/+my-account/my-account.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core'
 import { TableModule } from 'primeng/table'
 import { AutoCompleteModule } from 'primeng/autocomplete'
 import { InputSwitchModule } from 'primeng/inputswitch'
-import { ChartModule } from 'primeng/chart'
 import { SharedModule } from '../shared'
 import { MyAccountRoutingModule } from './my-account-routing.module'
 import { MyAccountChangePasswordComponent } from './my-account-settings/my-account-change-password/my-account-change-password.component'
@@ -13,9 +12,6 @@ import { VideoChangeOwnershipComponent } from './my-account-videos/video-change-
 import { MyAccountOwnershipComponent } from './my-account-ownership/my-account-ownership.component'
 import { MyAccountAcceptOwnershipComponent } from './my-account-ownership/my-account-accept-ownership/my-account-accept-ownership.component'
 import { MyAccountProfileComponent } from '@app/+my-account/my-account-settings/my-account-profile/my-account-profile.component'
-import { MyAccountVideoChannelsComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channels.component'
-import { MyAccountVideoChannelCreateComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channel-create.component'
-import { MyAccountVideoChannelUpdateComponent } from '@app/+my-account/my-account-video-channels/my-account-video-channel-update.component'
 import { MyAccountVideoImportsComponent } from '@app/+my-account/my-account-video-imports/my-account-video-imports.component'
 import { MyAccountDangerZoneComponent } from '@app/+my-account/my-account-settings/my-account-danger-zone'
 import { MyAccountSubscriptionsComponent } from '@app/+my-account/my-account-subscriptions/my-account-subscriptions.component'
@@ -45,8 +41,7 @@ import { MyAccountChangeEmailComponent } from '@app/+my-account/my-account-setti
     SharedModule,
     TableModule,
     InputSwitchModule,
-    DragDropModule,
-    ChartModule
+    DragDropModule
   ],
 
   declarations: [
@@ -61,9 +56,6 @@ import { MyAccountChangeEmailComponent } from '@app/+my-account/my-account-setti
     VideoChangeOwnershipComponent,
     MyAccountOwnershipComponent,
     MyAccountAcceptOwnershipComponent,
-    MyAccountVideoChannelsComponent,
-    MyAccountVideoChannelCreateComponent,
-    MyAccountVideoChannelUpdateComponent,
     MyAccountVideoImportsComponent,
     MyAccountDangerZoneComponent,
     MyAccountSubscriptionsComponent,

--- a/client/src/app/shared/video-channel/video-channel.model.ts
+++ b/client/src/app/shared/video-channel/video-channel.model.ts
@@ -1,4 +1,4 @@
-import { VideoChannel as ServerVideoChannel, viewsPerTime } from '../../../../../shared/models/videos'
+import { VideoChannel as ServerVideoChannel, ViewsPerDate } from '../../../../../shared/models/videos'
 import { Actor } from '../actor/actor.model'
 import { Account } from '../../../../../shared/models/actors'
 
@@ -12,7 +12,7 @@ export class VideoChannel extends Actor implements ServerVideoChannel {
   ownerAccount?: Account
   ownerBy?: string
   ownerAvatarUrl?: string
-  viewsPerDay?: viewsPerTime[]
+  viewsPerDay?: ViewsPerDate[]
 
   constructor (hash: ServerVideoChannel) {
     super(hash)

--- a/client/src/app/shared/video-channel/video-channel.model.ts
+++ b/client/src/app/shared/video-channel/video-channel.model.ts
@@ -25,7 +25,7 @@ export class VideoChannel extends Actor implements ServerVideoChannel {
     this.nameWithHostForced = Actor.CREATE_BY_STRING(this.name, this.host, true)
 
     if (hash.viewsPerDay) {
-      this.viewsPerDay = hash.viewsPerDay.map(v => ({ ...v, date: new Date(v.date)}))
+      this.viewsPerDay = hash.viewsPerDay.map(v => ({ ...v, date: new Date(v.date) }))
     }
 
     if (hash.ownerAccount) {

--- a/client/src/app/shared/video-channel/video-channel.model.ts
+++ b/client/src/app/shared/video-channel/video-channel.model.ts
@@ -1,4 +1,4 @@
-import { VideoChannel as ServerVideoChannel } from '../../../../../shared/models/videos'
+import { VideoChannel as ServerVideoChannel, viewsPerTime } from '../../../../../shared/models/videos'
 import { Actor } from '../actor/actor.model'
 import { Account } from '../../../../../shared/models/actors'
 
@@ -12,6 +12,7 @@ export class VideoChannel extends Actor implements ServerVideoChannel {
   ownerAccount?: Account
   ownerBy?: string
   ownerAvatarUrl?: string
+  viewsPerDay?: viewsPerTime[]
 
   constructor (hash: ServerVideoChannel) {
     super(hash)
@@ -22,6 +23,10 @@ export class VideoChannel extends Actor implements ServerVideoChannel {
     this.isLocal = hash.isLocal
     this.nameWithHost = Actor.CREATE_BY_STRING(this.name, this.host)
     this.nameWithHostForced = Actor.CREATE_BY_STRING(this.name, this.host, true)
+
+    if (hash.viewsPerDay) {
+      this.viewsPerDay = hash.viewsPerDay.map(v => ({ ...v, date: new Date(v.date)}))
+    }
 
     if (hash.ownerAccount) {
       this.ownerAccount = hash.ownerAccount

--- a/client/src/app/shared/video-channel/video-channel.service.ts
+++ b/client/src/app/shared/video-channel/video-channel.service.ts
@@ -44,13 +44,18 @@ export class VideoChannelService {
                )
   }
 
-  listAccountVideoChannels (account: Account, componentPagination?: ComponentPaginationLight): Observable<ResultList<VideoChannel>> {
+  listAccountVideoChannels (
+    account: Account,
+    componentPagination?: ComponentPaginationLight,
+    withStats = false
+  ): Observable<ResultList<VideoChannel>> {
     const pagination = componentPagination
       ? this.restService.componentPaginationToRestPagination(componentPagination)
       : { start: 0, count: 20 }
 
     let params = new HttpParams()
     params = this.restService.addRestGetParams(params, pagination)
+    params = params.set('withStats', withStats + '')
 
     const url = AccountService.BASE_ACCOUNT_URL + account.nameWithHost + '/video-channels'
     return this.authHttp.get<ResultList<VideoChannelServer>>(url, { params })

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1149,6 +1149,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/chart.js@^2.9.16":
+  version "2.9.16"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.16.tgz#ac9d268fa192c0ec0efd740f802683e3ed97642c"
+  integrity sha512-Mofg7xFIeAWME46YMVKHPCyUz2Z0KsVMNE1f4oF3T74mK3RiPQxOm9qzoeNTyMs6lpl4x0tiHL+Wsz2DHCxQlQ==
+  dependencies:
+    moment "^2.10.2"
+
 "@types/core-js@^2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-2.5.2.tgz#d4c25420044d4a5b65e00a82fc04b7824b62691f"

--- a/server/controllers/api/accounts.ts
+++ b/server/controllers/api/accounts.ts
@@ -17,7 +17,8 @@ import {
   accountsSortValidator,
   ensureAuthUserOwnsAccountValidator,
   videoChannelsSortValidator,
-  videosSortValidator
+  videosSortValidator,
+  videoChannelStatsValidator
 } from '../../middlewares/validators'
 import { AccountModel } from '../../models/account/account'
 import { AccountVideoRateModel } from '../../models/account/account-video-rate'
@@ -56,6 +57,7 @@ accountsRouter.get('/:accountName/videos',
 
 accountsRouter.get('/:accountName/video-channels',
   asyncMiddleware(accountNameWithHostGetValidator),
+  videoChannelStatsValidator,
   paginationValidator,
   videoChannelsSortValidator,
   setDefaultSort,
@@ -116,7 +118,8 @@ async function listAccountChannels (req: express.Request, res: express.Response)
     accountId: res.locals.account.id,
     start: req.query.start,
     count: req.query.count,
-    sort: req.query.sort
+    sort: req.query.sort,
+    withStats: req.query.withStats
   }
 
   const resultList = await VideoChannelModel.listByAccount(options)

--- a/server/middlewares/validators/videos/video-channels.ts
+++ b/server/middlewares/validators/videos/video-channels.ts
@@ -1,5 +1,5 @@
 import * as express from 'express'
-import { body, param } from 'express-validator'
+import { body, param, query } from 'express-validator'
 import { UserRight } from '../../../../shared'
 import {
   isVideoChannelDescriptionValid,
@@ -128,6 +128,15 @@ const localVideoChannelValidator = [
   }
 ]
 
+const videoChannelStatsValidator = [
+  query('withStats').optional().isBoolean().withMessage('Should have a valid stats flag'),
+
+  (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (areValidationErrors(req, res)) return
+    return next()
+  }
+]
+
 // ---------------------------------------------------------------------------
 
 export {
@@ -135,7 +144,8 @@ export {
   videoChannelsUpdateValidator,
   videoChannelsRemoveValidator,
   videoChannelsNameWithHostValidator,
-  localVideoChannelValidator
+  localVideoChannelValidator,
+  videoChannelStatsValidator
 }
 
 // ---------------------------------------------------------------------------

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -412,7 +412,6 @@ export class VideoChannelModel extends Model<VideoChannelModel> {
 
     const scopes: string | ScopeOptions | (string | ScopeOptions)[] = [ ScopeNames.WITH_ACTOR ]
 
-    options.withStats = true // TODO: remove beyond after initial tests
     if (options.withStats) {
       scopes.push({
         method: [ ScopeNames.WITH_STATS, { daysPrior: 30 } as AvailableWithStatsOptions ]

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -191,7 +191,7 @@ export type SummaryOptions = {
               'SELECT days.day AS day, ' +
                      'COALESCE(SUM(views.views), 0) AS views ' +
               'FROM days ' +
-              `LEFT JOIN views ON date_trunc('day', "views"."createdAt") = days.day ` +
+              `LEFT JOIN views ON date_trunc('day', "views"."startDate") = date_trunc('day', days.day) ` +
               'GROUP BY 1 ' +
               'ORDER BY day ' +
             ') t' +

--- a/server/tests/api/videos/video-channels.ts
+++ b/server/tests/api/videos/video-channels.ts
@@ -2,7 +2,7 @@
 
 import * as chai from 'chai'
 import 'mocha'
-import { User, Video, VideoChannel, viewsPerTime, VideoDetails } from '../../../../shared/index'
+import { User, Video, VideoChannel, ViewsPerDate, VideoDetails } from '../../../../shared/index'
 import {
   cleanupTests,
   createUser,
@@ -376,7 +376,7 @@ describe('Test video channels', function () {
       res.body.data.forEach((channel: VideoChannel) => {
         expect(channel).to.haveOwnProperty('viewsPerDay')
         expect(channel.viewsPerDay).to.have.length(30 + 1) // daysPrior + today
-        channel.viewsPerDay.forEach((v: viewsPerTime) => {
+        channel.viewsPerDay.forEach((v: ViewsPerDate) => {
           expect(v.date).to.be.an('string')
           expect(v.views).to.equal(0)
         })

--- a/shared/extra-utils/videos/video-channels.ts
+++ b/shared/extra-utils/videos/video-channels.ts
@@ -8,7 +8,7 @@ import { ServerInfo } from '../server/servers'
 import { User } from '../../models/users/user.model'
 import { getMyUserInformation } from '../users/users'
 
-function getVideoChannelsList (url: string, start: number, count: number, sort?: string) {
+function getVideoChannelsList (url: string, start: number, count: number, sort?: string, withStats?: boolean) {
   const path = '/api/v1/video-channels'
 
   const req = request(url)
@@ -17,6 +17,7 @@ function getVideoChannelsList (url: string, start: number, count: number, sort?:
     .query({ count: count })
 
   if (sort) req.query({ sort })
+  if (withStats) req.query({ withStats })
 
   return req.set('Accept', 'application/json')
             .expect(200)
@@ -30,8 +31,9 @@ function getAccountVideoChannelsList (parameters: {
   count?: number
   sort?: string
   specialStatus?: number
+  withStats?: boolean
 }) {
-  const { url, accountName, start, count, sort = 'createdAt', specialStatus = 200 } = parameters
+  const { url, accountName, start, count, sort = 'createdAt', specialStatus = 200, withStats = false } = parameters
 
   const path = '/api/v1/accounts/' + accountName + '/video-channels'
 
@@ -41,7 +43,8 @@ function getAccountVideoChannelsList (parameters: {
     query: {
       start,
       count,
-      sort
+      sort,
+      withStats
     },
     statusCodeExpected: specialStatus
   })

--- a/shared/models/videos/channel/video-channel.model.ts
+++ b/shared/models/videos/channel/video-channel.model.ts
@@ -2,7 +2,7 @@ import { Actor } from '../../actors/actor.model'
 import { Account } from '../../actors/index'
 import { Avatar } from '../../avatars'
 
-export type viewsPerTime = {
+export type ViewsPerDate = {
   date: Date
   views: number
 }
@@ -13,7 +13,7 @@ export interface VideoChannel extends Actor {
   support: string
   isLocal: boolean
   ownerAccount?: Account
-  viewsPerDay?: viewsPerTime[] // chronologically ordered
+  viewsPerDay?: ViewsPerDate[] // chronologically ordered
 }
 
 export interface VideoChannelSummary {

--- a/shared/models/videos/channel/video-channel.model.ts
+++ b/shared/models/videos/channel/video-channel.model.ts
@@ -2,12 +2,18 @@ import { Actor } from '../../actors/actor.model'
 import { Account } from '../../actors/index'
 import { Avatar } from '../../avatars'
 
+export type viewsPerTime = {
+  date: Date
+  views: number
+}
+
 export interface VideoChannel extends Actor {
   displayName: string
   description: string
   support: string
   isLocal: boolean
   ownerAccount?: Account
+  viewsPerDay?: viewsPerTime[] // chronologically ordered
 }
 
 export interface VideoChannelSummary {


### PR DESCRIPTION
This PR shows a low-profile stats bar in the channels list, showing daily aggregated views for the videos of that channel for the past 30 days. 

Why just a thin bar? A more involved stats page would require more space, and either a dedicated view or dedicated component to integrate in the channel edit page - that's for later. This is just a proof-of-concept.

![Screenshot from 2020-03-23 16-51-11](https://user-images.githubusercontent.com/6329880/77335656-bd47b700-6d26-11ea-9ba2-32a2900da088.png)