### PR TITLE
Make video-add-nav tabs scrollable on small devices

### DIFF
--- a/client/src/app/videos/+video-edit/video-add.component.scss
+++ b/client/src/app/videos/+video-edit/video-add.component.scss
@@ -62,8 +62,7 @@ $nav-link-height: 40px;
   }
 }
 
-/* Make .video-add-nav tabs scrollable on small devices */
-@media screen and (max-width: $small-view) {
+@mixin nav-scroll {
   ::ng-deep .video-add-nav {
     height: #{$nav-link-height + $border-width * 2};
     overflow-x: auto;
@@ -75,5 +74,16 @@ $nav-link-height: 40px;
       border: none;
       background-color: var(--mainBackgroundColor) !important;
     }
+  }
+}
+
+/* Make .video-add-nav tabs scrollable on small devices */
+@media screen and (max-width: $small-view) {
+  @include nav-scroll();
+}
+
+@media screen and (max-width: #{$small-view + $menu-width}) {
+  :host-context(.main-col:not(.expanded)) {
+    @include nav-scroll();
   }
 }

--- a/client/src/app/videos/+video-edit/video-add.component.scss
+++ b/client/src/app/videos/+video-edit/video-add.component.scss
@@ -4,6 +4,7 @@
 $border-width: 3px;
 $border-type: solid;
 $border-color: #EAEAEA;
+$nav-link-height: 40px;
 
 .margin-content {
   padding-top: 50px;
@@ -25,7 +26,7 @@ $border-color: #EAEAEA;
     @include disable-default-a-behaviour;
 
     margin-bottom: -$border-width;
-    height: 40px !important;
+    height: $nav-link-height !important;
     padding: 0 30px !important;
     font-size: 15px;
 
@@ -58,5 +59,21 @@ $border-color: #EAEAEA;
 
   &.dragover {
     border: 3px dashed var(--mainColor);
+  }
+}
+
+/* Make .video-add-nav tabs scrollable on small devices */
+@media screen and (max-width: $small-view) {
+  ::ng-deep .video-add-nav {
+    height: #{$nav-link-height + $border-width * 2};
+    overflow-x: auto;
+    white-space: nowrap;
+    flex-wrap: unset;
+
+    /* Hide active tab style to not have a moving tab effect */
+    a.nav-link.active {
+      border: none;
+      background-color: var(--mainBackgroundColor) !important;
+    }
   }
 }


### PR DESCRIPTION
**Issue** : https://github.com/Chocobozzz/PeerTube/issues/2676

Before
------

<div>
<img width=49% alt=videos-upload-small src=https://user-images.githubusercontent.com/1877318/80231974-7108d300-8654-11ea-8f39-5334dc8e5541.png />
<img width=49% alt=videos-upload-mobile src=https://user-images.githubusercontent.com/1877318/80231976-71a16980-8654-11ea-83b6-cb74c9da7265.png />
</div>


After
------

<div>
<img width=49% alt=videos-upload-mobile--fr-fix src=https://user-images.githubusercontent.com/1877318/80232352-0e640700-8655-11ea-9fcb-0378875fa168.png />
<img width=49% alt=videos-upload-small-fr-fix src=https://user-images.githubusercontent.com/1877318/80232356-0e640700-8655-11ea-870c-9dda3abc4f8f.png />
</div>
<div>
<img width=49% alt=videos-upload-small-fix src=https://user-images.githubusercontent.com/1877318/80232357-0efc9d80-8655-11ea-9ba0-8633c123639d.png />
<img width=49% alt=videos-upload-mobile-fix src=https://user-images.githubusercontent.com/1877318/80232358-0efc9d80-8655-11ea-8d16-06c17761329f.png />

</div>
