### PR TITLE
Support player hotkeys when it is not focused

### DIFF
--- a/client/src/app/videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/videos/+video-watch/video-watch.component.ts
@@ -475,7 +475,6 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
     this.zone.runOutsideAngular(async () => {
       this.player = await PeertubePlayerManager.initialize(playerMode, playerOptions, player => this.player = player)
-      this.player.focus()
 
       this.player.on('customError', ({ err }: { err: any }) => this.handleError(err))
 

--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -452,6 +452,13 @@ export class PeertubePlayerManager {
   private static addHotkeysOptions (plugins: VideoJSPluginOptions) {
     Object.assign(plugins, {
       hotkeys: {
+        skipInitialFocus: true,
+        enableInactiveFocus: false,
+        captureDocumentHotkeys: true,
+        documentHotkeysFocusElementFilter: (e: HTMLElement) => {
+          return e.id === 'content' || e.tagName.toLowerCase() === 'body'
+        },
+
         enableVolumeScroll: false,
         enableModifiersForNumbers: false,
 


### PR DESCRIPTION
Testing a way to use player hotkeys when it is not focused without (too much) accessibility issues.

Currently blocked by https://github.com/ctd1500/videojs-hotkeys/pull/68