### PR TITLE
Fix broken buttons on mobile history view

### DIFF
--- a/client/src/app/+my-account/my-account-history/my-account-history.component.scss
+++ b/client/src/app/+my-account/my-account-history/my-account-history.component.scss
@@ -12,6 +12,8 @@
 .top-buttons {
   margin-bottom: 20px;
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 
   .history-switch {
     display: flex;
@@ -36,5 +38,22 @@
 
   .my-video-miniature {
     flex-grow: 1;
+  }
+}
+
+@media screen and (max-width: $mobile-view) {
+  .top-buttons {
+    .history-switch label, .delete-history {
+      @include ellipsis;
+    }
+
+    .history-switch label {
+      width: 60%;
+    }
+
+    .delete-history {
+      margin-left: auto;
+      max-width: 32%;
+    }
   }
 }


### PR DESCRIPTION
Small to fix broken buttons on mobile history view, for example in French language :

<div>
<img width=49% alt=my-account-history src=https://user-images.githubusercontent.com/1877318/80488216-470a2600-895e-11ea-9a08-5b18ef743848.png />
<img width=49% alt=my-account-history-fix src=https://user-images.githubusercontent.com/1877318/80488214-46718f80-895e-11ea-9614-1ad752ff0458.png />
</div>
