### PR TITLE
Fix select width on view < 800px (mobile)

### DIFF
--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -325,7 +325,8 @@ table {
       input[type=text],
       input[type=password],
       input[type=email],
-      textarea {
+      textarea,
+      .peertube-select-container {
         width: 100% !important;
       }
     }


### PR DESCRIPTION
Very small fix linked to this merged PR : https://github.com/Chocobozzz/PeerTube/pull/2671

The peertube-select where not included in the CSS rules for screen width under 800px, it caused an `overflow-x` on mobile view (between ~ `340px`  and  ~`400px` screen width)

