### PR TITLE
Use modal instead of dropdown menu in small/mobile views

### DIFF
--- a/client/src/app/shared/menu/top-menu-dropdown.component.html
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.html
@@ -1,10 +1,20 @@
-<div class="sub-menu">
-  <ng-container *ngFor="let menuEntry of menuEntries">
+<div class="sub-menu" [ngClass]="{ 'no-scroll': isModalOpened }">
+  <ng-container *ngFor="let menuEntry of menuEntries; index as id">
 
     <a *ngIf="menuEntry.routerLink" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
-    <div *ngIf="!menuEntry.routerLink" ngbDropdown [container]="container" class="parent-entry" #dropdown="ngbDropdown" (mouseleave)="closeDropdownIfHovered(dropdown)">
+    <div *ngIf="!menuEntry.routerLink" ngbDropdown [container]="container" class="parent-entry"
+      #dropdown="ngbDropdown" (mouseleave)="closeDropdownIfHovered(dropdown)">
       <span
+        *ngIf="isInSmallView"
+        [ngClass]="{ active: !!suffixLabels[menuEntry.label] }"
+        (click)="openModal(id)" role="button" class="title-page title-page-settings">
+        <ng-container i18n>{{ menuEntry.label }}</ng-container>
+        <ng-container *ngIf="!!suffixLabels[menuEntry.label]"> - {{ suffixLabels[menuEntry.label] }}</ng-container>
+      </span>
+
+      <span
+        *ngIf="!isInSmallView"
         (mouseenter)="openDropdownOnHover(dropdown)" [ngClass]="{ active: !!suffixLabels[menuEntry.label] }" ngbDropdownAnchor
         (click)="dropdownAnchorClicked(dropdown)" role="button" class="title-page title-page-settings"
       >
@@ -20,6 +30,21 @@
         </a>
       </div>
     </div>
-
   </ng-container>
 </div>
+
+<ng-template #modal let-close="close" let-dismiss="dismiss">
+  <div class="modal-body">
+    <ng-container *ngFor="let menuEntry of menuEntries; index as id">
+      <div [ngClass]="{ hidden: id !== currentMenuEntryIndex }">
+        <a *ngFor="let menuChild of menuEntry.children"
+          [ngClass]="{ icon: hasIcons }"
+          [routerLink]="menuChild.routerLink" routerLinkActive="active" (click)="dismissOtherModals()">
+          <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName"></my-global-icon>
+
+          {{ menuChild.label }}
+        </a>
+      </div>
+    </ng-container>
+  </div>
+</ng-template>

--- a/client/src/app/shared/menu/top-menu-dropdown.component.scss
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.scss
@@ -25,3 +25,32 @@
 
   top: -1px;
 }
+
+.sub-menu.no-scroll {
+  overflow-x: hidden;
+}
+
+.modal-body {
+  .hidden {
+    display: none;
+  }
+
+  a {
+    @include disable-default-a-behaviour;
+
+    color: currentColor;
+    box-sizing: border-box;
+    display: block;
+    font-size: 1.2rem;
+    padding: 9px 12px;
+    text-align: initial;
+    text-transform: unset;
+    width: 100%;
+
+    &.active {
+      color: var(--mainBackgroundColor) !important;
+      background-color: var(--mainHoverColor);
+      opacity: .9;
+    }
+  }
+}

--- a/client/src/app/shared/menu/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.ts
@@ -1,7 +1,5 @@
 import {
-  AfterViewInit,
   Component,
-  HostListener,
   Input,
   OnDestroy,
   OnInit,
@@ -31,7 +29,7 @@ export type TopMenuDropdownParam = {
   templateUrl: './top-menu-dropdown.component.html',
   styleUrls: [ './top-menu-dropdown.component.scss' ]
 })
-export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
+export class TopMenuDropdownComponent implements OnInit, OnDestroy {
   @Input() menuEntries: TopMenuDropdownParam[] = []
 
   @ViewChild('modal', { static: true }) modal: NgbModal
@@ -39,7 +37,6 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewIni
   suffixLabels: { [ parentLabel: string ]: string }
   hasIcons = false
   container: undefined | 'body' = undefined
-  isInSmallView = false
   isModalOpened = false
   currentMenuEntryIndex: number
 
@@ -50,7 +47,11 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewIni
     private router: Router,
     private modalService: NgbModal,
     private screen: ScreenService
-  ) {}
+  ) { }
+
+  get isInSmallView () {
+    return this.screen.isInSmallView()
+  }
 
   ngOnInit () {
     this.updateChildLabels(window.location.pathname)
@@ -64,14 +65,9 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewIni
     )
 
     // We have to set body for the container to avoid scroll overflow on mobile and small views
-    if (this.screen.isInSmallView()) {
+    if (this.isInSmallView) {
       this.container = 'body'
-      this.isInSmallView = true
     }
-  }
-
-  ngAfterViewInit () {
-    setTimeout(() => this.onWindowResize(), 0)
   }
 
   ngOnDestroy () {
@@ -102,11 +98,6 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewIni
 
     dropdown.close()
     this.openedOnHover = false
-  }
-
-  @HostListener('window:resize')
-  onWindowResize () {
-    this.isInSmallView = !!this.screen.isInSmallView()
   }
 
   openModal (index: number) {

--- a/client/src/app/shared/menu/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.ts
@@ -1,8 +1,17 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core'
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  HostListener,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from '@angular/core'
 import { filter, take } from 'rxjs/operators'
 import { NavigationEnd, Router } from '@angular/router'
 import { Subscription } from 'rxjs'
-import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap'
+import { NgbDropdown, NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { GlobalIconName } from '@app/shared/images/global-icon.component'
 import { ScreenService } from '@app/shared/misc/screen.service'
 
@@ -23,18 +32,24 @@ export type TopMenuDropdownParam = {
   templateUrl: './top-menu-dropdown.component.html',
   styleUrls: [ './top-menu-dropdown.component.scss' ]
 })
-export class TopMenuDropdownComponent implements OnInit, OnDestroy {
+export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() menuEntries: TopMenuDropdownParam[] = []
+
+  @ViewChild('modal', { static: true }) modal: ElementRef
 
   suffixLabels: { [ parentLabel: string ]: string }
   hasIcons = false
   container: undefined | 'body' = undefined
+  isInSmallView = false
+  isModalOpened = false
+  currentMenuEntryIndex: number
 
   private openedOnHover = false
   private routeSub: Subscription
 
   constructor (
     private router: Router,
+    private modalService: NgbModal,
     private screen: ScreenService
   ) {}
 
@@ -42,17 +57,22 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
     this.updateChildLabels(window.location.pathname)
 
     this.routeSub = this.router.events
-                        .pipe(filter(event => event instanceof NavigationEnd))
-                        .subscribe(() => this.updateChildLabels(window.location.pathname))
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(() => this.updateChildLabels(window.location.pathname))
 
     this.hasIcons = this.menuEntries.some(
       e => e.children && e.children.some(c => !!c.iconName)
     )
 
-    // We have to set body for the container to avoid scroll overflow on mobile view
-    if (this.screen.isInMobileView()) {
+    // We have to set body for the container to avoid scroll overflow on mobile and small views
+    if (this.screen.isInSmallView()) {
       this.container = 'body'
+      this.isInSmallView = true
     }
+  }
+
+  ngAfterViewInit () {
+    setTimeout(() => this.onWindowResize(), 0)
   }
 
   ngOnDestroy () {
@@ -83,6 +103,31 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
 
     dropdown.close()
     this.openedOnHover = false
+  }
+
+  @HostListener('window:resize')
+  onWindowResize () {
+    this.isInSmallView = !!this.screen.isInSmallView()
+  }
+
+  openModal (index: number) {
+    this.currentMenuEntryIndex = index
+    this.isModalOpened = true
+
+    this.modalService.open(this.modal, {
+      centered: true, beforeDismiss: async () => {
+        this.onModalDismiss()
+        return true
+      }
+    })
+  }
+
+  onModalDismiss () {
+    this.isModalOpened = false
+  }
+
+  dismissOtherModals () {
+    this.modalService.dismissAll()
   }
 
   private updateChildLabels (path: string) {

--- a/client/src/app/shared/menu/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.ts
@@ -1,7 +1,6 @@
 import {
   AfterViewInit,
   Component,
-  ElementRef,
   HostListener,
   Input,
   OnDestroy,

--- a/client/src/app/shared/menu/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.ts
@@ -115,7 +115,8 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewIni
     this.isModalOpened = true
 
     this.modalService.open(this.modal, {
-      centered: true, beforeDismiss: async () => {
+      centered: true,
+      beforeDismiss: async () => {
         this.onModalDismiss()
         return true
       }

--- a/client/src/app/shared/menu/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.ts
@@ -35,7 +35,7 @@ export type TopMenuDropdownParam = {
 export class TopMenuDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() menuEntries: TopMenuDropdownParam[] = []
 
-  @ViewChild('modal', { static: true }) modal: ElementRef
+  @ViewChild('modal', { static: true }) modal: NgbModal
 
   suffixLabels: { [ parentLabel: string ]: string }
   hasIcons = false


### PR DESCRIPTION
Here is the solution suggested for this issue :  https://github.com/Chocobozzz/PeerTube/issues/2673

Before:
<div>
<img width=49% alt=[my-account_nav_mobile src=https://user-images.githubusercontent.com/1877318/80216234-09478d80-863e-11ea-9823-02869e2560c7.png />
</div>

Now:
<div>
<img width=49% alt=my-account_nav_mobile-fix src=https://user-images.githubusercontent.com/1877318/80216231-08aef700-863e-11ea-967c-a574060fa1a6.png />
</div>

Edit : it may be an issue of NgbDropdown, on small screens sometimes the dropdown is inside sometimes outside but in any case dropdown on a horizontal overflow menu is such a pain on touch screens, and not really mobile-friendly.
