### PR TITLE
Filter comments from muted accounts/instances

### DIFF
--- a/server/controllers/activitypub/client.ts
+++ b/server/controllers/activitypub/client.ts
@@ -285,7 +285,7 @@ async function videoCommentsController (req: express.Request, res: express.Respo
   const video = res.locals.onlyImmutableVideo
 
   const handler = async (start: number, count: number) => {
-    const result = await VideoCommentModel.listAndCountByVideoId(video.id, start, count)
+    const result = await VideoCommentModel.listAndCountByVideoForAP(video, start, count)
     return {
       total: result.count,
       data: result.rows.map(r => r.url)

--- a/server/controllers/api/videos/comment.ts
+++ b/server/controllers/api/videos/comment.ts
@@ -78,6 +78,7 @@ async function listVideoThreads (req: express.Request, res: express.Response) {
   if (video.commentsEnabled === true) {
     const apiOptions = await Hooks.wrapObject({
       videoId: video.id,
+      isVideoOwned: video.isOwned(),
       start: req.query.start,
       count: req.query.count,
       sort: req.query.sort,
@@ -108,6 +109,7 @@ async function listVideoThreadComments (req: express.Request, res: express.Respo
   if (video.commentsEnabled === true) {
     const apiOptions = await Hooks.wrapObject({
       videoId: video.id,
+      isVideoOwned: video.isOwned(),
       threadId: res.locals.videoCommentThread.id,
       user
     }, 'filter:api.video-thread-comments.list.params')

--- a/server/models/account/account.ts
+++ b/server/models/account/account.ts
@@ -32,9 +32,10 @@ import { FindOptions, IncludeOptions, Op, Transaction, WhereOptions } from 'sequ
 import { AccountBlocklistModel } from './account-blocklist'
 import { ServerBlocklistModel } from '../server/server-blocklist'
 import { ActorFollowModel } from '../activitypub/actor-follow'
-import { MAccountActor, MAccountAP, MAccountDefault, MAccountFormattable, MAccountSummaryFormattable } from '../../typings/models'
+import { MAccountActor, MAccountAP, MAccountDefault, MAccountFormattable, MAccountSummaryFormattable, MAccount } from '../../typings/models'
 import * as Bluebird from 'bluebird'
 import { ModelCache } from '@server/models/model-cache'
+import { VideoModel } from '../video/video'
 
 export enum ScopeNames {
   SUMMARY = 'SUMMARY'
@@ -341,6 +342,29 @@ export class AccountModel extends Model<AccountModel> {
           total: count
         }
       })
+  }
+
+  static loadAccountIdFromVideo (videoId: number): Bluebird<MAccount> {
+    const query = {
+      include: [
+        {
+          attributes: [ 'id', 'accountId' ],
+          model: VideoChannelModel.unscoped(),
+          required: true,
+          include: [
+            {
+              attributes: [ 'id', 'channelId' ],
+              model: VideoModel.unscoped(),
+              where: {
+                id: videoId
+              }
+            }
+          ]
+        }
+      ]
+    }
+
+    return AccountModel.findOne(query)
   }
 
   static listLocalsForSitemap (sort: string): Bluebird<MAccountActor[]> {

--- a/server/models/utils.ts
+++ b/server/models/utils.ts
@@ -136,10 +136,7 @@ function createSimilarityAttribute (col: string, value: string) {
   )
 }
 
-function buildBlockedAccountSQL (serverAccountId: number, userAccountId?: number) {
-  const blockerIds = [ serverAccountId ]
-  if (userAccountId) blockerIds.push(userAccountId)
-
+function buildBlockedAccountSQL (blockerIds: number[]) {
   const blockerIdsString = blockerIds.join(', ')
 
   return 'SELECT "targetAccountId" AS "id" FROM "accountBlocklist" WHERE "accountId" IN (' + blockerIdsString + ')' +

--- a/server/models/video/video-abuse.ts
+++ b/server/models/video/video-abuse.ts
@@ -57,7 +57,7 @@ export enum ScopeNames {
   }) => {
     const where = {
       reporterAccountId: {
-        [Op.notIn]: literal('(' + buildBlockedAccountSQL(options.serverAccountId, options.userAccountId) + ')')
+        [Op.notIn]: literal('(' + buildBlockedAccountSQL([ options.serverAccountId, options.userAccountId ]) + ')')
       }
     }
 

--- a/server/tests/api/videos/multiple-servers.ts
+++ b/server/tests/api/videos/multiple-servers.ts
@@ -37,7 +37,8 @@ import {
   addVideoCommentThread,
   deleteVideoComment,
   getVideoCommentThreads,
-  getVideoThreadComments
+  getVideoThreadComments,
+  findCommentId
 } from '../../../../shared/extra-utils/videos/video-comments'
 import { waitJobs } from '../../../../shared/extra-utils/server/jobs'
 
@@ -773,8 +774,7 @@ describe('Test multiple servers', function () {
       await waitJobs(servers)
 
       {
-        const res = await getVideoCommentThreads(servers[1].url, videoUUID, 0, 5)
-        const threadId = res.body.data.find(c => c.text === 'my super first comment').id
+        const threadId = await findCommentId(servers[1].url, videoUUID, 'my super first comment')
 
         const text = 'my super answer to thread 1'
         await addVideoCommentReply(servers[1].url, servers[1].accessToken, videoUUID, threadId, text)
@@ -783,8 +783,7 @@ describe('Test multiple servers', function () {
       await waitJobs(servers)
 
       {
-        const res1 = await getVideoCommentThreads(servers[2].url, videoUUID, 0, 5)
-        const threadId = res1.body.data.find(c => c.text === 'my super first comment').id
+        const threadId = await findCommentId(servers[2].url, videoUUID, 'my super first comment')
 
         const res2 = await getVideoThreadComments(servers[2].url, videoUUID, threadId)
         const childCommentId = res2.body.children[0].comment.id

--- a/shared/extra-utils/videos/video-comments.ts
+++ b/shared/extra-utils/videos/video-comments.ts
@@ -61,6 +61,12 @@ function addVideoCommentReply (
     .expect(expectedStatus)
 }
 
+async function findCommentId (url: string, videoId: number | string, text: string) {
+  const res = await getVideoCommentThreads(url, videoId, 0, 25, '-createdAt')
+
+  return res.body.data.find(c => c.text === text).id as number
+}
+
 function deleteVideoComment (
   url: string,
   token: string,
@@ -85,5 +91,6 @@ export {
   getVideoThreadComments,
   addVideoCommentThread,
   addVideoCommentReply,
+  findCommentId,
   deleteVideoComment
 }

--- a/shared/extra-utils/videos/videos.ts
+++ b/shared/extra-utils/videos/videos.ts
@@ -95,6 +95,12 @@ function getVideo (url: string, id: number | string, expectedStatus = 200) {
           .expect(expectedStatus)
 }
 
+async function getVideoIdFromUUID (url: string, uuid: string) {
+  const res = await getVideo(url, uuid)
+
+  return res.body.id
+}
+
 function getVideoFileMetadataUrl (url: string) {
   return request(url)
     .get('/')
@@ -669,5 +675,6 @@ export {
   checkVideoFilesWereRemoved,
   getPlaylistVideos,
   uploadVideoAndGetId,
-  getLocalIdByUUID
+  getLocalIdByUUID,
+  getVideoIdFromUUID
 }


### PR DESCRIPTION
Add better control for users of comments displayed on their videos:
     
  * Do not forward comments from muted remote accounts/servers (muted by the current server or by the video owner)
  * Do not list threads and hide replies (with their children) of accounts/servers muted by the video owner
  * Hide from RSS comments of muted accounts/servers by video owners

Use case:

  * Try to limit spam propagation in the federation
  * Add ability for users to automatically hide comments on their videos from undesirable accounts/servers (the comment section belongs to videomakers, so they choose what's posted there)