### PR TITLE
Fix regression scrollbar bgcolor mdtextarea maximized-mode

### DIFF
--- a/client/src/app/shared/forms/markdown-textarea.component.scss
+++ b/client/src/app/shared/forms/markdown-textarea.component.scss
@@ -214,7 +214,7 @@ $input-border-radius: 3px;
       padding: $base-padding;
       border-right: 1px dashed $input-border-color !important;
       resize: none;
-      scrollbar-color: var(--actionButtonColor) var(--textareaBackgroundColor);
+      scrollbar-color: var(--actionButtonColor) var(--markdownTextareaBackgroundColor);
 
       &:focus {
         box-shadow: none;


### PR DESCRIPTION
This PR fixes a regression on the scrollbar background-color of the markdown textarea in maximized-mode.

It should be grey instead of white.

![regression-scrollbar](https://user-images.githubusercontent.com/1877318/83363753-17ef3600-a39c-11ea-92b8-bbca42a6cdb8.png)
