### PR TITLE
cleanup extraneous timestamps in model definitions

### DIFF
--- a/server/lib/job-queue/job-queue.ts
+++ b/server/lib/job-queue/job-queue.ts
@@ -86,11 +86,14 @@ class JobQueue {
     this.initialized = true
 
     this.jobRedisPrefix = 'bull-' + WEBSERVER.HOST
-    const queueOptions = {
+    const queueOptions: Bull.QueueOptions = {
       prefix: this.jobRedisPrefix,
       redis: Redis.getRedisClientOptions(),
       settings: {
         maxStalledCount: 10 // transcoding could be long, so jobs can often be interrupted by restarts
+      },
+      defaultJobOptions: {
+        backoff: { delay: 60 * 1000, type: 'exponential' }
       }
     }
 
@@ -135,7 +138,6 @@ class JobQueue {
     }
 
     const jobArgs: Bull.JobOptions = {
-      backoff: { delay: 60 * 1000, type: 'exponential' },
       attempts: JOB_ATTEMPTS[obj.type],
       timeout: JOB_TTL[obj.type]
     }

--- a/server/models/account/account-blocklist.ts
+++ b/server/models/account/account-blocklist.ts
@@ -1,4 +1,4 @@
-import { BelongsTo, Column, CreatedAt, ForeignKey, Model, Scopes, Table, UpdatedAt } from 'sequelize-typescript'
+import { BelongsTo, Column, ForeignKey, Model, Scopes, Table } from 'sequelize-typescript'
 import { AccountModel } from './account'
 import { getSort, searchAttribute } from '../utils'
 import { AccountBlock } from '../../../shared/models/blocklist'
@@ -42,13 +42,6 @@ enum ScopeNames {
   ]
 })
 export class AccountBlocklistModel extends Model<AccountBlocklistModel> {
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @ForeignKey(() => AccountModel)
   @Column
   accountId: number

--- a/server/models/account/account-video-rate.ts
+++ b/server/models/account/account-video-rate.ts
@@ -1,6 +1,6 @@
 import { values } from 'lodash'
 import { FindOptions, Op, Transaction } from 'sequelize'
-import { AllowNull, BelongsTo, Column, CreatedAt, DataType, ForeignKey, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, DataType, ForeignKey, Is, Model, Table } from 'sequelize-typescript'
 import { VideoRateType } from '../../../shared/models/videos'
 import { CONSTRAINTS_FIELDS, VIDEO_RATE_TYPES } from '../../initializers/constants'
 import { VideoModel } from '../video/video'
@@ -53,12 +53,6 @@ export class AccountVideoRateModel extends Model<AccountVideoRateModel> {
   @Is('AccountVideoRateUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'url'))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_RATES.URL.max))
   url: string
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => VideoModel)
   @Column

--- a/server/models/account/account.ts
+++ b/server/models/account/account.ts
@@ -141,12 +141,6 @@ export class AccountModel extends Model<AccountModel> {
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.USERS.DESCRIPTION.max))
   description: string
 
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @ForeignKey(() => ActorModel)
   @Column
   actorId: number

--- a/server/models/account/user-notification-setting.ts
+++ b/server/models/account/user-notification-setting.ts
@@ -150,12 +150,6 @@ export class UserNotificationSettingModel extends Model<UserNotificationSettingM
   })
   User: UserModel
 
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AfterUpdate
   @AfterDestroy
   static removeTokenCache (instance: UserNotificationSettingModel) {

--- a/server/models/account/user-notification.ts
+++ b/server/models/account/user-notification.ts
@@ -1,4 +1,4 @@
-import { AllowNull, BelongsTo, Column, CreatedAt, Default, ForeignKey, Is, Model, Scopes, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, Default, ForeignKey, Is, Model, Scopes, Table } from 'sequelize-typescript'
 import { UserNotification, UserNotificationType } from '../../../shared'
 import { getSort, throwIfNotValid } from '../utils'
 import { isBooleanValid } from '../../helpers/custom-validators/misc'
@@ -233,12 +233,6 @@ export class UserNotificationModel extends Model<UserNotificationModel> {
   @Is('UserNotificationRead', value => throwIfNotValid(value, isBooleanValid, 'read'))
   @Column
   read: boolean
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => UserModel)
   @Column

--- a/server/models/account/user-video-history.ts
+++ b/server/models/account/user-video-history.ts
@@ -1,4 +1,4 @@
-import { AllowNull, BelongsTo, Column, CreatedAt, ForeignKey, IsInt, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, ForeignKey, IsInt, Model, Table } from 'sequelize-typescript'
 import { VideoModel } from '../video/video'
 import { UserModel } from './user'
 import { DestroyOptions, Op, Transaction } from 'sequelize'
@@ -20,12 +20,6 @@ import { MUserAccountId, MUserId } from '@server/typings/models'
   ]
 })
 export class UserVideoHistoryModel extends Model<UserVideoHistoryModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(false)
   @IsInt
   @Column

--- a/server/models/account/user.ts
+++ b/server/models/account/user.ts
@@ -358,12 +358,6 @@ export class UserModel extends Model<UserModel> {
   @Column
   lastLoginDate: Date
 
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @HasOne(() => AccountModel, {
     foreignKey: 'userId',
     onDelete: 'cascade',

--- a/server/models/activitypub/actor-follow.ts
+++ b/server/models/activitypub/actor-follow.ts
@@ -69,12 +69,6 @@ export class ActorFollowModel extends Model<ActorFollowModel> {
   @Column
   score: number
 
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @ForeignKey(() => ActorModel)
   @Column
   actorId: number

--- a/server/models/activitypub/actor.ts
+++ b/server/models/activitypub/actor.ts
@@ -208,12 +208,6 @@ export class ActorModel extends Model<ActorModel> {
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.ACTORS.URL.max))
   followingUrl: string
 
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @ForeignKey(() => AvatarModel)
   @Column
   avatarId: number

--- a/server/models/avatar/avatar.ts
+++ b/server/models/avatar/avatar.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { AfterDestroy, AllowNull, Column, CreatedAt, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AfterDestroy, AllowNull, Column, Is, Model, Table } from 'sequelize-typescript'
 import { Avatar } from '../../../shared/models/avatars/avatar.model'
 import { LAZY_STATIC_PATHS } from '../../initializers/constants'
 import { logger } from '../../helpers/logger'
@@ -32,12 +32,6 @@ export class AvatarModel extends Model<AvatarModel> {
   @AllowNull(false)
   @Column
   onDisk: boolean
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @AfterDestroy
   static removeFilesAndSendDelete (instance: AvatarModel) {

--- a/server/models/oauth/oauth-client.ts
+++ b/server/models/oauth/oauth-client.ts
@@ -1,4 +1,4 @@
-import { AllowNull, Column, CreatedAt, DataType, HasMany, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, Column, DataType, HasMany, Model, Table } from 'sequelize-typescript'
 import { OAuthTokenModel } from './oauth-token'
 
 @Table({
@@ -29,12 +29,6 @@ export class OAuthClientModel extends Model<OAuthClientModel> {
 
   @Column(DataType.ARRAY(DataType.STRING))
   redirectUris: string[]
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @HasMany(() => OAuthTokenModel, {
     onDelete: 'cascade'

--- a/server/models/oauth/oauth-token.ts
+++ b/server/models/oauth/oauth-token.ts
@@ -101,12 +101,6 @@ export class OAuthTokenModel extends Model<OAuthTokenModel> {
   @Column
   authName: string
 
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @ForeignKey(() => UserModel)
   @Column
   userId: number

--- a/server/models/redundancy/video-redundancy.ts
+++ b/server/models/redundancy/video-redundancy.ts
@@ -85,13 +85,6 @@ export enum ScopeNames {
   ]
 })
 export class VideoRedundancyModel extends Model<VideoRedundancyModel> {
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(true)
   @Column
   expiresOn: Date

--- a/server/models/server/plugin.ts
+++ b/server/models/server/plugin.ts
@@ -1,6 +1,6 @@
 import * as Bluebird from 'bluebird'
 import { FindAndCountOptions, json, QueryTypes } from 'sequelize'
-import { AllowNull, Column, CreatedAt, DataType, DefaultScope, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, Column, DataType, DefaultScope, Is, Model, Table } from 'sequelize-typescript'
 import { MPlugin, MPluginFormattable } from '@server/typings/models'
 import { PeerTubePlugin } from '../../../shared/models/plugins/peertube-plugin.model'
 import { PluginType } from '../../../shared/models/plugins/plugin.type'
@@ -80,12 +80,6 @@ export class PluginModel extends Model<PluginModel> {
   @AllowNull(true)
   @Column(DataType.JSONB)
   storage: any
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   static listEnabledPluginsAndThemes (): Bluebird<MPlugin[]> {
     const query = {

--- a/server/models/server/server-blocklist.ts
+++ b/server/models/server/server-blocklist.ts
@@ -1,4 +1,4 @@
-import { BelongsTo, Column, CreatedAt, ForeignKey, Model, Scopes, Table, UpdatedAt } from 'sequelize-typescript'
+import { BelongsTo, Column, ForeignKey, Model, Scopes, Table } from 'sequelize-typescript'
 import { AccountModel } from '../account/account'
 import { ServerModel } from './server'
 import { ServerBlock } from '../../../shared/models/blocklist'
@@ -44,12 +44,6 @@ enum ScopeNames {
   ]
 })
 export class ServerBlocklistModel extends Model<ServerBlocklistModel> {
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => AccountModel)
   @Column

--- a/server/models/server/server.ts
+++ b/server/models/server/server.ts
@@ -1,4 +1,4 @@
-import { AllowNull, Column, CreatedAt, Default, HasMany, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, Column, Default, HasMany, Is, Model, Table } from 'sequelize-typescript'
 import { isHostValid } from '../../helpers/custom-validators/servers'
 import { ActorModel } from '../activitypub/actor'
 import { throwIfNotValid } from '../utils'
@@ -26,12 +26,6 @@ export class ServerModel extends Model<ServerModel> {
   @Default(false)
   @Column
   redundancyAllowed: boolean
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @HasMany(() => ActorModel, {
     foreignKey: {

--- a/server/models/video/schedule-video-update.ts
+++ b/server/models/video/schedule-video-update.ts
@@ -1,4 +1,4 @@
-import { AllowNull, BelongsTo, Column, CreatedAt, Default, ForeignKey, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, Default, ForeignKey, Model, Table } from 'sequelize-typescript'
 import { ScopeNames as VideoScopeNames, VideoModel } from './video'
 import { VideoPrivacy } from '../../../shared/models/videos'
 import { Op, Transaction } from 'sequelize'
@@ -27,12 +27,6 @@ export class ScheduleVideoUpdateModel extends Model<ScheduleVideoUpdateModel> {
   @Default(null)
   @Column
   privacy: VideoPrivacy.PUBLIC | VideoPrivacy.UNLISTED | VideoPrivacy.INTERNAL
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => VideoModel)
   @Column

--- a/server/models/video/tag.ts
+++ b/server/models/video/tag.ts
@@ -1,6 +1,6 @@
 import * as Bluebird from 'bluebird'
 import { fn, QueryTypes, Transaction, col } from 'sequelize'
-import { AllowNull, BelongsToMany, Column, CreatedAt, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsToMany, Column, Is, Model, Table } from 'sequelize-typescript'
 import { isVideoTagValid } from '../../helpers/custom-validators/videos'
 import { throwIfNotValid } from '../utils'
 import { VideoModel } from './video'
@@ -28,12 +28,6 @@ export class TagModel extends Model<TagModel> {
   @Is('VideoTag', value => throwIfNotValid(value, isVideoTagValid, 'tag'))
   @Column
   name: string
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @BelongsToMany(() => VideoModel, {
     foreignKey: 'tagId',

--- a/server/models/video/thumbnail.ts
+++ b/server/models/video/thumbnail.ts
@@ -4,13 +4,11 @@ import {
   AllowNull,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   Default,
   ForeignKey,
   Model,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { CONSTRAINTS_FIELDS, LAZY_STATIC_PATHS, STATIC_PATHS, WEBSERVER } from '../../initializers/constants'
 import { logger } from '../../helpers/logger'
@@ -85,12 +83,6 @@ export class ThumbnailModel extends Model<ThumbnailModel> {
     onDelete: 'CASCADE'
   })
   VideoPlaylist: VideoPlaylistModel
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   private static readonly types: { [ id in ThumbnailType ]: { label: string, directory: string, staticPath: string } } = {
     [ThumbnailType.MINIATURE]: {

--- a/server/models/video/video-abuse.ts
+++ b/server/models/video/video-abuse.ts
@@ -4,15 +4,13 @@ import {
   AllowNull,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   Default,
   ForeignKey,
   Is,
   Model,
   Scopes,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { VideoAbuseVideoIs } from '@shared/models/videos/abuse/video-abuse-video-is.type'
 import { VideoAbuseState, VideoDetails } from '../../../shared'
@@ -257,12 +255,6 @@ export class VideoAbuseModel extends Model<VideoAbuseModel> {
   @Default(null)
   @Column(DataType.JSONB)
   deletedVideo: VideoDetails
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => AccountModel)
   @Column

--- a/server/models/video/video-blacklist.ts
+++ b/server/models/video/video-blacklist.ts
@@ -1,4 +1,4 @@
-import { AllowNull, BelongsTo, Column, CreatedAt, DataType, Default, ForeignKey, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, DataType, Default, ForeignKey, Is, Model, Table } from 'sequelize-typescript'
 import { getBlacklistSort, SortType, throwIfNotValid, searchAttribute } from '../utils'
 import { VideoModel } from './video'
 import { ScopeNames as VideoChannelScopeNames, SummaryOptions, VideoChannelModel } from './video-channel'
@@ -35,12 +35,6 @@ export class VideoBlacklistModel extends Model<VideoBlacklistModel> {
   @Is('VideoBlacklistType', value => throwIfNotValid(value, isVideoBlacklistTypeValid, 'type'))
   @Column
   type: VideoBlacklistType
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => VideoModel)
   @Column

--- a/server/models/video/video-caption.ts
+++ b/server/models/video/video-caption.ts
@@ -4,14 +4,12 @@ import {
   BeforeDestroy,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   ForeignKey,
   Is,
   Model,
   Scopes,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { buildWhereIdOrUUID, throwIfNotValid } from '../utils'
 import { VideoModel } from './video'
@@ -55,12 +53,6 @@ export enum ScopeNames {
   ]
 })
 export class VideoCaptionModel extends Model<VideoCaptionModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(false)
   @Is('VideoCaptionLanguage', value => throwIfNotValid(value, isVideoCaptionLanguageValid, 'language'))
   @Column

--- a/server/models/video/video-change-ownership.ts
+++ b/server/models/video/video-change-ownership.ts
@@ -1,4 +1,4 @@
-import { AllowNull, BelongsTo, Column, CreatedAt, ForeignKey, Model, Scopes, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, ForeignKey, Model, Scopes, Table } from 'sequelize-typescript'
 import { AccountModel } from '../account/account'
 import { ScopeNames as VideoScopeNames, VideoModel } from './video'
 import { VideoChangeOwnership, VideoChangeOwnershipStatus } from '../../../shared/models/videos'
@@ -54,12 +54,6 @@ enum ScopeNames {
   }
 }))
 export class VideoChangeOwnershipModel extends Model<VideoChangeOwnershipModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(false)
   @Column
   status: VideoChangeOwnershipStatus

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -3,7 +3,6 @@ import {
   BeforeDestroy,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   Default,
   DefaultScope,
@@ -13,8 +12,7 @@ import {
   Model,
   Scopes,
   Sequelize,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { ActivityPubActor } from '../../../shared/models/activitypub'
 import { VideoChannel, VideoChannelSummary } from '../../../shared/models/videos'
@@ -231,12 +229,6 @@ export class VideoChannelModel extends Model<VideoChannelModel> {
   @Is('VideoChannelSupport', value => throwIfNotValid(value, isVideoChannelSupportValid, 'support', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_CHANNELS.SUPPORT.max))
   support: string
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => ActorModel)
   @Column

--- a/server/models/video/video-comment.ts
+++ b/server/models/video/video-comment.ts
@@ -1,7 +1,7 @@
 import * as Bluebird from 'bluebird'
 import { uniq } from 'lodash'
 import { FindOptions, Op, Order, ScopeOptions, Sequelize, Transaction } from 'sequelize'
-import { AllowNull, BelongsTo, Column, CreatedAt, DataType, ForeignKey, Is, Model, Scopes, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, DataType, ForeignKey, Is, Model, Scopes, Table } from 'sequelize-typescript'
 import { getServerActor } from '@server/models/application/application'
 import { MAccount, MAccountId, MUserAccountId } from '@server/typings/models'
 import { VideoPrivacy } from '@shared/models'
@@ -153,12 +153,6 @@ enum ScopeNames {
   ]
 })
 export class VideoCommentModel extends Model<VideoCommentModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(true)
   @Column(DataType.DATE)
   deletedAt: Date

--- a/server/models/video/video-file.ts
+++ b/server/models/video/video-file.ts
@@ -2,7 +2,6 @@ import {
   AllowNull,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   Default,
   ForeignKey,
@@ -10,7 +9,6 @@ import {
   Is,
   Model,
   Table,
-  UpdatedAt,
   Scopes,
   DefaultScope
 } from 'sequelize-typescript'
@@ -102,12 +100,6 @@ export enum ScopeNames {
   ]
 })
 export class VideoFileModel extends Model<VideoFileModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(false)
   @Is('VideoFileResolution', value => throwIfNotValid(value, isVideoFileResolutionValid, 'resolution'))
   @Column

--- a/server/models/video/video-import.ts
+++ b/server/models/video/video-import.ts
@@ -3,15 +3,13 @@ import {
   AllowNull,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   Default,
   DefaultScope,
   ForeignKey,
   Is,
   Model,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { CONSTRAINTS_FIELDS, VIDEO_IMPORT_STATES } from '../../initializers/constants'
 import { getSort, throwIfNotValid } from '../utils'
@@ -53,12 +51,6 @@ import { MVideoImportDefault, MVideoImportFormattable } from '@server/typings/mo
   ]
 })
 export class VideoImportModel extends Model<VideoImportModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(true)
   @Default(null)
   @Is('VideoImportTargetUrl', value => throwIfNotValid(value, isVideoImportTargetUrlValid, 'targetUrl', true))

--- a/server/models/video/video-playlist-element.ts
+++ b/server/models/video/video-playlist-element.ts
@@ -2,7 +2,6 @@ import {
   AllowNull,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   Default,
   ForeignKey,
@@ -10,8 +9,7 @@ import {
   IsInt,
   Min,
   Model,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { ForAPIOptions, ScopeNames as VideoScopeNames, VideoModel } from './video'
 import { VideoPlaylistModel } from './video-playlist'
@@ -54,12 +52,6 @@ import { MUserAccountId } from '@server/typings/models'
   ]
 })
 export class VideoPlaylistElementModel extends Model<VideoPlaylistElementModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(false)
   @Is('VideoPlaylistUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'url'))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_PLAYLISTS.URL.max))

--- a/server/models/video/video-playlist.ts
+++ b/server/models/video/video-playlist.ts
@@ -2,7 +2,6 @@ import {
   AllowNull,
   BelongsTo,
   Column,
-  CreatedAt,
   DataType,
   Default,
   ForeignKey,
@@ -12,8 +11,7 @@ import {
   IsUUID,
   Model,
   Scopes,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { VideoPlaylistPrivacy } from '../../../shared/models/videos/playlist/video-playlist-privacy.model'
 import { buildServerIdsFollowedBy, buildWhereIdOrUUID, getSort, isOutdated, throwIfNotValid } from '../utils'
@@ -218,12 +216,6 @@ type AvailableForListOptions = {
   ]
 })
 export class VideoPlaylistModel extends Model<VideoPlaylistModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(false)
   @Is('VideoPlaylistName', value => throwIfNotValid(value, isVideoPlaylistNameValid, 'name'))
   @Column

--- a/server/models/video/video-share.ts
+++ b/server/models/video/video-share.ts
@@ -1,5 +1,5 @@
 import * as Bluebird from 'bluebird'
-import { AllowNull, BelongsTo, Column, CreatedAt, DataType, ForeignKey, Is, Model, Scopes, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, DataType, ForeignKey, Is, Model, Scopes, Table } from 'sequelize-typescript'
 import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
 import { CONSTRAINTS_FIELDS } from '../../initializers/constants'
 import { ActorModel } from '../activitypub/actor'
@@ -57,12 +57,6 @@ export class VideoShareModel extends Model<VideoShareModel> {
   @Is('VideoShareUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'url'))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_SHARE.URL.max))
   url: string
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @ForeignKey(() => ActorModel)
   @Column

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -1,4 +1,4 @@
-import { AllowNull, BelongsTo, Column, CreatedAt, DataType, ForeignKey, HasMany, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, DataType, ForeignKey, HasMany, Is, Model, Table } from 'sequelize-typescript'
 import { isVideoFileInfoHashValid } from '../../helpers/custom-validators/videos'
 import { throwIfNotValid } from '../utils'
 import { VideoModel } from './video'
@@ -41,12 +41,6 @@ import { logger } from '@server/helpers/logger'
   ]
 })
 export class VideoStreamingPlaylistModel extends Model<VideoStreamingPlaylistModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @AllowNull(false)
   @Column
   type: VideoStreamingPlaylistType

--- a/server/models/video/video-tag.ts
+++ b/server/models/video/video-tag.ts
@@ -1,9 +1,10 @@
-import { Column, CreatedAt, ForeignKey, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { Column, ForeignKey, Model, Table } from 'sequelize-typescript'
 import { TagModel } from './tag'
 import { VideoModel } from './video'
 
 @Table({
   tableName: 'videoTag',
+  timestamps: false,
   indexes: [
     {
       fields: [ 'videoId' ]
@@ -14,12 +15,6 @@ import { VideoModel } from './video'
   ]
 })
 export class VideoTagModel extends Model<VideoTagModel> {
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
-
   @ForeignKey(() => VideoModel)
   @Column
   videoId: number

--- a/server/models/video/video-views.ts
+++ b/server/models/video/video-views.ts
@@ -1,4 +1,4 @@
-import { AllowNull, BelongsTo, Column, CreatedAt, ForeignKey, Model, Table } from 'sequelize-typescript'
+import { AllowNull, BelongsTo, Column, ForeignKey, Model, Table } from 'sequelize-typescript'
 import { VideoModel } from './video'
 import * as Sequelize from 'sequelize'
 
@@ -15,9 +15,6 @@ import * as Sequelize from 'sequelize'
   ]
 })
 export class VideoViewModel extends Model<VideoViewModel> {
-  @CreatedAt
-  createdAt: Date
-
   @AllowNull(false)
   @Column(Sequelize.DATE)
   startDate: Date

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -8,7 +8,6 @@ import {
   BelongsTo,
   BelongsToMany,
   Column,
-  CreatedAt,
   DataType,
   Default,
   ForeignKey,
@@ -20,8 +19,7 @@ import {
   Min,
   Model,
   Scopes,
-  Table,
-  UpdatedAt
+  Table
 } from 'sequelize-typescript'
 import { UserRight, VideoPrivacy, VideoState, ResultList } from '../../../shared'
 import { VideoTorrentObject } from '../../../shared/models/activitypub/objects'
@@ -571,12 +569,6 @@ export class VideoModel extends Model<VideoModel> {
   @Is('VideoState', value => throwIfNotValid(value, isVideoStateValid, 'state'))
   @Column
   state: VideoState
-
-  @CreatedAt
-  createdAt: Date
-
-  @UpdatedAt
-  updatedAt: Date
 
   @AllowNull(false)
   @Default(DataType.NOW)


### PR DESCRIPTION
per [the Sequelize documentation relative to timestamps](https://sequelize.org/master/manual/model-basics.html#timestamps), `createdAt` and `updatedAt` are automatically created on models unless explicitly disabled, which we already do.