### PR TITLE
change focus color instead of opacity of video play button

### DIFF
--- a/client/src/app/menu/language-chooser.component.ts
+++ b/client/src/app/menu/language-chooser.component.ts
@@ -20,7 +20,7 @@ export class LanguageChooserComponent {
     @Inject(LOCALE_ID) private localeId: string
   ) {
     const l = Object.keys(I18N_LOCALES)
-                    .map(k => ({ id: k, label: I18N_LOCALES[k] , iso: getShortLocale(k)}))
+                    .map(k => ({ id: k, label: I18N_LOCALES[k] , iso: getShortLocale(k) }))
 
     this.languages = sortBy(l, 'label')
   }

--- a/client/src/sass/player/peertube-skin.scss
+++ b/client/src/sass/player/peertube-skin.scss
@@ -85,9 +85,10 @@ body {
       background-image: url('#{$assets-path}/player/images/big-play-button.svg');
     }
 
-    &:hover {
-      opacity: 0.8;
+    &.focus-visible, &:hover {
+      background-color: var(--mainColor);
     }
+
   }
 
   // Small effect when we click on the play button


### PR DESCRIPTION
This PR will highlight the central play button on a video when it is focused in order to improve a11y. 

![image](https://user-images.githubusercontent.com/25347588/84064571-1dafd180-a9c3-11ea-8f2c-22eda5bed3eb.png)
