### PR TITLE
Add markdown support to plugins

### DIFF
--- a/client/src/app/+admin/plugins/plugin-show-installed/plugin-show-installed.component.html
+++ b/client/src/app/+admin/plugins/plugin-show-installed/plugin-show-installed.component.html
@@ -10,6 +10,18 @@
       <label *ngIf="setting.type !== 'input-checkbox'" [attr.for]="setting.name" [innerHTML]="setting.label"></label>
       <input *ngIf="setting.type === 'input'" type="text" [id]="setting.name" [formControlName]="setting.name" />
       <textarea *ngIf="setting.type === 'input-textarea'" type="text" [id]="setting.name" [formControlName]="setting.name"></textarea>
+      <my-help *ngIf="setting.type === 'markdown-text'" helpType="markdownText"></my-help>
+      <my-help *ngIf="setting.type === 'markdown-enhanced'" helpType="markdownEnhanced"></my-help>
+      <my-markdown-textarea
+        *ngIf="setting.type === 'markdown-text'"
+        markdownType="text" [id]="setting.name" [formControlName]="setting.name" textareaWidth="500px" [previewColumn]="false"
+        [classes]="{ 'input-error': formErrors['settings.name'] }"
+      ></my-markdown-textarea>
+      <my-markdown-textarea
+        *ngIf="setting.type === 'markdown-enhanced'"
+        markdownType="enhanced" [id]="setting.name" [formControlName]="setting.name" textareaWidth="500px" [previewColumn]="false"
+        [classes]="{ 'input-error': formErrors['settings.name'] }"
+      ></my-markdown-textarea>
 
       <my-peertube-checkbox
         *ngIf="setting.type === 'input-checkbox'"

--- a/client/src/app/+admin/plugins/plugin-show-installed/plugin-show-installed.component.html
+++ b/client/src/app/+admin/plugins/plugin-show-installed/plugin-show-installed.component.html
@@ -8,15 +8,21 @@
   <form *ngIf="hasRegisteredSettings()" role="form" (ngSubmit)="formValidated()" [formGroup]="form">
     <div class="form-group" *ngFor="let setting of registeredSettings">
       <label *ngIf="setting.type !== 'input-checkbox'" [attr.for]="setting.name" [innerHTML]="setting.label"></label>
+
       <input *ngIf="setting.type === 'input'" type="text" [id]="setting.name" [formControlName]="setting.name" />
+
       <textarea *ngIf="setting.type === 'input-textarea'" type="text" [id]="setting.name" [formControlName]="setting.name"></textarea>
+
       <my-help *ngIf="setting.type === 'markdown-text'" helpType="markdownText"></my-help>
+
       <my-help *ngIf="setting.type === 'markdown-enhanced'" helpType="markdownEnhanced"></my-help>
+
       <my-markdown-textarea
         *ngIf="setting.type === 'markdown-text'"
         markdownType="text" [id]="setting.name" [formControlName]="setting.name" textareaWidth="500px" [previewColumn]="false"
         [classes]="{ 'input-error': formErrors['settings.name'] }"
       ></my-markdown-textarea>
+
       <my-markdown-textarea
         *ngIf="setting.type === 'markdown-enhanced'"
         markdownType="enhanced" [id]="setting.name" [formControlName]="setting.name" textareaWidth="500px" [previewColumn]="false"

--- a/client/src/app/core/plugins/plugin.service.ts
+++ b/client/src/app/core/plugins/plugin.service.ts
@@ -15,6 +15,7 @@ import { HttpClient } from '@angular/common/http'
 import { AuthService } from '@app/core/auth'
 import { Notifier } from '@app/core/notification'
 import { RestExtractor } from '@app/shared/rest'
+import { MarkdownService } from '@app/shared/renderer'
 import { PluginType } from '@shared/models/plugins/plugin.type'
 import { PublicServerSetting } from '@shared/models/plugins/public-server.setting'
 import { getDevLocale, isOnDevLocale } from '@app/shared/i18n/i18n-utils'
@@ -65,6 +66,7 @@ export class PluginService implements ClientHook {
     private router: Router,
     private authService: AuthService,
     private notifier: Notifier,
+    private markdownRenderer: MarkdownService,
     private server: ServerService,
     private zone: NgZone,
     private authHttp: HttpClient,
@@ -295,6 +297,16 @@ export class PluginService implements ClientHook {
         confirm?: { value: string, action?: () => void }
       }) => {
         this.customModal.show(input)
+      },
+
+      markdownRenderer: {
+        textMarkdownToHTML: (textMarkdown: string) => {
+          return this.markdownRenderer.textMarkdownToHTML(textMarkdown)
+        },
+
+        enhancedMarkdownToHTML: (enhancedMarkdown: string) => {
+          return this.markdownRenderer.enhancedMarkdownToHTML(enhancedMarkdown)
+        }
       },
 
       translate: (value: string) => {

--- a/client/src/types/register-client-option.model.ts
+++ b/client/src/types/register-client-option.model.ts
@@ -28,8 +28,8 @@ export type RegisterClientHelpers = {
   }) => void
 
   markdownRenderer: {
-    textMarkdownToHTML: (textMarkdown: string) => void
-    enhancedMarkdownToHTML: (enhancedMarkdown: string) => void
+    textMarkdownToHTML: (textMarkdown: string) => Promise<string>
+    enhancedMarkdownToHTML: (enhancedMarkdown: string) => Promise<string>
   }
 
   translate: (toTranslate: string) => Promise<string>

--- a/client/src/types/register-client-option.model.ts
+++ b/client/src/types/register-client-option.model.ts
@@ -27,5 +27,10 @@ export type RegisterClientHelpers = {
     confirm?: { value: string, action?: () => void }
   }) => void
 
+  markdownRenderer: {
+    textMarkdownToHTML: (textMarkdown: string) => void
+    enhancedMarkdownToHTML: (enhancedMarkdown: string) => void
+  }
+
   translate: (toTranslate: string) => Promise<string>
 }

--- a/shared/models/plugins/register-server-setting.model.ts
+++ b/shared/models/plugins/register-server-setting.model.ts
@@ -1,7 +1,7 @@
 export interface RegisterServerSettingOptions {
   name: string
   label: string
-  type: 'input' | 'input-checkbox' | 'input-textarea'
+  type: 'input' | 'input-checkbox' | 'input-textarea' | 'markdown-text' | 'markdown-enhanced'
 
   // If the setting is not private, anyone can view its value (client code included)
   // If the setting is private, only server-side hooks can access it

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -224,10 +224,10 @@ To render a formatted markdown text to HTML:
 ```js
 const { markdownRenderer } = peertubeHelpers
 
-markdownRenderer.textMarkdownToHTML('**My Bold Text**')
+await markdownRenderer.textMarkdownToHTML('**My Bold Text**')
 // return <strong>My Bold Text</strong>
 
-markdownRenderer.enhancedMarkdownToHTML('![alt-img](http://.../my-image.jpg)')
+await markdownRenderer.enhancedMarkdownToHTML('![alt-img](http://.../my-image.jpg)')
 // return <img alt=alt-img src=http://.../my-image.jpg />
 ```
 

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -149,6 +149,7 @@ registerSetting({
   name: 'admin-name',
   label: 'Admin name',
   type: 'input',
+  // type: input | input-checkbox | input-textarea | markdown-text | markdown-enhanced
   default: 'my super name'
 })
 
@@ -214,6 +215,20 @@ To notify the user with the PeerTube ToastModule:
 const { notifier } = peertubeHelpers
 notifier.success('Success message content.')
 notifier.error('Error message content.')
+```
+
+#### Markdown Renderer
+
+To render a formatted markdown text to HTML:
+
+```js
+const { markdownRenderer } = peertubeHelpers
+
+markdownRenderer.textMarkdownToHTML('**My Bold Text**')
+// return <strong>My Bold Text</strong>
+
+markdownRenderer.enhancedMarkdownToHTML('![alt-img](http://.../my-image.jpg)')
+// return <img alt=alt-img src=http://.../my-image.jpg />
 ```
 
 #### Custom Modal


### PR DESCRIPTION
This PR adds to plugins :

- `markdown-text` and `markdown-enhanced` setting type to the server helpers
- `markdownRenderer` to the client helpers

As mentioned in this issue https://github.com/Chocobozzz/PeerTube/issues/2602, markdown is rendered with another library (marked) lazy-loaded over the internal markdown-it of PeerTube.

```js
registerSetting({
  name: 'my-markdown-area',
  label: 'Markdown text',
  type: 'markdown-text',
  default: false
})
```

```js
const { markdownRenderer } = peertubeHelpers

await markdownRenderer.textMarkdownToHTML('**My Bold Text**')
// return <strong>My Bold Text</strong>

await markdownRenderer.enhancedMarkdownToHTML('![alt-img](http://.../my-image.jpg)')
// return <img alt=alt-img src=http://.../my-image.jpg />
```