### PR TITLE
Make sure a report doesn't get deleted upon the deletion of its video

### DIFF
--- a/client/src/app/+admin/follows/followers-list/followers-list.component.html
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.html
@@ -14,10 +14,10 @@
   <ng-template pTemplate="header">
     <tr>
       <th i18n>Follower handle</th>
-      <th i18n pSortableColumn="state">State <p-sortIcon field="state"></p-sortIcon></th>
-      <th i18n pSortableColumn="score">Score <p-sortIcon field="score"></p-sortIcon></th>
-      <th i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th></th>
+      <th style="width: 100px;" i18n pSortableColumn="state">State <p-sortIcon field="state"></p-sortIcon></th>
+      <th style="width: 100px;" i18n pSortableColumn="score">Score <p-sortIcon field="score"></p-sortIcon></th>
+      <th style="width: 200px;" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 100px;"></th>
     </tr>
   </ng-template>
 

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.html
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.html
@@ -1,6 +1,8 @@
 <p-table
-  [value]="followers" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="followers" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
+  [showCurrentPageReport]="true" i18n-currentPageReportTemplate
+  currentPageReportTemplate="Showing {first} to {last} of {totalRecords} followers"
 >
   <ng-template pTemplate="caption">
     <div class="caption">

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.html
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.html
@@ -41,4 +41,15 @@
       </td>
     </tr>
   </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="6">
+        <div class="empty-table-message">
+          <ng-container *ngIf="search" i18n>No follower found matching current filters.</ng-container>
+          <ng-container *ngIf="!search" i18n>Your instance doesn't have any follower.</ng-container>
+        </div>
+      </td>
+    </tr>
+  </ng-template>
 </p-table>

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.ts
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.ts
@@ -14,7 +14,8 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 export class FollowersListComponent extends RestTable implements OnInit {
   followers: ActorFollow[] = []
   totalRecords = 0
-  rowsPerPage = 10
+  rowsPerPageOptions = [ 20, 50, 100 ]
+  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.ts
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.ts
@@ -9,7 +9,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 @Component({
   selector: 'my-followers-list',
   templateUrl: './followers-list.component.html',
-  styleUrls: [ './followers-list.component.scss' ]
+  styleUrls: [ '../follows.component.scss', './followers-list.component.scss' ]
 })
 export class FollowersListComponent extends RestTable implements OnInit {
   followers: ActorFollow[] = []

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.ts
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.ts
@@ -14,8 +14,6 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 export class FollowersListComponent extends RestTable implements OnInit {
   followers: ActorFollow[] = []
   totalRecords = 0
-  rowsPerPageOptions = [ 20, 50, 100 ]
-  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+admin/follows/following-list/following-list.component.html
+++ b/client/src/app/+admin/follows/following-list/following-list.component.html
@@ -1,6 +1,8 @@
 <p-table
-  [value]="following" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="following" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
+  [showCurrentPageReport]="true" i18n-currentPageReportTemplate
+  currentPageReportTemplate="Showing {first} to {last} of {totalRecords} hosts"
 >
   <ng-template pTemplate="caption">
     <div class="caption">
@@ -29,7 +31,12 @@
 
   <ng-template pTemplate="body" let-follow>
     <tr>
-      <td>{{ follow.following.host }}</td>
+      <td>
+        <a [href]="'https://' + follow.following.host" i18n-title title="Open instance in a new tab" target="_blank" rel="noopener noreferrer">
+          {{ follow.following.host }}
+          <span class="glyphicon glyphicon-new-window"></span>
+        </a>
+      </td>
 
       <td *ngIf="follow.state === 'accepted'" i18n>Accepted</td>
       <td *ngIf="follow.state === 'pending'" i18n>Pending</td>
@@ -51,11 +58,17 @@
       <td colspan="6">
         <div class="empty-table-message">
           <ng-container *ngIf="search" i18n>No host found matching current filters.</ng-container>
-          <ng-container *ngIf="!search" i18n>Your instance is not follwing any host.</ng-container>
+          <ng-container *ngIf="!search" i18n>Your instance is not following anyone.</ng-container>
         </div>
       </td>
     </tr>
   </ng-template>
 </p-table>
 
-<my-batch-domains-modal #batchDomainsModal i18n-action action="Follow domains" (domains)="addFollowing($event)"></my-batch-domains-modal>
+<my-batch-domains-modal #batchDomainsModal i18n-action action="Follow domains" (domains)="addFollowing($event)">
+  <ng-container ngProjectAs="warning">
+    <div i18n *ngIf="httpEnabled() === false"  class="alert alert-warning">
+      It seems that you are not on a HTTPS server. Your webserver needs to have TLS activated in order to follow servers.
+    </div>
+  </ng-container>
+</my-batch-domains-modal>

--- a/client/src/app/+admin/follows/following-list/following-list.component.html
+++ b/client/src/app/+admin/follows/following-list/following-list.component.html
@@ -20,10 +20,10 @@
   <ng-template pTemplate="header">
     <tr>
       <th i18n>Host</th>
-      <th i18n pSortableColumn="state">State <p-sortIcon field="state"></p-sortIcon></th>
-      <th i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th i18n pSortableColumn="redundancyAllowed">Redundancy allowed <p-sortIcon field="redundancyAllowed"></p-sortIcon></th>
-      <th></th>
+      <th style="width: 100px;" i18n pSortableColumn="state">State <p-sortIcon field="state"></p-sortIcon></th>
+      <th style="width: 200px;" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 160px;" i18n pSortableColumn="redundancyAllowed">Redundancy allowed <p-sortIcon field="redundancyAllowed"></p-sortIcon></th>
+      <th style="width: 100px;"></th>
     </tr>
   </ng-template>
 

--- a/client/src/app/+admin/follows/following-list/following-list.component.html
+++ b/client/src/app/+admin/follows/following-list/following-list.component.html
@@ -45,6 +45,17 @@
       </td>
     </tr>
   </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="6">
+        <div class="empty-table-message">
+          <ng-container *ngIf="search" i18n>No host found matching current filters.</ng-container>
+          <ng-container *ngIf="!search" i18n>Your instance is not follwing any host.</ng-container>
+        </div>
+      </td>
+    </tr>
+  </ng-template>
 </p-table>
 
 <my-batch-domains-modal #batchDomainsModal i18n-action action="Follow domains" (domains)="addFollowing($event)"></my-batch-domains-modal>

--- a/client/src/app/+admin/follows/following-list/following-list.component.scss
+++ b/client/src/app/+admin/follows/following-list/following-list.component.scss
@@ -1,6 +1,20 @@
 @import '_variables';
 @import '_mixins';
 
+a {
+  @include disable-default-a-behaviour;
+  display: inline-block;
+
+  &, &:hover {
+    color: var(--mainForegroundColor);
+  }
+
+  span {
+    font-size: 80%;
+    color: var(--inputPlaceholderColor);
+  }
+}
+
 .caption {
   justify-content: flex-end;
 

--- a/client/src/app/+admin/follows/following-list/following-list.component.ts
+++ b/client/src/app/+admin/follows/following-list/following-list.component.ts
@@ -11,7 +11,7 @@ import { BatchDomainsModalComponent } from '@app/+admin/config/shared/batch-doma
 @Component({
   selector: 'my-followers-list',
   templateUrl: './following-list.component.html',
-  styleUrls: [ './following-list.component.scss' ]
+  styleUrls: [ '../follows.component.scss', './following-list.component.scss' ]
 })
 export class FollowingListComponent extends RestTable implements OnInit {
   @ViewChild('batchDomainsModal') batchDomainsModal: BatchDomainsModalComponent

--- a/client/src/app/+admin/follows/following-list/following-list.component.ts
+++ b/client/src/app/+admin/follows/following-list/following-list.component.ts
@@ -18,7 +18,8 @@ export class FollowingListComponent extends RestTable implements OnInit {
 
   following: ActorFollow[] = []
   totalRecords = 0
-  rowsPerPage = 10
+  rowsPerPageOptions = [ 20, 50, 100 ]
+  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 
@@ -41,6 +42,10 @@ export class FollowingListComponent extends RestTable implements OnInit {
 
   addDomainsToFollow () {
     this.batchDomainsModal.openModal()
+  }
+
+  httpEnabled () {
+    return window.location.protocol === 'https:'
   }
 
   async addFollowing (hosts: string[]) {

--- a/client/src/app/+admin/follows/following-list/following-list.component.ts
+++ b/client/src/app/+admin/follows/following-list/following-list.component.ts
@@ -18,8 +18,6 @@ export class FollowingListComponent extends RestTable implements OnInit {
 
   following: ActorFollow[] = []
   totalRecords = 0
-  rowsPerPageOptions = [ 20, 50, 100 ]
-  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+admin/follows/follows.component.scss
+++ b/client/src/app/+admin/follows/follows.component.scss
@@ -1,4 +1,10 @@
+@import "mixins";
+
 .form-sub-title {
   flex-grow: 0;
   margin-right: 30px;
+}
+
+.empty-table-message {
+  @include empty-state;
 }

--- a/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
+++ b/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
@@ -12,7 +12,7 @@
 </div>
 
 <p-table
-  [value]="videoRedundancies" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="videoRedundancies" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"
 >
   <ng-template pTemplate="header">

--- a/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
+++ b/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
@@ -17,11 +17,11 @@
 >
   <ng-template pTemplate="header">
     <tr>
-      <th style="width: 40px"></th>
-      <th i18n *ngIf="isDisplayingRemoteVideos()">Strategy</th>
+      <th style="width: 40px;"></th>
+      <th style="width: 160px;" i18n *ngIf="isDisplayingRemoteVideos()">Strategy</th>
       <th i18n pSortableColumn="name">Video name <p-sortIcon field="name"></p-sortIcon></th>
       <th i18n>Video URL</th>
-      <th i18n *ngIf="isDisplayingRemoteVideos()">Total size</th>
+      <th style="width: 100px;" i18n *ngIf="isDisplayingRemoteVideos()">Total size</th>
       <th style="width: 80px;"></th>
     </tr>
   </ng-template>

--- a/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
+++ b/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
@@ -19,7 +19,7 @@
     <tr>
       <th style="width: 40px;"></th>
       <th style="width: 160px;" i18n *ngIf="isDisplayingRemoteVideos()">Strategy</th>
-      <th i18n pSortableColumn="name">Video name <p-sortIcon field="name"></p-sortIcon></th>
+      <th i18n pSortableColumn="name">Video name <p-sortIcon field="name"></p-sortIcon></th >
       <th i18n>Video URL</th>
       <th style="width: 100px;" i18n *ngIf="isDisplayingRemoteVideos()">Total size</th>
       <th style="width: 80px;"></th>
@@ -64,6 +64,17 @@
       <td class="expand-cell" [attr.colspan]="getColspan()">
         <div *ngFor="let playlist of redundancy.redundancies.streamingPlaylists">
           <my-video-redundancy-information [redundancyElement]="playlist"></my-video-redundancy-information>
+        </div>
+      </td>
+    </tr>
+  </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="6">
+        <div class="empty-table-message">
+          <ng-container *ngIf="isDisplayingRemoteVideos()" i18n>Your instance doesn't mirror any video.</ng-container>
+          <ng-container *ngIf="!isDisplayingRemoteVideos()" i18n>Your instance has no mirrored videos.</ng-container>
         </div>
       </td>
     </tr>

--- a/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.ts
+++ b/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.ts
@@ -20,7 +20,6 @@ export class VideoRedundanciesListComponent extends RestTable implements OnInit 
 
   videoRedundancies: VideoRedundancy[] = []
   totalRecords = 0
-  rowsPerPage = 10
 
   sort: SortMeta = { field: 'name', order: 1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }

--- a/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.ts
+++ b/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.ts
@@ -13,7 +13,7 @@ import { RedundancyService } from '@app/shared/video/redundancy.service'
 @Component({
   selector: 'my-video-redundancies-list',
   templateUrl: './video-redundancies-list.component.html',
-  styleUrls: [ './video-redundancies-list.component.scss' ]
+  styleUrls: [ '../follows.component.scss', './video-redundancies-list.component.scss' ]
 })
 export class VideoRedundanciesListComponent extends RestTable implements OnInit {
   private static LOCAL_STORAGE_DISPLAY_TYPE = 'video-redundancies-list-display-type'

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
@@ -1,5 +1,5 @@
 <p-table
-  [value]="blockedAccounts" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
+  [value]="blockedAccounts" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} muted accounts"

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
@@ -17,7 +17,7 @@
 
   <ng-template pTemplate="header">
     <tr>
-      <th i18n>Account</th>
+      <th style="width: 100%;" i18n>Account</th>
       <th style="width: 190px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th style="width: 100px;"></th> <!-- column for action buttons --> 
     </tr>
@@ -25,10 +25,37 @@
 
   <ng-template pTemplate="body" let-accountBlock>
     <tr>
-      <td>{{ accountBlock.blockedAccount.nameWithHost }}</td>
+      <td>
+        <a [href]="accountBlock.blockedAccount.url" i18n-title title="Open account in a new tab" target="_blank" rel="noopener noreferrer">
+          <div class="chip two-lines">
+            <img
+              class="avatar"
+              [src]="accountBlock.blockedAccount.avatar?.path"
+              (error)="switchToDefaultAvatar($event)"
+              alt="Avatar"
+            >
+            <div>
+              {{ accountBlock.blockedAccount.displayName }}
+              <span class="text-muted">{{ accountBlock.blockedAccount.nameWithHost }}</span>
+            </div>
+          </div>
+        </a>
+      </td>
+
       <td>{{ accountBlock.createdAt }}</td>
       <td class="action-cell">
         <button class="unblock-button" (click)="unblockAccount(accountBlock)" i18n>Unmute</button>
+      </td>
+    </tr>
+  </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="6">
+        <div class="empty-table-message">
+          <ng-container *ngIf="search" i18n>No account found matching current filters.</ng-container>
+          <ng-container *ngIf="!search" i18n>No account found.</ng-container>
+        </div>
       </td>
     </tr>
   </ng-template>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
@@ -8,7 +8,7 @@
   <ng-template pTemplate="header">
     <tr>
       <th i18n>Account</th>
-      <th style="width: 200px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 190px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th style="width: 100px;"></th> <!-- column for action buttons --> 
     </tr>
   </ng-template>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
@@ -1,9 +1,19 @@
 <p-table
-  [value]="blockedAccounts" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="blockedAccounts" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} muted accounts"
 >
+  <ng-template pTemplate="caption">
+    <div class="caption">
+      <div class="ml-auto">
+        <input
+          type="text" name="table-filter" id="table-filter" i18n-placeholder placeholder="Filter..."
+          (keyup)="onSearch($event)"
+        >
+      </div>
+    </div>
+  </ng-template>
 
   <ng-template pTemplate="header">
     <tr>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.html
@@ -8,8 +8,8 @@
   <ng-template pTemplate="header">
     <tr>
       <th i18n>Account</th>
-      <th i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th></th> <!-- column for action buttons -->
+      <th style="width: 200px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 100px;"></th> <!-- column for action buttons --> 
     </tr>
   </ng-template>
 

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.ts
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.ts
@@ -7,13 +7,14 @@ import { AccountBlock, BlocklistService } from '@app/shared/blocklist'
 
 @Component({
   selector: 'my-instance-account-blocklist',
-  styleUrls: [ './instance-account-blocklist.component.scss' ],
+  styleUrls: [ '../moderation.component.scss', './instance-account-blocklist.component.scss' ],
   templateUrl: './instance-account-blocklist.component.html'
 })
 export class InstanceAccountBlocklistComponent extends RestTable implements OnInit {
   blockedAccounts: AccountBlock[] = []
   totalRecords = 0
-  rowsPerPage = 10
+  rowsPerPageOptions = [ 20, 50, 100 ]
+  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 
@@ -49,7 +50,11 @@ export class InstanceAccountBlocklistComponent extends RestTable implements OnIn
   }
 
   protected loadData () {
-    return this.blocklistService.getInstanceAccountBlocklist(this.pagination, this.sort)
+    return this.blocklistService.getInstanceAccountBlocklist({
+      pagination: this.pagination,
+      sort: this.sort,
+      search: this.search
+    })
       .subscribe(
         resultList => {
           this.blockedAccounts = resultList.data

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.ts
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.ts
@@ -4,6 +4,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 import { RestPagination, RestTable } from '@app/shared'
 import { SortMeta } from 'primeng/api'
 import { AccountBlock, BlocklistService } from '@app/shared/blocklist'
+import { Actor } from '@app/shared/actor/actor.model'
 
 @Component({
   selector: 'my-instance-account-blocklist',
@@ -32,6 +33,10 @@ export class InstanceAccountBlocklistComponent extends RestTable implements OnIn
 
   getIdentifier () {
     return 'InstanceAccountBlocklistComponent'
+  }
+
+  switchToDefaultAvatar ($event: Event) {
+    ($event.target as HTMLImageElement).src = Actor.GET_DEFAULT_AVATAR_URL()
   }
 
   unblockAccount (accountBlock: AccountBlock) {

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.ts
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-account-blocklist.component.ts
@@ -14,8 +14,6 @@ import { Actor } from '@app/shared/actor/actor.model'
 export class InstanceAccountBlocklistComponent extends RestTable implements OnInit {
   blockedAccounts: AccountBlock[] = []
   totalRecords = 0
-  rowsPerPageOptions = [ 20, 50, 100 ]
-  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
@@ -23,7 +23,12 @@
 
   <ng-template pTemplate="body" let-serverBlock>
     <tr>
-      <td>{{ serverBlock.blockedServer.host }}</td>
+      <td>
+        <a [href]="'https://' + serverBlock.blockedServer.host" i18n-title title="Open instance in a new tab" target="_blank" rel="noopener noreferrer">
+          {{ serverBlock.blockedServer.host }}
+          <span class="glyphicon glyphicon-new-window"></span>
+        </a>
+      </td>
       <td>{{ serverBlock.createdAt }}</td>
       <td class="action-cell">
         <button class="unblock-button" (click)="unblockServer(serverBlock)" i18n>Unmute</button>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
@@ -16,8 +16,8 @@
   <ng-template pTemplate="header">
     <tr>
       <th i18n>Instance</th>
-      <th i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th></th> <!-- column for action buttons -->
+      <th style="width: 200px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 100px;"></th> <!-- column for action buttons -->
     </tr>
   </ng-template>
 

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
@@ -1,5 +1,5 @@
 <p-table
-  [value]="blockedServers" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
+  [value]="blockedServers" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} muted instances"
@@ -54,10 +54,4 @@
   </ng-template>
 </p-table>
 
-<my-batch-domains-modal #batchDomainsModal i18n-action action="Mute domains" (domains)="onDomainsToBlock($event)">
-  <ng-container ngProjectAs="warning">
-    <div i18n *ngIf="httpEnabled() === false"  class="alert alert-warning">
-      It seems that you are not on a HTTPS server. Your webserver needs to have TLS activated in order to follow servers.
-    </div>
-  </ng-container>
-</my-batch-domains-modal>
+<my-batch-domains-modal #batchDomainsModal i18n-action action="Mute domains" (domains)="onDomainsToBlock($event)"></my-batch-domains-modal>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
@@ -1,12 +1,18 @@
 <p-table
-  [value]="blockedServers" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="blockedServers" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} muted instances"
 >
   <ng-template pTemplate="caption">
     <div class="caption">
-      <a class="ml-auto block-button" (click)="addServersToBlock()" (key.enter)="addServersToBlock()">
+      <div class="ml-auto">
+        <input
+          type="text" name="table-filter" id="table-filter" i18n-placeholder placeholder="Filter..."
+          (keyup)="onSearch($event)"
+        >
+      </div>
+      <a class="ml-2 block-button" (click)="addServersToBlock()" (key.enter)="addServersToBlock()">
         <my-global-icon iconName="add"></my-global-icon>
         <ng-container i18n>Mute domain</ng-container>
       </a>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
@@ -16,7 +16,7 @@
   <ng-template pTemplate="header">
     <tr>
       <th i18n>Instance</th>
-      <th style="width: 200px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 190px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th style="width: 100px;"></th> <!-- column for action buttons -->
     </tr>
   </ng-template>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.html
@@ -21,7 +21,7 @@
 
   <ng-template pTemplate="header">
     <tr>
-      <th i18n>Instance</th>
+      <th style="width: 100%;" i18n>Instance</th>
       <th style="width: 190px;" i18n pSortableColumn="createdAt">Muted at <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th style="width: 100px;"></th> <!-- column for action buttons -->
     </tr>
@@ -38,6 +38,17 @@
       <td>{{ serverBlock.createdAt }}</td>
       <td class="action-cell">
         <button class="unblock-button" (click)="unblockServer(serverBlock)" i18n>Unmute</button>
+      </td>
+    </tr>
+  </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="6">
+        <div class="empty-table-message">
+          <ng-container *ngIf="search" i18n>No server found matching current filters.</ng-container>
+          <ng-container *ngIf="!search" i18n>No server found.</ng-container>
+        </div>
       </td>
     </tr>
   </ng-template>

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.scss
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.scss
@@ -1,6 +1,20 @@
 @import '_variables';
 @import '_mixins';
 
+a {
+  @include disable-default-a-behaviour;
+  display: inline-block;
+
+  &, &:hover {
+    color: var(--mainForegroundColor);
+  }
+
+  span {
+    font-size: 80%;
+    color: var(--inputPlaceholderColor);
+  }
+}
+
 .unblock-button {
   @include peertube-button;
   @include grey-button;

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.ts
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.ts
@@ -17,8 +17,6 @@ export class InstanceServerBlocklistComponent extends RestTable implements OnIni
 
   blockedServers: ServerBlock[] = []
   totalRecords = 0
-  rowsPerPageOptions = [ 20, 50, 100 ]
-  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.ts
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.ts
@@ -51,10 +51,6 @@ export class InstanceServerBlocklistComponent extends RestTable implements OnIni
       )
   }
 
-  httpEnabled () {
-    return window.location.protocol === 'https:'
-  }
-
   addServersToBlock () {
     this.batchDomainsModal.openModal()
   }

--- a/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.ts
+++ b/client/src/app/+admin/moderation/instance-blocklist/instance-server-blocklist.component.ts
@@ -9,7 +9,7 @@ import { BatchDomainsModalComponent } from '@app/+admin/config/shared/batch-doma
 
 @Component({
   selector: 'my-instance-server-blocklist',
-  styleUrls: [ './instance-server-blocklist.component.scss' ],
+  styleUrls: [ '../moderation.component.scss', './instance-server-blocklist.component.scss' ],
   templateUrl: './instance-server-blocklist.component.html'
 })
 export class InstanceServerBlocklistComponent extends RestTable implements OnInit {
@@ -17,7 +17,8 @@ export class InstanceServerBlocklistComponent extends RestTable implements OnIni
 
   blockedServers: ServerBlock[] = []
   totalRecords = 0
-  rowsPerPage = 10
+  rowsPerPageOptions = [ 20, 50, 100 ]
+  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 
@@ -72,7 +73,11 @@ export class InstanceServerBlocklistComponent extends RestTable implements OnIni
   }
 
   protected loadData () {
-    return this.blocklistService.getInstanceServerBlocklist(this.pagination, this.sort)
+    return this.blocklistService.getInstanceServerBlocklist({
+      pagination: this.pagination,
+      sort: this.sort,
+      search: this.search
+    })
       .subscribe(
         resultList => {
           this.blockedServers = resultList.data

--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -7,19 +7,23 @@
   margin-right: 30px;
 }
 
-.moderation-expanded-label {
-  font-weight: $font-semibold;
-  display: inline-block;
-  vertical-align: top;
-  text-align: right;
-}
+.moderation-expanded {
+  font-size: 90%;
 
-.moderation-expanded-text {
-  display: inline-block;
-  word-wrap: break-word;
-
-  ::ng-deep p:last-child {
-    margin-bottom: 0px !important;
+  .moderation-expanded-label {
+    font-weight: $font-semibold;
+    display: inline-block;
+    vertical-align: top;
+    text-align: right;
+  }
+  
+  .moderation-expanded-text {
+    display: inline-flex;
+    word-wrap: break-word;
+  
+    ::ng-deep p:last-child {
+      margin-bottom: 0px !important;
+    }
   }
 }
 
@@ -57,4 +61,10 @@
 
 .chip {
   @include chip;
+}
+
+my-action-dropdown.show {
+  ::ng-deep .dropdown-root {
+    display: block !important;
+  }
 }

--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -15,6 +15,10 @@
   }
 }
 
+.empty-table-message {
+  @include empty-state;
+}
+
 .moderation-expanded {
   font-size: 90%;
 

--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -27,7 +27,7 @@
   }
 }
 
-.video-abuse-states {
+.video-table-states {
   & > :not(:first-child) {
     margin-left: .4rem;
   }
@@ -66,5 +66,73 @@
 my-action-dropdown.show {
   ::ng-deep .dropdown-root {
     display: block !important;
+  }
+}
+
+
+.video-table-video-link {
+  @include disable-outline;
+  position: relative;
+  top: 3px;
+}
+
+.video-table-video {
+  display: inline-flex;
+
+  .video-table-video-image {
+    @include miniature-thumbnail;
+
+    $image-height: 45px;
+
+    height: $image-height;
+    width: #{(16/9) * $image-height};
+    margin-right: 0.5rem;
+    border-radius: 2px;
+    border: none;
+    background: transparent;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+
+    img {
+      height: 100%;
+      width: 100%;
+      border-radius: 2px;
+    }
+
+    span {
+      color: var(--inputPlaceholderColor);
+    }
+
+    .video-table-video-image-label {
+      @include static-thumbnail-overlay;
+      position: absolute;
+      border-radius: 3px;
+      font-size: 10px;
+      padding: 0 3px;
+      line-height: 1.3;
+      bottom: 2px;
+      right: 2px;
+    }
+  }
+
+  .video-table-video-text {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    font-size: 90%;
+    color: var(--mainForegroundColor);
+    line-height: 1rem;
+
+    div .glyphicon {
+      font-size: 80%;
+      color: gray;
+      margin-left: 0.1rem;
+    }
+
+    div + div {
+      font-size: 80%;
+    }
   }
 }

--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -1,5 +1,6 @@
 @import 'variables';
 @import 'mixins';
+@import 'miniature';
 
 .form-sub-title {
   flex-grow: 0;
@@ -22,11 +23,27 @@
   }
 }
 
+.video-abuse-states {
+  & > :not(:first-child) {
+    margin-left: .4rem;
+  }
+}
+
 .screenratio {
   position: relative;
   width: 100%;
   height: 0;
   padding-bottom: 56%;
+
+  div {
+    @include miniature-thumbnail;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+  }
 
   ::ng-deep iframe {
     position: absolute;

--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -7,6 +7,14 @@
   margin-right: 30px;
 }
 
+.caption {
+  justify-content: flex-end;
+
+  input {
+    @include peertube-input-text(250px);
+  }
+}
+
 .moderation-expanded {
   font-size: 90%;
 

--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -29,6 +29,10 @@
   }
 }
 
+.glyphicon-trash {
+  font-size: 80%;
+}
+
 .screenratio {
   position: relative;
   width: 100%;

--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -29,10 +29,6 @@
   }
 }
 
-.glyphicon-trash {
-  font-size: 80%;
-}
-
 .screenratio {
   position: relative;
   width: 100%;
@@ -47,6 +43,7 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
+    color: var(--inputPlaceholderColor);
   }
 
   ::ng-deep iframe {

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -39,7 +39,7 @@
           <div class="chip two-lines">
             <img
               class="avatar"
-              [src]="videoAbuse.reporterAccount.avatar.path"
+              [src]="videoAbuse.reporterAccount.avatar?.path"
               (error)="switchToDefaultAvatar($event)"
               alt="Avatar"
             >
@@ -174,6 +174,17 @@
           </div>
         </td>
       </tr>
+  </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="6">
+        <div class="empty-table-message">
+          <ng-container *ngIf="search" i18n>No video abuses found matching current filters.</ng-container>
+          <ng-container *ngIf="!search" i18n>No video abuses found.</ng-container>
+        </div>
+      </td>
+    </tr>
   </ng-template>
 </p-table>
 

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -41,9 +41,22 @@
       </td>
 
       <td>
-        <span *ngIf="videoAbuse.video.deleted" i18n-title title="Video was deleted" class="glyphicon glyphicon-trash"></span>
-        <a [href]="getVideoUrl(videoAbuse)" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
-          {{ videoAbuse.video.name }}
+        <a [href]="getVideoUrl(videoAbuse)" class="video-abuse-video-link" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
+          <div class="video-abuse-video">
+            <div class="video-abuse-video-image">
+              <img *ngIf="!videoAbuse.video.deleted" [src]="videoAbuse.video.thumbnailPath">
+              <span *ngIf="videoAbuse.video.deleted" i18n>Deleted</span>
+            </div>
+            <div class="video-abuse-video-text">
+              <div>
+                {{ videoAbuse.video.name }}
+                <span *ngIf="!videoAbuse.video.deleted && !videoAbuse.video.blacklisted" class="glyphicon glyphicon-new-window"></span>
+                <span *ngIf="videoAbuse.video.deleted" i18n-title title="Video was deleted" class="glyphicon glyphicon-trash"></span>
+                <span *ngIf="videoAbuse.video.blacklisted" i18n-title title="Video was blacklisted" class="glyphicon glyphicon-ban-circle"></span>
+              </div>
+              <div class="text-muted">by {{ videoAbuse.video.channel?.displayName }} on {{ videoAbuse.video.channel?.host }} </div>
+            </div>
+          </div>
         </a>
       </td>
 
@@ -78,10 +91,10 @@
 
             <div class="col-4">
               <div class="screenratio">
-                <div *ngIf="videoAbuse.video.deleted">
+                <div *ngIf="videoAbuse.video.deleted || videoAbuse.video.blacklisted">
                   <span i18n>The video was {{ videoAbuse.video.deleted ? 'deleted' : 'blacklisted' }}</span>
                 </div>
-                <div *ngIf="!videoAbuse.video.deleted" [innerHTML]="videoAbuse.embedHtml"></div>
+                <div *ngIf="!videoAbuse.video.deleted && !videoAbuse.video.blacklisted" [innerHTML]="videoAbuse.embedHtml"></div>
               </div>
             </div>
           </div>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -48,9 +48,10 @@
         </a>
       </td>
 
-      <td class="c-hand" [pRowToggler]="videoAbuse">
+      <td class="c-hand video-abuse-states" [pRowToggler]="videoAbuse">
         <span *ngIf="isVideoAbuseAccepted(videoAbuse)" [title]="videoAbuse.state.label" class="glyphicon glyphicon-ok"></span>
         <span *ngIf="isVideoAbuseRejected(videoAbuse)" [title]="videoAbuse.state.label" class="glyphicon glyphicon-remove"></span>
+        <span *ngIf="videoAbuse.moderationComment" [title]="videoAbuse.moderationComment" class="glyphicon glyphicon-comment"></span>
       </td>
 
       <td class="action-cell">
@@ -75,7 +76,12 @@
             </div>
 
             <div class="col-4">
-              <div class="screenratio" [innerHTML]="videoAbuse.embedHtml"></div>
+              <div class="screenratio">
+                <div *ngIf="videoAbuse.video.deleted">
+                  <span i18n>The video was {{ videoAbuse.video.deleted ? 'deleted' : 'blacklisted' }}</span>
+                </div>
+                <div *ngIf="!videoAbuse.video.deleted" [innerHTML]="videoAbuse.embedHtml"></div>
+              </div>
             </div>
           </div>
         </td>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -149,7 +149,7 @@
                       <span class="text-muted">{{ videoAbuse.video.channel.ownerAccount ? createByString(videoAbuse.video.channel.ownerAccount) : '' }}</span>
                     </div>
                   </div>
-                  <a [routerLink]="[ '/admin/moderation/video-abuses/list' ]" [queryParams]="{ 'search': videoAbuse.video.channel.ownerAccount.displayName }" class="ml-auto text-muted video-details-links" *ngIf="!videoAbuse.video.deleted" i18n>
+                  <a [routerLink]="[ '/admin/moderation/video-abuses/list' ]" [queryParams]="{ 'search': videoAbuse.video.channel.ownerAccount.displayName }" class="ml-auto text-muted video-details-links" i18n>
                     {videoAbuse.countReportsForReportee, plural, =1 {1 report} other {{{ videoAbuse.countReportsForReportee }} reports}}<span class="ml-1 glyphicon glyphicon-flag"></span>
                   </a>
                 </span>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -20,7 +20,7 @@
       <th style="width: 40px;"></th>
       <th style="width: 20%;" pResizableColumn i18n>Reporter</th>
       <th i18n>Video</th>
-      <th style="width:190px;" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 190px;" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th i18n pSortableColumn="state" style="width: 80px;">State <p-sortIcon field="state"></p-sortIcon></th>
       <th style="width: 120px;"></th>
     </tr>
@@ -59,7 +59,9 @@
               <span
                 class="video-table-video-image-label" *ngIf="videoAbuse.count > 1"
                 i18n-title title="This video has been reported multiple times."
-              >{{ videoAbuse.nth }}/{{ videoAbuse.count }}</span>
+              >
+                {{ videoAbuse.nth }}/{{ videoAbuse.count }}
+              </span>
             </div>
             <div class="video-table-video-text">
               <div>
@@ -67,7 +69,7 @@
                 <span *ngIf="!videoAbuse.video.blacklisted" class="glyphicon glyphicon-new-window"></span>
                 <span *ngIf="videoAbuse.video.blacklisted" i18n-title title="Video was blacklisted" class="glyphicon glyphicon-ban-circle"></span>
               </div>
-              <div class="text-muted">by {{ videoAbuse.video.channel?.displayName }} on {{ videoAbuse.video.channel?.host }} </div>
+              <div class="text-muted" i18n>by {{ videoAbuse.video.channel?.displayName }} on {{ videoAbuse.video.channel?.host }} </div>
             </div>
           </div>
         </a>
@@ -75,13 +77,15 @@
 
       <td *ngIf="videoAbuse.video.deleted" class="c-hand" [pRowToggler]="videoAbuse">
         <div class="video-table-video" i18n-title title="Video was deleted">
-          <div class="video-table-video-image"><span i18n>Deleted</span></div>
+          <div class="video-table-video-image">
+            <span i18n>Deleted</span>
+          </div>
           <div class="video-table-video-text">
             <div>
               {{ videoAbuse.video.name }}
               <span class="glyphicon glyphicon-trash"></span>
             </div>
-            <div class="text-muted">by {{ videoAbuse.video.channel?.displayName }} on {{ videoAbuse.video.channel?.host }} </div>
+            <div class="text-muted" i18n>by {{ videoAbuse.video.channel?.displayName }} on {{ videoAbuse.video.channel?.host }} </div>
           </div>
         </div>
       </td>
@@ -107,8 +111,10 @@
       <tr>
         <td class="expand-cell" colspan="6">
           <div class="d-flex moderation-expanded">
-            <!-- report metadata -->
+            <!-- report left part (report details) -->
             <div class="col-8">
+
+              <!-- report metadata -->
               <div class="d-flex">
                 <span class="col-3 moderation-expanded-label" i18n>Reporter</span>
                 <span class="col-9 moderation-expanded-text">
@@ -128,6 +134,7 @@
                   </a>
                 </span>
               </div>
+
               <div class="d-flex">
                 <span class="col-3 moderation-expanded-label" i18n>Reportee</span>
                 <span class="col-9 moderation-expanded-text">
@@ -147,6 +154,7 @@
                   </a>
                 </span>
               </div>
+
               <div class="d-flex">
                 <span class="col-3 moderation-expanded-label" i18n>Updated</span>
                 <time class="col-9 moderation-expanded-text video-details-date-updated">{{ videoAbuse.updatedAt | date: 'medium' }}</time>
@@ -157,16 +165,20 @@
                 <span class="col-3 moderation-expanded-label" i18n>Report #{{ videoAbuse.id }}</span>
                 <span class="col-9 moderation-expanded-text" [innerHTML]="videoAbuse.reasonHtml"></span>
               </div>
+
               <div class="mt-3 d-flex" *ngIf="videoAbuse.moderationComment">
                 <span class="col-3 moderation-expanded-label" i18n>Note</span>
                 <span class="col-9 moderation-expanded-text" [innerHTML]="videoAbuse.moderationCommentHtml"></span>
               </div>
+
             </div>
 
+            <!-- report right part (video details) -->
             <div class="col-4">
               <div class="screenratio">
                 <div *ngIf="videoAbuse.video.deleted || videoAbuse.video.blacklisted">
-                  <span i18n>The video was {{ videoAbuse.video.deleted ? 'deleted' : 'blacklisted' }}</span>
+                  <span i18n *ngIf="videoAbuse.video.deleted">The video was deleted</span>
+                  <span i18n *ngIf="!videoAbuse.video.deleted">The video was blacklisted</span>
                 </div>
                 <div *ngIf="!videoAbuse.video.deleted && !videoAbuse.video.blacklisted" [innerHTML]="videoAbuse.embedHtml"></div>
               </div>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -52,16 +52,16 @@
       </td>
 
       <td *ngIf="!videoAbuse.video.deleted">
-        <a [href]="getVideoUrl(videoAbuse)" class="video-abuse-video-link" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
-          <div class="video-abuse-video">
-            <div class="video-abuse-video-image">
+        <a [href]="getVideoUrl(videoAbuse)" class="video-table-video-link" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
+          <div class="video-table-video">
+            <div class="video-table-video-image">
               <img [src]="videoAbuse.video.thumbnailPath">
               <span
-                class="video-abuse-video-image-label" *ngIf="videoAbuse.count > 1"
+                class="video-table-video-image-label" *ngIf="videoAbuse.count > 1"
                 i18n-title title="This video has been reported multiple times."
               >{{ videoAbuse.nth }}/{{ videoAbuse.count }}</span>
             </div>
-            <div class="video-abuse-video-text">
+            <div class="video-table-video-text">
               <div>
                 {{ videoAbuse.video.name }}
                 <span *ngIf="!videoAbuse.video.blacklisted" class="glyphicon glyphicon-new-window"></span>
@@ -74,9 +74,9 @@
       </td>
 
       <td *ngIf="videoAbuse.video.deleted" class="c-hand" [pRowToggler]="videoAbuse">
-        <div class="video-abuse-video" i18n-title title="Video was deleted">
-          <div class="video-abuse-video-image"><span i18n>Deleted</span></div>
-          <div class="video-abuse-video-text">
+        <div class="video-table-video" i18n-title title="Video was deleted">
+          <div class="video-table-video-image"><span i18n>Deleted</span></div>
+          <div class="video-table-video-text">
             <div>
               {{ videoAbuse.video.name }}
               <span class="glyphicon glyphicon-trash"></span>
@@ -123,7 +123,7 @@
                       <span class="text-muted">{{ createByString(videoAbuse.reporterAccount) }}</span>
                     </div>
                   </div>
-                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-abuse-links" i18n>
+                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-details-links" i18n>
                     {videoAbuse.countReportsForReporter, plural, =1 {1 report} other {{{ videoAbuse.countReportsForReporter }} reports}}<span class="ml-1 glyphicon glyphicon-flag"></span>
                   </a>
                 </span>
@@ -142,14 +142,14 @@
                       <span class="text-muted">{{ videoAbuse.video.channel.ownerAccount ? createByString(videoAbuse.video.channel.ownerAccount) : '' }}</span>
                     </div>
                   </div>
-                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-abuse-links" *ngIf="!videoAbuse.video.deleted" i18n>
+                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-details-links" *ngIf="!videoAbuse.video.deleted" i18n>
                     {videoAbuse.countReportsForReportee, plural, =1 {1 report} other {{{ videoAbuse.countReportsForReportee }} reports}}<span class="ml-1 glyphicon glyphicon-flag"></span>
                   </a>
                 </span>
               </div>
               <div class="d-flex">
                 <span class="col-3 moderation-expanded-label" i18n>Updated</span>
-                <time class="col-9 moderation-expanded-text video-abuse-date-updated">{{ videoAbuse.updatedAt | date: 'medium' }}</time>
+                <time class="col-9 moderation-expanded-text video-details-date-updated">{{ videoAbuse.updatedAt | date: 'medium' }}</time>
               </div>
 
               <!-- report text -->

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -154,7 +154,7 @@
 
               <!-- report text -->
               <div class="mt-3 d-flex">
-                <span class="col-3 moderation-expanded-label" i18n>Report</span>
+                <span class="col-3 moderation-expanded-label" i18n>Report #{{ videoAbuse.id }}</span>
                 <span class="col-9 moderation-expanded-text" [innerHTML]="videoAbuse.reasonHtml"></span>
               </div>
               <div class="mt-3 d-flex" *ngIf="videoAbuse.moderationComment">

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -4,6 +4,17 @@
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} reports"
 >
+  <ng-template pTemplate="caption">
+    <div class="caption">
+      <div class="ml-auto">
+        <input
+          type="text" name="table-filter" id="table-filter" i18n-placeholder placeholder="Filter..."
+          (keyup)="onSearch($event)"
+        >
+      </div>
+    </div>
+  </ng-template>
+
   <ng-template pTemplate="header">
     <tr> <!-- header -->
       <th style="width: 40px;"></th>
@@ -40,18 +51,14 @@
         </a>
       </td>
 
-      <td>
+      <td *ngIf="!videoAbuse.video.deleted">
         <a [href]="getVideoUrl(videoAbuse)" class="video-abuse-video-link" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
           <div class="video-abuse-video">
-            <div class="video-abuse-video-image">
-              <img *ngIf="!videoAbuse.video.deleted" [src]="videoAbuse.video.thumbnailPath">
-              <span *ngIf="videoAbuse.video.deleted" i18n>Deleted</span>
-            </div>
+            <div class="video-abuse-video-image"><img [src]="videoAbuse.video.thumbnailPath"></div>
             <div class="video-abuse-video-text">
               <div>
                 {{ videoAbuse.video.name }}
-                <span *ngIf="!videoAbuse.video.deleted && !videoAbuse.video.blacklisted" class="glyphicon glyphicon-new-window"></span>
-                <span *ngIf="videoAbuse.video.deleted" i18n-title title="Video was deleted" class="glyphicon glyphicon-trash"></span>
+                <span *ngIf="!videoAbuse.video.blacklisted" class="glyphicon glyphicon-new-window"></span>
                 <span *ngIf="videoAbuse.video.blacklisted" i18n-title title="Video was blacklisted" class="glyphicon glyphicon-ban-circle"></span>
               </div>
               <div class="text-muted">by {{ videoAbuse.video.channel?.displayName }} on {{ videoAbuse.video.channel?.host }} </div>
@@ -60,7 +67,20 @@
         </a>
       </td>
 
-      <td>{{ videoAbuse.createdAt }}</td>
+      <td *ngIf="videoAbuse.video.deleted" class="c-hand" [pRowToggler]="videoAbuse">
+        <div class="video-abuse-video" i18n-title title="Video was deleted">
+          <div class="video-abuse-video-image"><span i18n>Deleted</span></div>
+          <div class="video-abuse-video-text">
+            <div>
+              {{ videoAbuse.video.name }}
+              <span class="glyphicon glyphicon-trash"></span>
+            </div>
+            <div class="text-muted">by {{ videoAbuse.video.channel?.displayName }} on {{ videoAbuse.video.channel?.host }} </div>
+          </div>
+        </div>
+      </td>
+
+      <td class="c-hand" [pRowToggler]="videoAbuse">{{ videoAbuse.createdAt }}</td>
 
       <td class="c-hand video-abuse-states" [pRowToggler]="videoAbuse">
         <span *ngIf="isVideoAbuseAccepted(videoAbuse)" [title]="videoAbuse.state.label" class="glyphicon glyphicon-ok"></span>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -1,15 +1,15 @@
 <p-table
-  [value]="videoAbuses" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
-  [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"
+  [value]="videoAbuses" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
+  [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id" [resizableColumns]="true"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} reports"
 >
   <ng-template pTemplate="header">
     <tr> <!-- header -->
       <th style="width: 40px;"></th>
-      <th i18n>Reporter</th>
-      <th style="width: 200px;" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 20%;" pResizableColumn i18n>Reporter</th>
       <th i18n>Video</th>
+      <th style="width:190px;" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th i18n pSortableColumn="state" style="width: 80px;">State <p-sortIcon field="state"></p-sortIcon></th>
       <th style="width: 120px;"></th>
     </tr>
@@ -40,13 +40,14 @@
         </a>
       </td>
 
-      <td>{{ videoAbuse.createdAt }}</td>
-
       <td>
+        <span *ngIf="videoAbuse.video.deleted" i18n-title title="Video was deleted" class="glyphicon glyphicon-trash"></span>
         <a [href]="getVideoUrl(videoAbuse)" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
           {{ videoAbuse.video.name }}
         </a>
       </td>
+
+      <td>{{ videoAbuse.createdAt }}</td>
 
       <td class="c-hand video-abuse-states" [pRowToggler]="videoAbuse">
         <span *ngIf="isVideoAbuseAccepted(videoAbuse)" [title]="videoAbuse.state.label" class="glyphicon glyphicon-ok"></span>
@@ -55,7 +56,7 @@
       </td>
 
       <td class="action-cell">
-        <my-action-dropdown placement="bottom-right auto" i18n-label label="Actions" [actions]="videoAbuseActions" [entry]="videoAbuse"></my-action-dropdown>
+        <my-action-dropdown placement="bottom-right auto" container="body" i18n-label label="Actions" [actions]="videoAbuseActions" [entry]="videoAbuse"></my-action-dropdown>
       </td>
     </tr>
   </ng-template>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -1,5 +1,5 @@
 <p-table
-  [value]="videoAbuses" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
+  [value]="videoAbuses" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id" [resizableColumns]="true"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} reports"
@@ -123,7 +123,7 @@
                       <span class="text-muted">{{ createByString(videoAbuse.reporterAccount) }}</span>
                     </div>
                   </div>
-                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-details-links" i18n>
+                  <a [routerLink]="[ '/admin/moderation/video-abuses/list' ]" [queryParams]="{ 'search': videoAbuse.reporterAccount.displayName }" class="ml-auto text-muted video-details-links" i18n>
                     {videoAbuse.countReportsForReporter, plural, =1 {1 report} other {{{ videoAbuse.countReportsForReporter }} reports}}<span class="ml-1 glyphicon glyphicon-flag"></span>
                   </a>
                 </span>
@@ -142,7 +142,7 @@
                       <span class="text-muted">{{ videoAbuse.video.channel.ownerAccount ? createByString(videoAbuse.video.channel.ownerAccount) : '' }}</span>
                     </div>
                   </div>
-                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-details-links" *ngIf="!videoAbuse.video.deleted" i18n>
+                  <a [routerLink]="[ '/admin/moderation/video-abuses/list' ]" [queryParams]="{ 'search': videoAbuse.video.channel.ownerAccount.displayName }" class="ml-auto text-muted video-details-links" *ngIf="!videoAbuse.video.deleted" i18n>
                     {videoAbuse.countReportsForReportee, plural, =1 {1 report} other {{{ videoAbuse.countReportsForReportee }} reports}}<span class="ml-1 glyphicon glyphicon-flag"></span>
                   </a>
                 </span>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.html
@@ -54,7 +54,13 @@
       <td *ngIf="!videoAbuse.video.deleted">
         <a [href]="getVideoUrl(videoAbuse)" class="video-abuse-video-link" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
           <div class="video-abuse-video">
-            <div class="video-abuse-video-image"><img [src]="videoAbuse.video.thumbnailPath"></div>
+            <div class="video-abuse-video-image">
+              <img [src]="videoAbuse.video.thumbnailPath">
+              <span
+                class="video-abuse-video-image-label" *ngIf="videoAbuse.count > 1"
+                i18n-title title="This video has been reported multiple times."
+              >{{ videoAbuse.nth }}/{{ videoAbuse.count }}</span>
+            </div>
             <div class="video-abuse-video-text">
               <div>
                 {{ videoAbuse.video.name }}
@@ -85,11 +91,14 @@
       <td class="c-hand video-abuse-states" [pRowToggler]="videoAbuse">
         <span *ngIf="isVideoAbuseAccepted(videoAbuse)" [title]="videoAbuse.state.label" class="glyphicon glyphicon-ok"></span>
         <span *ngIf="isVideoAbuseRejected(videoAbuse)" [title]="videoAbuse.state.label" class="glyphicon glyphicon-remove"></span>
-        <span *ngIf="videoAbuse.moderationComment" [title]="videoAbuse.moderationComment" class="glyphicon glyphicon-comment"></span>
+        <span *ngIf="videoAbuse.moderationComment" container="body" placement="left auto" [ngbTooltip]="videoAbuse.moderationComment" class="glyphicon glyphicon-comment"></span>
       </td>
 
       <td class="action-cell">
-        <my-action-dropdown placement="bottom-right auto" container="body" i18n-label label="Actions" [actions]="videoAbuseActions" [entry]="videoAbuse"></my-action-dropdown>
+        <my-action-dropdown
+          [ngClass]="{ 'show': expanded }" placement="bottom-right auto" container="body"
+          i18n-label label="Actions" [actions]="videoAbuseActions" [entry]="videoAbuse"
+        ></my-action-dropdown>
       </td>
     </tr>
   </ng-template>
@@ -97,14 +106,59 @@
   <ng-template pTemplate="rowexpansion" let-videoAbuse>
       <tr>
         <td class="expand-cell" colspan="6">
-          <div class="d-flex">
+          <div class="d-flex moderation-expanded">
+            <!-- report metadata -->
             <div class="col-8">
               <div class="d-flex">
-                <span class="col-3 moderation-expanded-label" i18n>Reason:</span>
+                <span class="col-3 moderation-expanded-label" i18n>Reporter</span>
+                <span class="col-9 moderation-expanded-text">
+                  <div class="chip">
+                    <img
+                      class="avatar"
+                      [src]="videoAbuse.reporterAccount.avatar.path"
+                      (error)="switchToDefaultAvatar($event)"
+                      alt="Avatar"
+                    >
+                    <div>
+                      <span class="text-muted">{{ createByString(videoAbuse.reporterAccount) }}</span>
+                    </div>
+                  </div>
+                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-abuse-links" i18n>
+                    {videoAbuse.countReportsForReporter, plural, =1 {1 report} other {{{ videoAbuse.countReportsForReporter }} reports}}<span class="ml-1 glyphicon glyphicon-flag"></span>
+                  </a>
+                </span>
+              </div>
+              <div class="d-flex">
+                <span class="col-3 moderation-expanded-label" i18n>Reportee</span>
+                <span class="col-9 moderation-expanded-text">
+                  <div class="chip">
+                    <img
+                      class="avatar"
+                      [src]="videoAbuse.video.channel.ownerAccount?.avatar.path"
+                      (error)="switchToDefaultAvatar($event)"
+                      alt="Avatar"
+                    >
+                    <div>
+                      <span class="text-muted">{{ videoAbuse.video.channel.ownerAccount ? createByString(videoAbuse.video.channel.ownerAccount) : '' }}</span>
+                    </div>
+                  </div>
+                  <a routerLink="/admin/moderation/video-abuses/list" class="ml-auto text-muted video-abuse-links" *ngIf="!videoAbuse.video.deleted" i18n>
+                    {videoAbuse.countReportsForReportee, plural, =1 {1 report} other {{{ videoAbuse.countReportsForReportee }} reports}}<span class="ml-1 glyphicon glyphicon-flag"></span>
+                  </a>
+                </span>
+              </div>
+              <div class="d-flex">
+                <span class="col-3 moderation-expanded-label" i18n>Updated</span>
+                <time class="col-9 moderation-expanded-text video-abuse-date-updated">{{ videoAbuse.updatedAt | date: 'medium' }}</time>
+              </div>
+
+              <!-- report text -->
+              <div class="mt-3 d-flex">
+                <span class="col-3 moderation-expanded-label" i18n>Report</span>
                 <span class="col-9 moderation-expanded-text" [innerHTML]="videoAbuse.reasonHtml"></span>
               </div>
               <div class="mt-3 d-flex" *ngIf="videoAbuse.moderationComment">
-                <span class="col-3 moderation-expanded-label" i18n>Note:</span>
+                <span class="col-3 moderation-expanded-label" i18n>Note</span>
                 <span class="col-9 moderation-expanded-text" [innerHTML]="videoAbuse.moderationCommentHtml"></span>
               </div>
             </div>

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
@@ -9,78 +9,15 @@
   }
 }
 
-.video-abuse-date-updated {
+.video-details-date-updated {
   font-size: 90%;
   margin-top: .1rem;
 }
 
-.video-abuse-links {
+.video-details-links {
   @include disable-default-a-behaviour;
 }
 
-.video-abuse-video-link {
-  @include disable-outline;
-  position: relative;
-  top: 3px;
-}
-
-.video-abuse-video {
-  display: inline-flex;
-
-  .video-abuse-video-image {
-    @include miniature-thumbnail;
-
-    $image-height: 45px;
-
-    height: $image-height;
-    width: #{(16/9) * $image-height};
-    margin-right: 0.5rem;
-    border-radius: 2px;
-    border: none;
-    background: transparent;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-
-    img {
-      height: 100%;
-      width: 100%;
-      border-radius: 2px;
-    }
-
-    span {
-      color: var(--inputPlaceholderColor);
-    }
-
-    .video-abuse-video-image-label {
-      @include static-thumbnail-overlay;
-      position: absolute;
-      border-radius: 3px;
-      font-size: 10px;
-      padding: 0 3px;
-      line-height: 1.3;
-      bottom: 2px;
-      right: 2px;
-    }
-  }
-
-  .video-abuse-video-text {
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: center;
-    font-size: 90%;
-    color: var(--mainForegroundColor);
-    line-height: 1rem;
-
-    div .glyphicon {
-      font-size: 80%;
-      color: gray;
-      margin-left: 0.1rem;
-    }
-
-    div + div {
-      font-size: 80%;
-    }
-  }
+.video-abuse-states .glyphicon-comment {
+  margin-left: 0.5rem;
 }

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
@@ -1,6 +1,14 @@
 @import 'mixins';
 @import 'miniature';
 
+.caption {
+  justify-content: flex-end;
+
+  input {
+    @include peertube-input-text(250px);
+  }
+}
+
 .video-abuse-video-link {
   @include disable-outline;
   position: relative;

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
@@ -9,6 +9,15 @@
   }
 }
 
+.video-abuse-date-updated {
+  font-size: 90%;
+  margin-top: .1rem;
+}
+
+.video-abuse-links {
+  @include disable-default-a-behaviour;
+}
+
 .video-abuse-video-link {
   @include disable-outline;
   position: relative;
@@ -32,6 +41,7 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
+    position: relative;
 
     img {
       height: 100%;
@@ -41,6 +51,17 @@
 
     span {
       color: var(--inputPlaceholderColor);
+    }
+
+    .video-abuse-video-image-label {
+      @include static-thumbnail-overlay;
+      position: absolute;
+      border-radius: 3px;
+      font-size: 10px;
+      padding: 0 3px;
+      line-height: 1.3;
+      bottom: 2px;
+      right: 2px;
     }
   }
 

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
@@ -1,0 +1,57 @@
+@import 'mixins';
+@import 'miniature';
+
+.video-abuse-video-link {
+  @include disable-outline;
+  position: relative;
+  top: 3px;
+}
+
+.video-abuse-video {
+  display: inline-flex;
+
+  .video-abuse-video-image {
+    @include miniature-thumbnail;
+
+    $image-height: 45px;
+
+    height: $image-height;
+    width: #{(16/9) * $image-height};
+    margin-right: 0.5rem;
+    border-radius: 2px;
+    border: none;
+    background: transparent;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+
+    img {
+      height: 100%;
+      width: 100%;
+      border-radius: 2px;
+    }
+
+    span {
+      color: var(--inputPlaceholderColor);
+    }
+  }
+
+  .video-abuse-video-text {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    font-size: 90%;
+    color: var(--mainForegroundColor);
+    line-height: 1rem;
+
+    div .glyphicon {
+      font-size: 80%;
+      color: gray;
+      margin-left: 0.1rem;
+    }
+
+    div + div {
+      font-size: 80%;
+    }
+  }
+}

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.scss
@@ -1,14 +1,6 @@
 @import 'mixins';
 @import 'miniature';
 
-.caption {
-  justify-content: flex-end;
-
-  input {
-    @include peertube-input-text(250px);
-  }
-}
-
 .video-details-date-updated {
   font-size: 90%;
   margin-top: .1rem;

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
@@ -217,6 +217,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit, AfterV
   }
 
   setTableFilter (filter: string) {
+    // FIXME: cannot use ViewChild, so create a component for the filter input
     const filterInput = document.getElementById('table-filter') as HTMLInputElement
     if (filterInput) filterInput.value = filter
   }

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
@@ -29,8 +29,6 @@ export class VideoAbuseListComponent extends RestTable implements OnInit, AfterV
 
   videoAbuses: (VideoAbuse & { moderationCommentHtml?: string, reasonHtml?: string })[] = []
   totalRecords = 0
-  rowsPerPageOptions = [ 20, 50, 100 ]
-  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: 1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 
@@ -199,7 +197,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit, AfterV
   }
 
   ngAfterViewInit () {
-    this.setTableFilter(this.search)
+    if (this.search) this.setTableFilter(this.search)
   }
 
   getIdentifier () {

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
@@ -223,7 +223,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit {
   }
 
   getVideoEmbed (videoAbuse: VideoAbuse) {
-    const absoluteAPIUrl = 'http://localhost:9000' || getAbsoluteAPIUrl() // TODO
+    const absoluteAPIUrl = getAbsoluteAPIUrl()
     const embedUrl = buildVideoLink({
       baseUrl: absoluteAPIUrl + '/videos/embed/' + videoAbuse.video.uuid,
       warningTitle: false
@@ -262,7 +262,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit {
   protected loadData () {
     return this.videoAbuseService.getVideoAbuses({
       pagination: this.pagination,
-      sort: this.sort,
+      sort: this.sort,
       search: this.search
     }).subscribe(
         async resultList => {

--- a/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
+++ b/client/src/app/+admin/moderation/video-abuse-list/video-abuse-list.component.ts
@@ -46,7 +46,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit {
     private i18n: I18n,
     private markdownRenderer: MarkdownService,
     private sanitizer: DomSanitizer,
-    private route: ActivatedRoute,
+    private route: ActivatedRoute
   ) {
     super()
 
@@ -223,7 +223,7 @@ export class VideoAbuseListComponent extends RestTable implements OnInit {
   }
 
   getVideoEmbed (videoAbuse: VideoAbuse) {
-    const absoluteAPIUrl = 'http://localhost:9000' || getAbsoluteAPIUrl()
+    const absoluteAPIUrl = 'http://localhost:9000' || getAbsoluteAPIUrl() // TODO
     const embedUrl = buildVideoLink({
       baseUrl: absoluteAPIUrl + '/videos/embed/' + videoAbuse.video.uuid,
       warningTitle: false

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
@@ -30,9 +30,16 @@
         </a>
       </td>
 
-      <td>{{ booleanToText(videoBlacklist.video.nsfw) }}</td>
-      <td>{{ booleanToText(videoBlacklist.unfederated) }}</td>
-      <td>{{ videoBlacklist.createdAt }}</td>
+      <ng-container *ngIf="videoBlacklist.reason">
+        <td class="c-hand" [pRowToggler]="videoBlacklist">{{ booleanToText(videoBlacklist.video.nsfw) }}</td>
+        <td class="c-hand" [pRowToggler]="videoBlacklist">{{ booleanToText(videoBlacklist.unfederated) }}</td>
+        <td class="c-hand" [pRowToggler]="videoBlacklist">{{ videoBlacklist.createdAt }}</td>
+      </ng-container>
+      <ng-container *ngIf="!videoBlacklist.reason">
+        <td>{{ booleanToText(videoBlacklist.video.nsfw) }}</td>
+        <td>{{ booleanToText(videoBlacklist.unfederated) }}</td>
+        <td>{{ videoBlacklist.createdAt }}</td>
+      </ng-container>
 
       <td class="action-cell">
         <my-action-dropdown i18n-label  placement="bottom-right" label="Actions" [actions]="videoBlacklistActions" [entry]="videoBlacklist"></my-action-dropdown>

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
@@ -1,5 +1,5 @@
 <p-table
-  [value]="blacklist" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
+  [value]="blacklist" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} blacklisted videos"

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
@@ -82,5 +82,16 @@
       </td>
     </tr>
   </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="6">
+        <div class="empty-table-message">
+          <ng-container *ngIf="search" i18n>No blacklisted video found matching current filters.</ng-container>
+          <ng-container *ngIf="!search" i18n>No blacklisted video found.</ng-container>
+        </div>
+      </td>
+    </tr>
+  </ng-template>
 </p-table>
 

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
@@ -10,7 +10,7 @@
       <th i18n pSortableColumn="name">Video <p-sortIcon field="name"></p-sortIcon></th>
       <th style="width: 120px;" i18n>Sensitive</th>
       <th style="width: 120px;" i18n>Unfederated</th>
-      <th style="width: 200px;" i18n pSortableColumn="createdAt">Date <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 190px;" i18n pSortableColumn="createdAt">Date <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th style="width: 120px;"></th>
     </tr>
   </ng-template>

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
@@ -1,9 +1,20 @@
 <p-table
-  [value]="blacklist" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="blacklist" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate
   currentPageReportTemplate="Showing {{'{first}'}} to {{'{last}'}} of {{'{totalRecords}'}} blacklisted videos"
 >
+  <ng-template pTemplate="caption">
+    <div class="caption">
+      <div class="ml-auto">
+        <input
+          type="text" name="table-filter" id="table-filter" i18n-placeholder placeholder="Filter..."
+          (keyup)="onSearch($event)"
+        >
+      </div>
+    </div>
+  </ng-template>
+
   <ng-template pTemplate="header">
     <tr>
       <th style="width: 40px"></th>
@@ -33,7 +44,7 @@
             <div class="video-table-video-text">
               <div>
                 {{ videoBlacklist.video.name }}
-                <span class="glyphicon glyphicon-new-window"></span>
+                <span i18n-title title="Video was blacklisted" class="glyphicon glyphicon-ban-circle"></span>
               </div>
               <div class="text-muted">by {{ videoBlacklist.video.channel?.displayName }} on {{ videoBlacklist.video.channel?.host }} </div>
             </div>
@@ -53,7 +64,10 @@
       </ng-container>
 
       <td class="action-cell">
-        <my-action-dropdown i18n-label  placement="bottom-right" label="Actions" [actions]="videoBlacklistActions" [entry]="videoBlacklist"></my-action-dropdown>
+        <my-action-dropdown
+          [ngClass]="{ 'show': expanded }" placement="bottom-right" container="body"
+          i18n-label label="Actions" [actions]="videoBlacklistActions" [entry]="videoBlacklist"
+        ></my-action-dropdown>
       </td>
     </tr>
   </ng-template>
@@ -61,8 +75,10 @@
   <ng-template pTemplate="rowexpansion" let-videoBlacklist>
     <tr>
       <td class="expand-cell" colspan="6">
-        <span class="col-2 moderation-expanded-label" i18n>Blacklist reason:</span>
-        <span class="col-9 moderation-expanded-text" [innerHTML]="videoBlacklist.reasonHtml"></span>
+        <div class="d-flex moderation-expanded">
+          <span class="col-2 moderation-expanded-label" i18n>Blacklist reason:</span>
+          <span class="col-9 moderation-expanded-text" [innerHTML]="videoBlacklist.reasonHtml"></span>
+        </div>
       </td>
     </tr>
   </ng-template>

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.html
@@ -8,7 +8,7 @@
     <tr>
       <th style="width: 40px"></th>
       <th i18n pSortableColumn="name">Video <p-sortIcon field="name"></p-sortIcon></th>
-      <th style="width: 120px;" i18n>Sensitive</th>
+      <th style="width: 100px;" i18n>Sensitive</th>
       <th style="width: 120px;" i18n>Unfederated</th>
       <th style="width: 190px;" i18n pSortableColumn="createdAt">Date <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th style="width: 120px;"></th>
@@ -25,8 +25,19 @@
       </td>
 
       <td>
-        <a [href]="getVideoUrl(videoBlacklist)" i18n-title title="Go to the video" target="_blank" rel="noopener noreferrer">
-          {{ videoBlacklist.video.name }}
+        <a [href]="getVideoUrl(videoBlacklist)" class="video-table-video-link" i18n-title title="Open video in a new tab" target="_blank" rel="noopener noreferrer">
+          <div class="video-table-video">
+            <div class="video-table-video-image">
+              <img [src]="videoBlacklist.video.thumbnailPath">
+            </div>
+            <div class="video-table-video-text">
+              <div>
+                {{ videoBlacklist.video.name }}
+                <span class="glyphicon glyphicon-new-window"></span>
+              </div>
+              <div class="text-muted">by {{ videoBlacklist.video.channel?.displayName }} on {{ videoBlacklist.video.channel?.host }} </div>
+            </div>
+          </div>
         </a>
       </td>
 

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.ts
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.ts
@@ -17,7 +17,8 @@ import { MarkdownService } from '@app/shared/renderer'
 export class VideoBlacklistListComponent extends RestTable implements OnInit {
   blacklist: (VideoBlacklist & { reasonHtml?: string })[] = []
   totalRecords = 0
-  rowsPerPage = 10
+  rowsPerPageOptions = [ 20, 50, 100 ]
+  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
   listBlacklistTypeFilter: VideoBlacklistType = undefined
@@ -38,7 +39,7 @@ export class VideoBlacklistListComponent extends RestTable implements OnInit {
   ngOnInit () {
     this.serverService.getConfig()
         .subscribe(config => {
-          // don't filter if auto-blacklist not enabled as this will be the only list
+          // don't filter if auto-blacklist is not enabled as this will be the only list
           if (config.autoBlacklist.videos.ofUsers.enabled) {
             this.listBlacklistTypeFilter = VideoBlacklistType.MANUAL
           }
@@ -91,7 +92,12 @@ export class VideoBlacklistListComponent extends RestTable implements OnInit {
   }
 
   protected loadData () {
-    this.videoBlacklistService.listBlacklist(this.pagination, this.sort, this.listBlacklistTypeFilter)
+    this.videoBlacklistService.listBlacklist({
+      pagination: this.pagination,
+      sort: this.sort,
+      search: this.search,
+      type: this.listBlacklistTypeFilter
+    })
       .subscribe(
         async resultList => {
           this.totalRecords = resultList.total

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.ts
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.ts
@@ -17,8 +17,6 @@ import { MarkdownService } from '@app/shared/renderer'
 export class VideoBlacklistListComponent extends RestTable implements OnInit {
   blacklist: (VideoBlacklist & { reasonHtml?: string })[] = []
   totalRecords = 0
-  rowsPerPageOptions = [ 20, 50, 100 ]
-  rowsPerPage = this.rowsPerPageOptions[0]
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
   listBlacklistTypeFilter: VideoBlacklistType = undefined

--- a/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.ts
+++ b/client/src/app/+admin/moderation/video-blacklist-list/video-blacklist-list.component.ts
@@ -38,7 +38,7 @@ export class VideoBlacklistListComponent extends RestTable implements OnInit {
   ngOnInit () {
     this.serverService.getConfig()
         .subscribe(config => {
-          // don't filter if auto-blacklist not enabled as this will be only list
+          // don't filter if auto-blacklist not enabled as this will be the only list
           if (config.autoBlacklist.videos.ofUsers.enabled) {
             this.listBlacklistTypeFilter = VideoBlacklistType.MANUAL
           }

--- a/client/src/app/+admin/plugins/plugin-list-installed/plugin-list-installed.component.ts
+++ b/client/src/app/+admin/plugins/plugin-list-installed/plugin-list-installed.component.ts
@@ -89,10 +89,10 @@ export class PluginListInstalledComponent implements OnInit {
 
   getNoResultMessage () {
     if (this.pluginType === PluginType.PLUGIN) {
-      return this.i18n('You don\'t have plugins installed yet.')
+      return this.i18n("You don't have plugins installed yet.")
     }
 
-    return this.i18n('You don\'t have themes installed yet.')
+    return this.i18n("You don't have themes installed yet.")
   }
 
   isUpdateAvailable (plugin: PeerTubePlugin) {

--- a/client/src/app/+admin/system/jobs/jobs.component.html
+++ b/client/src/app/+admin/system/jobs/jobs.component.html
@@ -19,7 +19,7 @@
 </div>
 
 <p-table
-  [value]="jobs" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage" dataKey="uniqId"
+  [value]="jobs" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" dataKey="uniqId"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" [first]="pagination.start"
   [tableStyle]="{'table-layout':'auto'}"
 >

--- a/client/src/app/+admin/system/jobs/jobs.component.ts
+++ b/client/src/app/+admin/system/jobs/jobs.component.ts
@@ -40,7 +40,6 @@ export class JobsComponent extends RestTable implements OnInit {
 
   jobs: Job[] = []
   totalRecords: number
-  rowsPerPage = 10
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+admin/users/user-edit/user-edit.component.html
+++ b/client/src/app/+admin/users/user-edit/user-edit.component.html
@@ -37,13 +37,13 @@
       </a>
     </div>
     <div>
-      <a>
+      <a [routerLink]="[ '/admin/moderation/video-abuses/list' ]" [queryParams]="{ 'search': user?.account.displayName }">
         <div class="dashboard-num">{{ user.videoAbusesCount }}</div>
         <div class="dashboard-label" i18n>Incriminated in reports</div>
       </a>
     </div>
     <div>
-      <a>
+      <a [routerLink]="[ '/admin/moderation/video-abuses/list' ]" [queryParams]="{ 'search': user?.account.displayName }">
         <div class="dashboard-num">{{ user.videoAbusesAcceptedCount }} / {{ user.videoAbusesCreatedCount }}</div>
         <div class="dashboard-label" i18n>Authored reports accepted</div>
       </a>

--- a/client/src/app/+admin/users/user-edit/user-update.component.ts
+++ b/client/src/app/+admin/users/user-edit/user-update.component.ts
@@ -85,7 +85,7 @@ export class UserUpdateComponent extends UserEdit implements OnInit, OnDestroy {
 
     this.userService.updateUser(this.user.id, userUpdate).subscribe(
       () => {
-        this.notifier.success(this.i18n('User {{user.username}} updated.', { username: this.user.username }))
+        this.notifier.success(this.i18n('User {{username}} updated.', { username: this.user.username }))
         this.router.navigate([ '/admin/users/list' ])
       },
 

--- a/client/src/app/+admin/users/user-list/user-list.component.html
+++ b/client/src/app/+admin/users/user-list/user-list.component.html
@@ -8,7 +8,7 @@
 </div>
 
 <p-table
-  [value]="users" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="users" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"
   [(selection)]="selectedUsers"
   [showCurrentPageReport]="true" i18n-currentPageReportTemplate

--- a/client/src/app/+admin/users/user-list/user-list.component.ts
+++ b/client/src/app/+admin/users/user-list/user-list.component.ts
@@ -19,7 +19,6 @@ export class UserListComponent extends RestTable implements OnInit {
 
   users: User[] = []
   totalRecords = 0
-  rowsPerPage = 10
   sort: SortMeta = { field: 'createdAt', order: 1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+my-account/my-account-blocklist/my-account-blocklist.component.html
+++ b/client/src/app/+my-account/my-account-blocklist/my-account-blocklist.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <p-table
-  [value]="blockedAccounts" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="blockedAccounts" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
 >
 

--- a/client/src/app/+my-account/my-account-blocklist/my-account-blocklist.component.ts
+++ b/client/src/app/+my-account/my-account-blocklist/my-account-blocklist.component.ts
@@ -13,7 +13,6 @@ import { AccountBlock, BlocklistService } from '@app/shared/blocklist'
 export class MyAccountBlocklistComponent extends RestTable implements OnInit {
   blockedAccounts: AccountBlock[] = []
   totalRecords = 0
-  rowsPerPage = 10
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+my-account/my-account-blocklist/my-account-server-blocklist.component.html
+++ b/client/src/app/+my-account/my-account-blocklist/my-account-server-blocklist.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <p-table
-  [value]="blockedServers" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="blockedServers" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)"
 >
 

--- a/client/src/app/+my-account/my-account-blocklist/my-account-server-blocklist.component.ts
+++ b/client/src/app/+my-account/my-account-blocklist/my-account-server-blocklist.component.ts
@@ -14,7 +14,6 @@ import { BlocklistService } from '@app/shared/blocklist'
 export class MyAccountServerBlocklistComponent extends RestTable implements OnInit {
   blockedServers: ServerBlock[] = []
   totalRecords = 0
-  rowsPerPage = 10
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
@@ -1,7 +1,7 @@
 <p-table
     [value]="videoChangeOwnerships"
     [lazy]="true"
-    [paginator]="true"
+    [paginator]="totalRecords > 0"
     [totalRecords]="totalRecords"
     [rows]="rowsPerPage"
     [sortField]="sort.field"

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.ts
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.ts
@@ -14,7 +14,6 @@ import { MyAccountAcceptOwnershipComponent } from './my-account-accept-ownership
 export class MyAccountOwnershipComponent extends RestTable implements OnInit {
   videoChangeOwnerships: VideoChangeOwnership[] = []
   totalRecords = 0
-  rowsPerPage = 10
   sort: SortMeta = { field: 'createdAt', order: -1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
+++ b/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
@@ -1,5 +1,5 @@
 <p-table
-  [value]="videoImports" [lazy]="true" [paginator]="true" [totalRecords]="totalRecords" [rows]="rowsPerPage"
+  [value]="videoImports" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"
 >
   <ng-template pTemplate="header">

--- a/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.ts
+++ b/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core'
 import { RestPagination, RestTable } from '@app/shared'
 import { SortMeta } from 'primeng/api'
 import { Notifier } from '@app/core'
-import { I18n } from '@ngx-translate/i18n-polyfill'
 import { VideoImport, VideoImportState } from '../../../../../shared/models/videos'
 import { VideoImportService } from '@app/shared/video-import'
 
@@ -14,7 +13,6 @@ import { VideoImportService } from '@app/shared/video-import'
 export class MyAccountVideoImportsComponent extends RestTable implements OnInit {
   videoImports: VideoImport[] = []
   totalRecords = 0
-  rowsPerPage = 10
   sort: SortMeta = { field: 'createdAt', order: 1 }
   pagination: RestPagination = { count: this.rowsPerPage, start: 0 }
 

--- a/client/src/app/header/search-typeahead.component.ts
+++ b/client/src/app/header/search-typeahead.component.ts
@@ -36,7 +36,7 @@ export class SearchTypeaheadComponent implements OnInit, OnDestroy {
 
   ngOnInit () {
     this.route.queryParams
-      .pipe(first(params => params.search !== undefined && params.search !== null))
+      .pipe(first(params => this.isOnSearch() && params.search !== undefined && params.search !== null))
       .subscribe(params => this.search = params.search)
     this.serverService.getConfig()
       .subscribe(config => this.serverConfig = config)
@@ -146,11 +146,15 @@ export class SearchTypeaheadComponent implements OnInit, OnDestroy {
     }
   }
 
+  isOnSearch () {
+    return window.location.pathname === '/search'
+  }
+
   doSearch () {
     this.newSearch = false
     const queryParams: Params = {}
 
-    if (window.location.pathname === '/search' && this.route.snapshot.queryParams) {
+    if (this.isOnSearch() && this.route.snapshot.queryParams) {
       Object.assign(queryParams, this.route.snapshot.queryParams)
     }
 

--- a/client/src/app/shared/blocklist/blocklist.service.ts
+++ b/client/src/app/shared/blocklist/blocklist.service.ts
@@ -76,9 +76,13 @@ export class BlocklistService {
 
   /*********************** Instance -> Account blocklist ***********************/
 
-  getInstanceAccountBlocklist (pagination: RestPagination, sort: SortMeta) {
+  getInstanceAccountBlocklist (options: { pagination: RestPagination, sort: SortMeta, search: string }) {
+    const { pagination, sort, search } = options
+
     let params = new HttpParams()
     params = this.restService.addRestGetParams(params, pagination, sort)
+
+    if (search) params = params.append('search', search)
 
     return this.authHttp.get<ResultList<AccountBlock>>(BlocklistService.BASE_SERVER_BLOCKLIST_URL + '/accounts', { params })
                .pipe(
@@ -104,9 +108,13 @@ export class BlocklistService {
 
   /*********************** Instance -> Server blocklist ***********************/
 
-  getInstanceServerBlocklist (pagination: RestPagination, sort: SortMeta) {
+  getInstanceServerBlocklist (options: { pagination: RestPagination, sort: SortMeta, search: string }) {
+    const { pagination, sort, search } = options
+
     let params = new HttpParams()
     params = this.restService.addRestGetParams(params, pagination, sort)
+
+    if (search) params = params.append('search', search)
 
     return this.authHttp.get<ResultList<ServerBlock>>(BlocklistService.BASE_SERVER_BLOCKLIST_URL + '/servers', { params })
                .pipe(

--- a/client/src/app/shared/buttons/action-dropdown.component.html
+++ b/client/src/app/shared/buttons/action-dropdown.component.html
@@ -1,4 +1,4 @@
-<div class="dropdown-root" ngbDropdown [placement]="placement" container="body" *ngIf="areActionsDisplayed(actions, entry)">
+<div class="dropdown-root" ngbDropdown [placement]="placement" [container]="container" *ngIf="areActionsDisplayed(actions, entry)">
   <div
     class="action-button" [ngClass]="{ small: buttonSize === 'small', grey: theme === 'grey', orange: theme === 'orange', 'button-styled': buttonStyled }"
     ngbDropdownToggle role="button"

--- a/client/src/app/shared/buttons/action-dropdown.component.ts
+++ b/client/src/app/shared/buttons/action-dropdown.component.ts
@@ -27,6 +27,7 @@ export class ActionDropdownComponent<T> {
   @Input() entry: T
 
   @Input() placement = 'bottom-left auto'
+  @Input() container: null | 'body'
 
   @Input() buttonSize: DropdownButtonSize = 'normal'
   @Input() buttonDirection: DropdownDirection = 'horizontal'

--- a/client/src/app/shared/rest/rest-table.ts
+++ b/client/src/app/shared/rest/rest-table.ts
@@ -7,11 +7,13 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
 export abstract class RestTable {
 
   abstract totalRecords: number
-  abstract rowsPerPage: number
   abstract sort: SortMeta
   abstract pagination: RestPagination
 
   search: string
+  rowsPerPageOptions = [ 10, 20, 50, 100 ]
+  rowsPerPage = this.rowsPerPageOptions[0]
+
   private searchStream: Subject<string>
 
   abstract getIdentifier (): string

--- a/client/src/app/shared/rest/rest-table.ts
+++ b/client/src/app/shared/rest/rest-table.ts
@@ -11,7 +11,7 @@ export abstract class RestTable {
   abstract sort: SortMeta
   abstract pagination: RestPagination
 
-  protected search: string
+  search: string
   private searchStream: Subject<string>
 
   abstract getIdentifier (): string

--- a/client/src/app/shared/video-abuse/video-abuse.service.ts
+++ b/client/src/app/shared/video-abuse/video-abuse.service.ts
@@ -17,11 +17,18 @@ export class VideoAbuseService {
     private restExtractor: RestExtractor
   ) {}
 
-  getVideoAbuses (pagination: RestPagination, sort: SortMeta): Observable<ResultList<VideoAbuse>> {
+  getVideoAbuses (options: {
+    pagination: RestPagination,
+    sort: SortMeta,
+    search?: string
+  }): Observable<ResultList<VideoAbuse>> {
+    const { pagination, sort, search } = options
     const url = VideoAbuseService.BASE_VIDEO_ABUSE_URL + 'abuse'
 
     let params = new HttpParams()
     params = this.restService.addRestGetParams(params, pagination, sort)
+
+    if (search) params = params.append('search', search)
 
     return this.authHttp.get<ResultList<VideoAbuse>>(url, { params })
                .pipe(

--- a/client/src/app/shared/video-blacklist/video-blacklist.service.ts
+++ b/client/src/app/shared/video-blacklist/video-blacklist.service.ts
@@ -19,13 +19,19 @@ export class VideoBlacklistService {
     private restExtractor: RestExtractor
   ) {}
 
-  listBlacklist (pagination: RestPagination, sort: SortMeta, type?: VideoBlacklistType): Observable<ResultList<VideoBlacklist>> {
+  listBlacklist (options: {
+    pagination: RestPagination,
+    sort: SortMeta,
+    search?: string
+    type?: VideoBlacklistType
+  }): Observable<ResultList<VideoBlacklist>> {
+    const { pagination, sort, search, type } = options
+
     let params = new HttpParams()
     params = this.restService.addRestGetParams(params, pagination, sort)
 
-    if (type) {
-      params = params.set('type', type.toString())
-    }
+    if (search) params = params.append('search', search)
+    if (type) params = params.append('type', type.toString())
 
     return this.authHttp.get<ResultList<VideoBlacklist>>(VideoBlacklistService.BASE_VIDEOS_URL + 'blacklist', { params })
                .pipe(

--- a/client/src/app/shared/video/video-actions-dropdown.component.ts
+++ b/client/src/app/shared/video/video-actions-dropdown.component.ts
@@ -251,7 +251,7 @@ export class VideoActionsDropdownComponent implements OnChanges {
           isDisplayed: () => this.authService.isLoggedIn() && this.displayOptions.blacklist && this.isVideoUnblacklistable()
         },
         {
-          label: this.i18n('Duplicate (redundancy)'),
+          label: this.i18n('Mirror'),
           handler: () => this.duplicateVideo(),
           isDisplayed: () => this.authService.isLoggedIn() && this.displayOptions.duplicate && this.canVideoBeDuplicated(),
           iconName: 'cloud-download'

--- a/client/src/app/shared/video/video-miniature.component.ts
+++ b/client/src/app/shared/video/video-miniature.component.ts
@@ -65,7 +65,7 @@ export class VideoMiniatureComponent implements OnInit {
     blacklist: true,
     delete: true,
     report: true,
-    duplicate: false
+    duplicate: true
   }
   showActions = false
   serverConfig: ServerConfig

--- a/client/src/app/videos/+video-edit/shared/video-caption-add-modal.component.html
+++ b/client/src/app/videos/+video-edit/shared/video-caption-add-modal.component.html
@@ -23,6 +23,7 @@
         <my-reactive-file
           formControlName="captionfile" inputName="captionfile" i18n-inputLabel inputLabel="Select the caption file"
           [extensions]="videoCaptionExtensions" [maxFileSize]="videoCaptionMaxSize" [displayFilename]="true"
+          i18n-ngbTooltip [ngbTooltip]="'(extensions: ' + videoCaptionExtensions.join(', ') + ')'"
         ></my-reactive-file>
       </div>
 

--- a/client/src/app/videos/+video-edit/shared/video-caption-add-modal.component.scss
+++ b/client/src/app/videos/+video-edit/shared/video-caption-add-modal.component.scss
@@ -7,6 +7,11 @@
 
 .caption-file {
   margin-top: 20px;
+  width: max-content;
+
+  ::ng-deep .root {
+    width: max-content;
+  }
 }
 
 .warning-replace-caption {

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -692,6 +692,8 @@
     margin-bottom: 10px;
 
     & > a {
+      @include disable-default-a-behaviour;
+
       text-decoration: none;
       color: inherit;
       display: block;

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -876,6 +876,15 @@
   }
 }
 
+@mixin empty-state {
+  min-height: 40vh;
+  max-height: 500px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 @mixin admin-sub-header-responsive ($horizontal-margins) {
   flex-direction: column;
 

--- a/client/src/sass/primeng-custom.scss
+++ b/client/src/sass/primeng-custom.scss
@@ -191,12 +191,22 @@ p-table {
 
       .ui-dropdown {
         position: absolute;
+        top: 3px;
         left: 0;
+
+        &.ui-state-focus {
+          box-shadow: #{$focus-box-shadow-form} var(--mainColorLightest);
+        }
+
+        .ui-dropdown-label {
+          color: var(--inputPlaceholderColor);
+        }
       }
 
       .ui-paginator-current {
         position: absolute;
         right: 0;
+        color: var(--inputPlaceholderColor);
       }
 
       .ui-paginator-first,

--- a/server/controllers/api/server/server-blocklist.ts
+++ b/server/controllers/api/server/server-blocklist.ts
@@ -82,7 +82,13 @@ export {
 async function listBlockedAccounts (req: express.Request, res: express.Response) {
   const serverActor = await getServerActor()
 
-  const resultList = await AccountBlocklistModel.listForApi(serverActor.Account.id, req.query.start, req.query.count, req.query.sort)
+  const resultList = await AccountBlocklistModel.listForApi({
+    start: req.query.start,
+    count: req.query.count,
+    sort: req.query.sort,
+    search: req.query.search,
+    accountId: serverActor.Account.id
+  })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }
@@ -107,7 +113,13 @@ async function unblockAccount (req: express.Request, res: express.Response) {
 async function listBlockedServers (req: express.Request, res: express.Response) {
   const serverActor = await getServerActor()
 
-  const resultList = await ServerBlocklistModel.listForApi(serverActor.Account.id, req.query.start, req.query.count, req.query.sort)
+  const resultList = await ServerBlocklistModel.listForApi({
+    start: req.query.start,
+    count: req.query.count,
+    sort: req.query.sort,
+    search: req.query.search,
+    accountId: serverActor.Account.id
+  })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }

--- a/server/controllers/api/users/my-blocklist.ts
+++ b/server/controllers/api/users/my-blocklist.ts
@@ -74,7 +74,13 @@ export {
 async function listBlockedAccounts (req: express.Request, res: express.Response) {
   const user = res.locals.oauth.token.User
 
-  const resultList = await AccountBlocklistModel.listForApi(user.Account.id, req.query.start, req.query.count, req.query.sort)
+  const resultList = await AccountBlocklistModel.listForApi({
+    start: req.query.start,
+    count: req.query.count,
+    sort: req.query.sort,
+    search: req.query.search,
+    accountId: user.Account.id
+  })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }
@@ -99,7 +105,13 @@ async function unblockAccount (req: express.Request, res: express.Response) {
 async function listBlockedServers (req: express.Request, res: express.Response) {
   const user = res.locals.oauth.token.User
 
-  const resultList = await ServerBlocklistModel.listForApi(user.Account.id, req.query.start, req.query.count, req.query.sort)
+  const resultList = await ServerBlocklistModel.listForApi({
+    start: req.query.start,
+    count: req.query.count,
+    sort: req.query.sort,
+    search: req.query.search,
+    accountId: user.Account.id
+  })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }

--- a/server/controllers/api/videos/abuse.ts
+++ b/server/controllers/api/videos/abuse.ts
@@ -69,6 +69,7 @@ async function listVideoAbuses (req: express.Request, res: express.Response) {
     start: req.query.start,
     count: req.query.count,
     sort: req.query.sort,
+    search: req.query.search,
     serverAccountId: serverActor.Account.id,
     user
   })

--- a/server/controllers/api/videos/blacklist.ts
+++ b/server/controllers/api/videos/blacklist.ts
@@ -102,7 +102,13 @@ async function updateVideoBlacklistController (req: express.Request, res: expres
 }
 
 async function listBlacklist (req: express.Request, res: express.Response) {
-  const resultList = await VideoBlacklistModel.listForApi(req.query.start, req.query.count, req.query.sort, req.query.type)
+  const resultList = await VideoBlacklistModel.listForApi({
+    start: req.query.start,
+    count: req.query.count,
+    sort: req.query.sort,
+    search: req.query.search,
+    type: req.query.type
+  })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }

--- a/server/helpers/middlewares/video-abuses.ts
+++ b/server/helpers/middlewares/video-abuses.ts
@@ -1,9 +1,17 @@
 import { Response } from 'express'
 import { VideoAbuseModel } from '../../models/video/video-abuse'
+import { fetchVideo } from '../video'
 
-async function doesVideoAbuseExist (abuseIdArg: number | string, videoId: number, res: Response) {
+async function doesVideoAbuseExist (abuseIdArg: number | string, videoUUID: string, res: Response) {
   const abuseId = parseInt(abuseIdArg + '', 10)
-  const videoAbuse = await VideoAbuseModel.loadByIdAndVideoId(abuseId, videoId)
+  let videoAbuse = await VideoAbuseModel.loadByIdAndVideoId(abuseId, null, videoUUID)
+
+  if (!videoAbuse) {
+    const userId = res.locals.oauth ? res.locals.oauth.token.User.id : undefined
+    const video = await fetchVideo(videoUUID, 'all', userId)
+
+    if (video) videoAbuse = await VideoAbuseModel.loadByIdAndVideoId(abuseId, video.id)
+  }
 
   if (videoAbuse === null) {
     res.status(404)

--- a/server/helpers/middlewares/video-abuses.ts
+++ b/server/helpers/middlewares/video-abuses.ts
@@ -7,7 +7,7 @@ async function doesVideoAbuseExist (abuseIdArg: number | string, videoUUID: stri
   let videoAbuse = await VideoAbuseModel.loadByIdAndVideoId(abuseId, null, videoUUID)
 
   if (!videoAbuse) {
-    const userId = res.locals.oauth ? res.locals.oauth.token.User.id : undefined
+    const userId = res.locals.oauth?.token.User.id
     const video = await fetchVideo(videoUUID, 'all', userId)
 
     if (video) videoAbuse = await VideoAbuseModel.loadByIdAndVideoId(abuseId, video.id)

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -14,7 +14,7 @@ import { CONFIG, registerConfigChangedHandler } from './config'
 
 // ---------------------------------------------------------------------------
 
-const LAST_MIGRATION_VERSION = 485
+const LAST_MIGRATION_VERSION = 490
 
 // ---------------------------------------------------------------------------
 

--- a/server/initializers/migrations/0490-abuse-video.ts
+++ b/server/initializers/migrations/0490-abuse-video.ts
@@ -11,10 +11,8 @@ async function up (utils: {
     allowNull: true
   }
   await utils.queryInterface.addColumn('videoAbuse', 'deletedVideo', deletedVideo)
-  await utils.sequelize.query(`ALTER TABLE "videoAbsue" ALTER COLUMN "videoId" DROP NOT NULL;`)
+  await utils.sequelize.query(`ALTER TABLE "videoAbuse" ALTER COLUMN "videoId" DROP NOT NULL;`)
   await utils.sequelize.query(`ALTER TABLE "videoAbuse" DROP CONSTRAINT IF EXISTS "videoAbuse_videoId_fkey";`)
-  await utils.sequelize.query(`ALTER TABLE "videoAbuse" ADD CONSTRAINT "videoAbuse_videoId_fkey" 
-  FOREIGN KEY ("videoId") REFERENCES video(id) ON UPDATE CASCADE ON DELETE SET NULL;`)
 
 }
 

--- a/server/initializers/migrations/0490-abuse-video.ts
+++ b/server/initializers/migrations/0490-abuse-video.ts
@@ -1,0 +1,28 @@
+import * as Sequelize from 'sequelize'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction
+  queryInterface: Sequelize.QueryInterface
+  sequelize: Sequelize.Sequelize
+}): Promise<void> {
+
+  const deletedVideo = {
+    type: Sequelize.JSONB,
+    allowNull: true
+  }
+  await utils.queryInterface.addColumn('videoAbuse', 'deletedVideo', deletedVideo)
+  await utils.sequelize.query(`ALTER TABLE "videoAbsue" ALTER COLUMN "videoId" DROP NOT NULL;`)
+  await utils.sequelize.query(`ALTER TABLE "videoAbuse" DROP CONSTRAINT IF EXISTS "videoAbuse_videoId_fkey";`)
+  await utils.sequelize.query(`ALTER TABLE "videoAbuse" ADD CONSTRAINT "videoAbuse_videoId_fkey" 
+  FOREIGN KEY ("videoId") REFERENCES video(id) ON UPDATE CASCADE ON DELETE SET NULL;`)
+
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export {
+  up,
+  down
+}

--- a/server/lib/emailer.ts
+++ b/server/lib/emailer.ts
@@ -292,7 +292,7 @@ class Emailer {
     const videoUrl = WEBSERVER.URL + videoAbuse.Video.getWatchStaticPath()
 
     const text = 'Hi,\n\n' +
-      `${WEBSERVER.HOST} received an abuse for the following video ${videoUrl}\n\n` +
+      `${WEBSERVER.HOST} received an abuse for the following video: ${videoUrl}\n\n` +
       'Cheers,\n' +
       `${CONFIG.EMAIL.BODY.SIGNATURE}`
 

--- a/server/middlewares/validators/videos/video-abuses.ts
+++ b/server/middlewares/validators/videos/video-abuses.ts
@@ -32,8 +32,7 @@ const videoAbuseGetValidator = [
     logger.debug('Checking videoAbuseGetValidator parameters', { parameters: req.body })
 
     if (areValidationErrors(req, res)) return
-    if (!await doesVideoExist(req.params.videoId, res)) return
-    if (!await doesVideoAbuseExist(req.params.id, res.locals.videoAll.id, res)) return
+    if (!await doesVideoAbuseExist(req.params.id, req.params.videoId, res)) return
 
     return next()
   }
@@ -53,8 +52,7 @@ const videoAbuseUpdateValidator = [
     logger.debug('Checking videoAbuseUpdateValidator parameters', { parameters: req.body })
 
     if (areValidationErrors(req, res)) return
-    if (!await doesVideoExist(req.params.videoId, res)) return
-    if (!await doesVideoAbuseExist(req.params.id, res.locals.videoAll.id, res)) return
+    if (!await doesVideoAbuseExist(req.params.id, req.params.videoId, res)) return
 
     return next()
   }

--- a/server/middlewares/validators/videos/video-blacklist.ts
+++ b/server/middlewares/validators/videos/video-blacklist.ts
@@ -69,6 +69,10 @@ const videosBlacklistFiltersValidator = [
   query('type')
     .optional()
     .custom(isVideoBlacklistTypeValid).withMessage('Should have a valid video blacklist type attribute'),
+  query('search')
+    .optional()
+    .not()
+    .isEmpty().withMessage('Should have a valid search'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videos blacklist filters query', { parameters: req.query })

--- a/server/models/account/account-blocklist.ts
+++ b/server/models/account/account-blocklist.ts
@@ -133,8 +133,8 @@ export class AccountBlocklistModel extends Model<AccountBlocklistModel> {
     if (search) {
       Object.assign(where, {
         [Op.or]: [
-          { ...searchAttribute(search, '$BlockedAccount.name$') },
-          { ...searchAttribute(search, '$BlockedAccount.Actor.url$') }
+          searchAttribute(search, '$BlockedAccount.name$'),
+          searchAttribute(search, '$BlockedAccount.Actor.url$')
         ]
       })
     }

--- a/server/models/server/server-blocklist.ts
+++ b/server/models/server/server-blocklist.ts
@@ -2,7 +2,7 @@ import { BelongsTo, Column, CreatedAt, ForeignKey, Model, Scopes, Table, Updated
 import { AccountModel } from '../account/account'
 import { ServerModel } from './server'
 import { ServerBlock } from '../../../shared/models/blocklist'
-import { getSort } from '../utils'
+import { getSort, searchAttribute } from '../utils'
 import * as Bluebird from 'bluebird'
 import { MServerBlocklist, MServerBlocklistAccountServer, MServerBlocklistFormattable } from '@server/typings/models'
 import { Op } from 'sequelize'
@@ -120,15 +120,26 @@ export class ServerBlocklistModel extends Model<ServerBlocklistModel> {
     return ServerBlocklistModel.findOne(query)
   }
 
-  static listForApi (accountId: number, start: number, count: number, sort: string) {
+  static listForApi (parameters: {
+    start: number
+    count: number
+    sort: string
+    search?: string
+    accountId: number
+  }) {
+    const { start, count, sort, search, accountId } = parameters
+
     const query = {
       offset: start,
       limit: count,
       order: getSort(sort),
       where: {
-        accountId
+        accountId,
+        ...searchAttribute(search, '$BlockedServer.host$')
       }
     }
+
+    console.log(search)
 
     return ServerBlocklistModel
       .scope([ ScopeNames.WITH_ACCOUNT, ScopeNames.WITH_SERVER ])

--- a/server/models/server/server-blocklist.ts
+++ b/server/models/server/server-blocklist.ts
@@ -139,8 +139,6 @@ export class ServerBlocklistModel extends Model<ServerBlocklistModel> {
       }
     }
 
-    console.log(search)
-
     return ServerBlocklistModel
       .scope([ ScopeNames.WITH_ACCOUNT, ScopeNames.WITH_SERVER ])
       .findAndCountAll<MServerBlocklistAccountServer>(query)

--- a/server/models/utils.ts
+++ b/server/models/utils.ts
@@ -208,13 +208,15 @@ function buildDirectionAndField (value: string) {
 }
 
 function searchAttribute (sourceField, targetField) {
-  return sourceField
-    ? {
+  if (sourceField) {
+    return {
       [targetField]: {
         [Op.iLike]: `%${sourceField}%`
       }
     }
-    : {}
+  } else {
+    return {}
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/models/utils.ts
+++ b/server/models/utils.ts
@@ -1,7 +1,7 @@
 import { Model, Sequelize } from 'sequelize-typescript'
 import validator from 'validator'
 import { Col } from 'sequelize/types/lib/utils'
-import { literal, OrderItem } from 'sequelize'
+import { literal, OrderItem, Op } from 'sequelize'
 
 type Primitive = string | Function | number | boolean | Symbol | undefined | null
 type DeepOmitHelper<T, K extends keyof T> = {
@@ -207,6 +207,16 @@ function buildDirectionAndField (value: string) {
   return { direction, field }
 }
 
+function searchAttribute (sourceField, targetField) {
+  return sourceField
+    ? {
+      [targetField]: {
+        [Op.iLike]: `%${sourceField}%`
+      }
+    }
+    : {}
+}
+
 // ---------------------------------------------------------------------------
 
 export {
@@ -228,7 +238,8 @@ export {
   parseAggregateResult,
   getFollowsSort,
   buildDirectionAndField,
-  createSafeIn
+  createSafeIn,
+  searchAttribute
 }
 
 // ---------------------------------------------------------------------------

--- a/server/models/video/video-abuse.ts
+++ b/server/models/video/video-abuse.ts
@@ -143,7 +143,8 @@ export enum ScopeNames {
                 'SELECT count(DISTINCT "videoAbuse"."id") ' +
                 'FROM "videoAbuse" ' +
                 `WHERE CAST("deletedVideo"->'channel'->'ownerAccount'->>'id' AS INTEGER) = "Video->VideoChannel"."accountId" ` +
-                   `OR CAST("deletedVideo"->'channel'->'ownerAccount'->>'id' AS INTEGER) = CAST("VideoAbuseModel"."deletedVideo"->'channel'->'ownerAccount'->>'id' AS INTEGER) ` +
+                   `OR CAST("deletedVideo"->'channel'->'ownerAccount'->>'id' AS INTEGER) = ` +
+                      `CAST("VideoAbuseModel"."deletedVideo"->'channel'->'ownerAccount'->>'id' AS INTEGER) ` +
               ')'
             ),
             'countReportsForReportee__deletedVideo'

--- a/server/models/video/video-blacklist.ts
+++ b/server/models/video/video-blacklist.ts
@@ -78,7 +78,7 @@ export class VideoBlacklistModel extends Model<VideoBlacklistModel> {
       {
         model: VideoModel,
         required: true,
-        where: { ...searchAttribute(search, 'name') },
+        where: searchAttribute(search, 'name'),
         include: [
           {
             model: VideoChannelModel.scope({ method: [ VideoChannelScopeNames.SUMMARY, { withAccount: true } as SummaryOptions ] }),

--- a/server/models/video/video-blacklist.ts
+++ b/server/models/video/video-blacklist.ts
@@ -1,5 +1,5 @@
 import { AllowNull, BelongsTo, Column, CreatedAt, DataType, Default, ForeignKey, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
-import { getBlacklistSort, SortType, throwIfNotValid } from '../utils'
+import { getBlacklistSort, SortType, throwIfNotValid, searchAttribute } from '../utils'
 import { VideoModel } from './video'
 import { ScopeNames as VideoChannelScopeNames, SummaryOptions, VideoChannelModel } from './video-channel'
 import { isVideoBlacklistReasonValid, isVideoBlacklistTypeValid } from '../../helpers/custom-validators/video-blacklist'
@@ -54,7 +54,15 @@ export class VideoBlacklistModel extends Model<VideoBlacklistModel> {
   })
   Video: VideoModel
 
-  static listForApi (start: number, count: number, sort: SortType, type?: VideoBlacklistType) {
+  static listForApi (parameters: {
+    start: number
+    count: number
+    sort: SortType
+    search?: string
+    type?: VideoBlacklistType
+  }) {
+    const { start, count, sort, search, type } = parameters
+
     function buildBaseQuery (): FindOptions {
       return {
         offset: start,
@@ -70,6 +78,7 @@ export class VideoBlacklistModel extends Model<VideoBlacklistModel> {
       {
         model: VideoModel,
         required: true,
+        where: { ...searchAttribute(search, 'name') },
         include: [
           {
             model: VideoChannelModel.scope({ method: [ VideoChannelScopeNames.SUMMARY, { withAccount: true } as SummaryOptions ] }),

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -810,7 +810,7 @@ export class VideoModel extends Model<VideoModel> {
       if (instance.VideoAbuses.length === 0) return undefined
     }
 
-    const details = instance.toFormattedJSON()
+    const details = instance.toFormattedDetailsJSON()
 
     for (const abuse of instance.VideoAbuses) {
       tasks.push((_ => {

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -813,10 +813,8 @@ export class VideoModel extends Model<VideoModel> {
     const details = instance.toFormattedDetailsJSON()
 
     for (const abuse of instance.VideoAbuses) {
-      tasks.push((_ => {
-        abuse.deletedVideo = details
-        return abuse.save({ transaction: options.transaction })
-      })())
+      abuse.deletedVideo = details
+      tasks.push(abuse.save({ transaction: options.transaction }))
     }
 
     Promise.all(tasks)

--- a/server/typings/models/video/video-abuse.ts
+++ b/server/typings/models/video/video-abuse.ts
@@ -1,6 +1,6 @@
 import { VideoAbuseModel } from '../../../models/video/video-abuse'
 import { PickWith } from '../../utils'
-import { MVideoAccountLightBlacklistAllFiles } from './video'
+import { MVideoAccountLightBlacklistAllFiles, MVideo } from './video'
 import { MAccountDefault, MAccountFormattable } from '../account'
 
 type Use<K extends keyof VideoAbuseModel, M> = PickWith<VideoAbuseModel, K, M>
@@ -16,7 +16,7 @@ export type MVideoAbuseId = Pick<VideoAbuseModel, 'id'>
 export type MVideoAbuseVideo =
   MVideoAbuse &
   Pick<VideoAbuseModel, 'toActivityPubObject'> &
-  Use<'Video', MVideoAccountLightBlacklistAllFiles>
+  Use<'Video', MVideo>
 
 export type MVideoAbuseAccountVideo =
   MVideoAbuse &

--- a/server/typings/models/video/video-abuse.ts
+++ b/server/typings/models/video/video-abuse.ts
@@ -31,4 +31,4 @@ export type MVideoAbuseAccountVideo =
 export type MVideoAbuseFormattable =
   MVideoAbuse &
   Use<'Account', MAccountFormattable> &
-  Use<'Video', Pick<MVideo, 'id' | 'uuid' | 'name'>>
+  Use<'Video', Pick<MVideo, 'id' | 'uuid' | 'name' | 'nsfw'>>

--- a/server/typings/models/video/video-abuse.ts
+++ b/server/typings/models/video/video-abuse.ts
@@ -1,6 +1,6 @@
 import { VideoAbuseModel } from '../../../models/video/video-abuse'
 import { PickWith } from '../../utils'
-import { MVideo } from './video'
+import { MVideoAccountLightBlacklistAllFiles } from './video'
 import { MAccountDefault, MAccountFormattable } from '../account'
 
 type Use<K extends keyof VideoAbuseModel, M> = PickWith<VideoAbuseModel, K, M>
@@ -16,12 +16,12 @@ export type MVideoAbuseId = Pick<VideoAbuseModel, 'id'>
 export type MVideoAbuseVideo =
   MVideoAbuse &
   Pick<VideoAbuseModel, 'toActivityPubObject'> &
-  Use<'Video', MVideo>
+  Use<'Video', MVideoAccountLightBlacklistAllFiles>
 
 export type MVideoAbuseAccountVideo =
   MVideoAbuse &
   Pick<VideoAbuseModel, 'toActivityPubObject'> &
-  Use<'Video', MVideo> &
+  Use<'Video', MVideoAccountLightBlacklistAllFiles> &
   Use<'Account', MAccountDefault>
 
 // ############################################################################
@@ -31,4 +31,5 @@ export type MVideoAbuseAccountVideo =
 export type MVideoAbuseFormattable =
   MVideoAbuse &
   Use<'Account', MAccountFormattable> &
-  Use<'Video', Pick<MVideo, 'id' | 'uuid' | 'name' | 'nsfw'>>
+  Use<'Video', Pick<MVideoAccountLightBlacklistAllFiles,
+  'id' | 'uuid' | 'name' | 'nsfw' | 'getMiniatureStaticPath' | 'isBlacklisted' | 'VideoChannel'>>

--- a/shared/models/videos/abuse/video-abuse.model.ts
+++ b/shared/models/videos/abuse/video-abuse.model.ts
@@ -14,6 +14,8 @@ export interface VideoAbuse {
     id: number
     name: string
     uuid: string
+    nsfw: boolean
+    deleted: boolean
   }
 
   createdAt: Date

--- a/shared/models/videos/abuse/video-abuse.model.ts
+++ b/shared/models/videos/abuse/video-abuse.model.ts
@@ -1,6 +1,7 @@
 import { Account } from '../../actors/index'
 import { VideoConstant } from '../video-constant.model'
 import { VideoAbuseState } from './video-abuse-state.model'
+import { VideoChannelSummary } from '../channel/video-channel.model'
 
 export interface VideoAbuse {
   id: number
@@ -16,6 +17,9 @@ export interface VideoAbuse {
     uuid: string
     nsfw: boolean
     deleted: boolean
+    blacklisted: boolean
+    thumbnailPath?: string
+    channel?: VideoChannelSummary
   }
 
   createdAt: Date

--- a/shared/models/videos/abuse/video-abuse.model.ts
+++ b/shared/models/videos/abuse/video-abuse.model.ts
@@ -1,7 +1,7 @@
 import { Account } from '../../actors/index'
 import { VideoConstant } from '../video-constant.model'
 import { VideoAbuseState } from './video-abuse-state.model'
-import { VideoChannelSummary } from '../channel/video-channel.model'
+import { VideoChannel } from '../channel/video-channel.model'
 
 export interface VideoAbuse {
   id: number
@@ -19,8 +19,15 @@ export interface VideoAbuse {
     deleted: boolean
     blacklisted: boolean
     thumbnailPath?: string
-    channel?: VideoChannelSummary
+    channel?: VideoChannel
   }
 
   createdAt: Date
+  updatedAt: Date
+
+  count?: number
+  nth?: number
+
+  countReportsForReporter?: number
+  countReportsForReportee?: number
 }

--- a/shared/models/videos/blacklist/video-blacklist.model.ts
+++ b/shared/models/videos/blacklist/video-blacklist.model.ts
@@ -7,11 +7,12 @@ export enum VideoBlacklistType {
 
 export interface VideoBlacklist {
   id: number
-  createdAt: Date
-  updatedAt: Date
   unfederated: boolean
   reason?: string
   type: VideoBlacklistType
 
   video: Video
+
+  createdAt: Date
+  updatedAt: Date
 }


### PR DESCRIPTION
Also contained in this PR:
- follows/moderation table empty states
- moderation tables generic filter
- moderation comment indicator
- moderation tables column space optimizations and ordering
- specific to video-abuse-list:
  - deletion indicator
  - additional quick actions for video and reporter: mute, blacklist, delete
  - video thumbnail and channel displayed along video title
  - reports stats for reporter and reportee
  - position of report among reports for a given video

![Screenshot_2020-04-18 Video abuses list - PeerTube](https://user-images.githubusercontent.com/6329880/79671124-358b8600-81c8-11ea-85b2-3f7b276bcfa0.png)

