### PR TITLE
Make admin sub-navs, selects, buttons responsive

### DIFF
--- a/client/src/app/+admin/plugins/plugins.component.scss
+++ b/client/src/app/+admin/plugins/plugins.component.scss
@@ -5,3 +5,29 @@
   flex-grow: 0;
   margin-right: 30px;
 }
+
+@media screen and (max-width: $small-view) {
+  ::ng-deep .plugins .plugin .first-row {
+    flex-wrap: wrap;
+
+    .plugin-name,
+    .plugin-version,
+    .plugin-icon {
+      margin-bottom: 10px;
+    }
+
+    .buttons {
+      my-edit-button,
+      my-delete-button,
+      my-button {
+        .action-button {
+          padding: 0 13px;
+        }
+
+        .button-label {
+          display: none;
+        }
+      }
+    }
+  }
+}

--- a/client/src/app/+admin/system/jobs/jobs.component.scss
+++ b/client/src/app/+admin/system/jobs/jobs.component.scss
@@ -18,6 +18,7 @@
 }
 
 .admin-sub-header {
+  flex-direction: row !important;
   justify-content: flex-end;
 
   .select-filter-block {

--- a/client/src/app/+admin/system/logs/logs.component.scss
+++ b/client/src/app/+admin/system/logs/logs.component.scss
@@ -73,3 +73,22 @@
     }
   }
 }
+
+@media screen and (max-width: #{$small-view + $menu-width}) {
+  :host-context(.main-col:not(.expanded)) {
+    .header {
+      flex-direction: column;
+
+      .peertube-select-container,
+      my-button {
+        width: 100% !important;
+        margin-left: 0px !important;
+        margin-bottom: 10px !important;
+      }
+
+      my-button {
+        text-align: center;
+      }
+    }
+  }
+}

--- a/client/src/app/+admin/system/logs/logs.component.scss
+++ b/client/src/app/+admin/system/logs/logs.component.scss
@@ -57,7 +57,7 @@
   }
 }
 
-@media screen and (max-width: $mobile-view) {
+@media screen and (max-width: $small-view) {
   .header {
     flex-direction: column;
 

--- a/client/src/app/+admin/system/logs/logs.component.scss
+++ b/client/src/app/+admin/system/logs/logs.component.scss
@@ -57,3 +57,19 @@
   }
 }
 
+@media screen and (max-width: $mobile-view) {
+  .header {
+    flex-direction: column;
+
+    .peertube-select-container,
+    my-button {
+      width: 100% !important;
+      margin-left: 0px !important;
+      margin-bottom: 10px !important;
+    }
+
+    my-button {
+      text-align: center;
+    }
+  }
+}

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -322,19 +322,16 @@ table {
         margin-bottom: $sub-menu-margin-bottom-small-view;
       }
 
-      .admin-sub-header:first {
+      .admin-sub-header {
         flex-direction: column;
 
         .admin-sub-nav {
           width: 100%;
         }
 
-        > :first-child {
+        .form-sub-title {
           margin-right: 0px !important;
           margin-bottom: 10px;
-        }
-
-        .form-sub-title {
           text-align: center;
         }
 

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -322,6 +322,36 @@ table {
         margin-bottom: $sub-menu-margin-bottom-small-view;
       }
 
+      .admin-sub-header:first {
+        flex-direction: column;
+
+        .admin-sub-nav {
+          width: 100%;
+        }
+
+        > :first-child {
+          margin-right: 0px !important;
+          margin-bottom: 10px;
+        }
+
+        .form-sub-title {
+          text-align: center;
+        }
+
+        .admin-sub-nav {
+          display: block;
+          overflow-x: auto;
+          white-space: nowrap;
+          height: 50px;
+          padding: 10px 0;
+          width: calc(100vw - 15px - 15px);
+
+          a {
+            margin-left: 5px;
+          }
+        }
+      }
+
       my-markdown-textarea {
         .root {
           max-width: 100% !important;

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -325,10 +325,6 @@ table {
       .admin-sub-header {
         flex-direction: column;
 
-        .admin-sub-nav {
-          width: 100%;
-        }
-
         .form-sub-title {
           margin-right: 0px !important;
           margin-bottom: 10px;
@@ -361,6 +357,35 @@ table {
       textarea,
       .peertube-select-container {
         width: 100% !important;
+      }
+    }
+  }
+}
+
+@media screen and (min-width: $small-view) and  (max-width: #{$small-view + $menu-width}) {
+  .main-col {
+    &:not(.expanded) {
+      .admin-sub-header {
+        flex-direction: column;
+
+        .form-sub-title {
+          margin-right: 0px !important;
+          margin-bottom: 10px;
+          text-align: center;
+        }
+
+        .admin-sub-nav {
+          display: block;
+          overflow-x: auto;
+          white-space: nowrap;
+          height: 50px;
+          padding: 10px 0;
+          width: calc(100vw - #{$menu-width + ($expanded-horizontal-margins/3) *2});
+
+          a {
+            margin-left: 5px;
+          }
+        }
       }
     }
   }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -323,26 +323,7 @@ table {
       }
 
       .admin-sub-header {
-        flex-direction: column;
-
-        .form-sub-title {
-          margin-right: 0px !important;
-          margin-bottom: 10px;
-          text-align: center;
-        }
-
-        .admin-sub-nav {
-          display: block;
-          overflow-x: auto;
-          white-space: nowrap;
-          height: 50px;
-          padding: 10px 0;
-          width: calc(100vw - 15px - 15px);
-
-          a {
-            margin-left: 5px;
-          }
-        }
+        @include admin-sub-header-responsive(15px*2);
       }
 
       my-markdown-textarea {
@@ -362,30 +343,11 @@ table {
   }
 }
 
-@media screen and (min-width: $small-view) and  (max-width: #{$small-view + $menu-width}) {
+@media screen and (min-width: $small-view) and (max-width: #{$small-view + $menu-width}) {
   .main-col {
     &:not(.expanded) {
       .admin-sub-header {
-        flex-direction: column;
-
-        .form-sub-title {
-          margin-right: 0px !important;
-          margin-bottom: 10px;
-          text-align: center;
-        }
-
-        .admin-sub-nav {
-          display: block;
-          overflow-x: auto;
-          white-space: nowrap;
-          height: 50px;
-          padding: 10px 0;
-          width: calc(100vw - #{$menu-width + ($expanded-horizontal-margins/3) *2});
-
-          a {
-            margin-left: 5px;
-          }
-        }
+        @include admin-sub-header-responsive($menu-width/2 + $expanded-horizontal-margins/3);
       }
     }
   }

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -875,3 +875,26 @@
     }
   }
 }
+
+@mixin admin-sub-header-responsive ($horizontal-margins) {
+  flex-direction: column;
+
+  .form-sub-title {
+    margin-right: 0px !important;
+    margin-bottom: 10px;
+    text-align: center;
+  }
+
+  .admin-sub-nav {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+    height: 50px;
+    padding: 10px 0;
+    width: calc(100vw - #{$horizontal-margins*2});
+
+    a {
+      margin-left: 5px;
+    }
+  }
+}


### PR DESCRIPTION
Small PR that makes the rest of the admin responsive (sub-navs, selects, buttons), what do you think ? 

<div>
<img width=49% alt=admin-follows src=https://user-images.githubusercontent.com/1877318/80631375-e65e1480-8a55-11ea-9fd7-c1dcc9efc2b6.png />
<img width=49% alt=admin-follows-fix src=https://user-images.githubusercontent.com/1877318/80631378-e6f6ab00-8a55-11ea-9f1f-4876100340ea.png />
</div>

_____

<div>
<img width=49% alt=admin-moderation src=https://user-images.githubusercontent.com/1877318/80631650-58365e00-8a56-11ea-9055-7165dff290dd.png />
<img width=49% alt=admin-moderation-fix src=https://user-images.githubusercontent.com/1877318/80631651-58cef480-8a56-11ea-9a3a-f26cdda342a3.png />
</div>

_____

<div>
<img width=49% alt=admin-plugins-themes src=https://user-images.githubusercontent.com/1877318/80631786-8c118380-8a56-11ea-9c18-a1c933258ea0.png />
<img width=49% alt=admin-plugins-themes-fix src=https://user-images.githubusercontent.com/1877318/80631788-8caa1a00-8a56-11ea-84d5-4cfbf4c2a71a.png />
</div>

____

<div>
<img width=49% alt=admin-system-logs src=https://user-images.githubusercontent.com/1877318/80631924-caa73e00-8a56-11ea-8248-deba53c21310.png />
<img width=49% alt=admin-system-logs-fix src=https://user-images.githubusercontent.com/1877318/80631926-caa73e00-8a56-11ea-93d0-99d2d456829f.png />
</div>