### PR TITLE
Remove border-bottom on header to prevent header redimensioning

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -2,7 +2,7 @@
 
 <my-hotkeys-cheatsheet></my-hotkeys-cheatsheet>
 
-<div class="peertube-container" [ngClass]="{ 'border-bottom': menu.isMenuDisplayed === false, 'user-logged-in': isUserLoggedIn(), 'user-not-logged-in': !isUserLoggedIn() }">
+<div class="peertube-container" [ngClass]="{ 'user-logged-in': isUserLoggedIn(), 'user-not-logged-in': !isUserLoggedIn() }">
   <div class="header">
 
     <div class="top-left-block">

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -2,10 +2,10 @@
 
 <my-hotkeys-cheatsheet></my-hotkeys-cheatsheet>
 
-<div class="peertube-container" [ngClass]="{ 'user-logged-in': isUserLoggedIn(), 'user-not-logged-in': !isUserLoggedIn() }">
+<div class="peertube-container" [ngClass]="{ 'border-bottom': menu.isMenuDisplayed === false, 'user-logged-in': isUserLoggedIn(), 'user-not-logged-in': !isUserLoggedIn() }">
   <div class="header">
 
-    <div class="top-left-block" [ngClass]="{ 'border-bottom': menu.isMenuDisplayed === false }">
+    <div class="top-left-block">
       <span class="icon icon-menu" (click)="menu.toggleMenu()"></span>
 
       <a class="peertube-title" [routerLink]="defaultRoute" title="Homepage" i18n-title>
@@ -14,7 +14,7 @@
       </a>
     </div>
 
-    <div class="header-right" [ngClass]="{ 'border-bottom': menu.isMenuDisplayed === false }">
+    <div class="header-right">
       <my-header class="w-100 d-flex justify-content-end"></my-header>
     </div>
   </div>


### PR DESCRIPTION
Small fix preventing header size change when clicking on the left menu; the header elements (Logo, Title, Search Bar and Upload Button) have a weird effect of being resized / re-align vertically.

If that `border-bottom` is really useful on the left and right header elements, we can put it on the parent, so the `.header` element as proposed.

On the contrary, if that `border-bottom` on expanded view is useless (it is just a grey line inside a grey gradient...) we can drop it ? @rigelk  ?