### PR TITLE
Fix regression my-account menu overflow-x on screen width < 800px

### DIFF
--- a/client/src/app/core/menu/menu.service.ts
+++ b/client/src/app/core/menu/menu.service.ts
@@ -7,7 +7,7 @@ import { debounceTime } from 'rxjs/operators'
 export class MenuService {
   isMenuDisplayed = true
   isMenuChangedByUser = false
-  menuWidth = 240
+  menuWidth = 240  // should be kept equal to $menu-width
 
   constructor (
     private screenService: ScreenService

--- a/client/src/app/core/menu/menu.service.ts
+++ b/client/src/app/core/menu/menu.service.ts
@@ -7,6 +7,7 @@ import { debounceTime } from 'rxjs/operators'
 export class MenuService {
   isMenuDisplayed = true
   isMenuChangedByUser = false
+  menuWidth = 240
 
   constructor (
     private screenService: ScreenService

--- a/client/src/app/shared/menu/top-menu-dropdown.component.html
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.html
@@ -3,7 +3,7 @@
 
     <a *ngIf="menuEntry.routerLink" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
-    <div *ngIf="!menuEntry.routerLink" ngbDropdown [container]="container" class="parent-entry"
+    <div *ngIf="!menuEntry.routerLink" ngbDropdown container="body" class="parent-entry"
       #dropdown="ngbDropdown" (mouseleave)="closeDropdownIfHovered(dropdown)">
       <span
         *ngIf="isInSmallView"

--- a/client/src/app/shared/menu/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.ts
@@ -11,6 +11,7 @@ import { Subscription } from 'rxjs'
 import { NgbDropdown, NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { GlobalIconName } from '@app/shared/images/global-icon.component'
 import { ScreenService } from '@app/shared/misc/screen.service'
+import { MenuService } from '@app/core/menu'
 
 export type TopMenuDropdownParam = {
   label: string
@@ -46,10 +47,16 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
   constructor (
     private router: Router,
     private modalService: NgbModal,
-    private screen: ScreenService
+    private screen: ScreenService,
+    private menuService: MenuService
   ) { }
 
   get isInSmallView () {
+    if (this.menuService.isMenuDisplayed) {
+      const contentWidth = this.screen.getWindowInnerWidth() - this.menuService.menuWidth
+      return contentWidth < 800
+    }
+
     return this.screen.isInSmallView()
   }
 

--- a/client/src/app/shared/menu/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/menu/top-menu-dropdown.component.ts
@@ -37,7 +37,6 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
 
   suffixLabels: { [ parentLabel: string ]: string }
   hasIcons = false
-  container: undefined | 'body' = undefined
   isModalOpened = false
   currentMenuEntryIndex: number
 
@@ -52,12 +51,12 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
   ) { }
 
   get isInSmallView () {
+    let marginLeft = 0
     if (this.menuService.isMenuDisplayed) {
-      const contentWidth = this.screen.getWindowInnerWidth() - this.menuService.menuWidth
-      return contentWidth < 800
+      marginLeft = this.menuService.menuWidth
     }
 
-    return this.screen.isInSmallView()
+    return this.screen.isInSmallView(marginLeft)
   }
 
   ngOnInit () {
@@ -70,11 +69,6 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
     this.hasIcons = this.menuEntries.some(
       e => e.children && e.children.some(c => !!c.iconName)
     )
-
-    // We have to set body for the container to avoid scroll overflow on mobile and small views
-    if (this.isInSmallView) {
-      this.container = 'body'
-    }
   }
 
   ngOnDestroy () {

--- a/client/src/app/shared/misc/screen.service.ts
+++ b/client/src/app/shared/misc/screen.service.ts
@@ -10,7 +10,12 @@ export class ScreenService {
     this.refreshWindowInnerWidth()
   }
 
-  isInSmallView () {
+  isInSmallView (marginLeft = 0) {
+    if (marginLeft > 0) {
+      const contentWidth = this.getWindowInnerWidth() - marginLeft
+      return contentWidth < 800
+    }
+
     return this.getWindowInnerWidth() < 800
   }
 

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -320,6 +320,7 @@ table {
         padding-left: 15px;
         padding-right: 15px;
         margin-bottom: $sub-menu-margin-bottom-small-view;
+        overflow-x: auto;
       }
 
       .admin-sub-header {
@@ -382,6 +383,10 @@ table {
     &:not(.expanded) {
       .admin-sub-header {
         @include admin-sub-header-responsive($menu-width/2 + $expanded-horizontal-margins/3);
+      }
+
+      .sub-menu {
+        overflow-x: auto;
       }
     }
   }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -387,6 +387,7 @@ table {
 
       .sub-menu {
         overflow-x: auto;
+        width: calc(100vw - #{$menu-width});
       }
     }
   }


### PR DESCRIPTION
This PR fix a regression on the menu of `/my-account/*` which was not horizontally scrollable anymore on screen width < 800px.

![account-menu-no-scroll](https://user-images.githubusercontent.com/1877318/80807338-3b686a80-8bbd-11ea-82f0-822c4a2fa875.png)
