### PR TITLE
[Docker] Move streaming-playlists to /data

### DIFF
--- a/support/docker/production/config/production.yaml
+++ b/support/docker/production/config/production.yaml
@@ -53,6 +53,7 @@ storage:
   captions: '../data/captions/'
   cache: '../data/cache/'
   plugins: '../data/plugins/'
+  streaming-playlists: '../data/streaming-playlists'
 
 log:
   level: 'info' # debug/info/warning/error


### PR DESCRIPTION
Everything under `/app/storage` should be moved to `/data`. However, `streaming-playlists` is not listed yet. So there will still be `/app/storage/streaming-playlists`. This PR fixes the problem.