### PR TITLE
Fix: make truncated moderation table field (video title) fully visible

### DIFF
--- a/client/src/app/+admin/moderation/moderation.component.scss
+++ b/client/src/app/+admin/moderation/moderation.component.scss
@@ -29,11 +29,11 @@
     vertical-align: top;
     text-align: right;
   }
-  
+
   .moderation-expanded-text {
     display: inline-flex;
     word-wrap: break-word;
-  
+
     ::ng-deep p:last-child {
       margin-bottom: 0px !important;
     }
@@ -137,6 +137,10 @@ my-action-dropdown.show {
     font-size: 90%;
     color: var(--mainForegroundColor);
     line-height: 1rem;
+
+    > div {
+      white-space: normal;
+    }
 
     div .glyphicon {
       font-size: 80%;


### PR DESCRIPTION
Issue: https://github.com/Chocobozzz/PeerTube/issues/2018

Before: 
![title-moderation-before](https://user-images.githubusercontent.com/1877318/83365744-d1ed9e80-a3aa-11ea-9728-bd177de19565.png)

After:
![title-moderation](https://user-images.githubusercontent.com/1877318/83365755-dd40ca00-a3aa-11ea-80e6-b89079961c06.png)

