### PR TITLE
Remove uneccessary details to link titles

### DIFF
--- a/client/src/app/+admin/plugins/plugin-list-installed/plugin-list-installed.component.html
+++ b/client/src/app/+admin/plugins/plugin-list-installed/plugin-list-installed.component.html
@@ -14,11 +14,11 @@
 
         <span class="plugin-version">{{ plugin.version }}</span>
 
-        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="plugin.homepage" i18n-title title="Go to the plugin homepage">
+        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="plugin.homepage" i18n-title title="Plugin homepage (new window)">
           <my-global-icon iconName="home"></my-global-icon>
         </a>
 
-        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="'https://www.npmjs.com/package/peertube-plugin-' + plugin.name" i18n-title title="Go to the plugin homepage">
+        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="'https://www.npmjs.com/package/peertube-plugin-' + plugin.name" i18n-title title="Plugin homepage (new window)">
           <my-global-icon iconName="npm"></my-global-icon>
         </a>
 

--- a/client/src/app/+admin/plugins/plugin-search/plugin-search.component.html
+++ b/client/src/app/+admin/plugins/plugin-search/plugin-search.component.html
@@ -37,11 +37,11 @@
 
         <span class="plugin-version">{{ plugin.latestVersion }}</span>
 
-        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="plugin.homepage" i18n-title title="Go to the plugin homepage">
+        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="plugin.homepage" i18n-title title="Plugin homepage (new window)">
           <my-global-icon iconName="home"></my-global-icon>
         </a>
 
-        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="'https://www.npmjs.com/package/peertube-plugin-' + plugin.name" i18n-title title="Go to the plugin npm package">
+        <a class="plugin-icon" target="_blank" rel="noopener noreferrer" [href]="'https://www.npmjs.com/package/peertube-plugin-' + plugin.name" i18n-title title="Plugin npm package (new window)">
           <my-global-icon iconName="npm"></my-global-icon>
         </a>
 

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
@@ -25,13 +25,13 @@
   <ng-template pTemplate="body" let-videoChangeOwnership>
     <tr>
       <td>
-        <a [href]="videoChangeOwnership.initiatorAccount.url" i18n-title title="Go to the account"
+        <a [href]="videoChangeOwnership.initiatorAccount.url" i18n-title title="Account page"
            target="_blank" rel="noopener noreferrer">
           {{ createByString(videoChangeOwnership.initiatorAccount) }}
         </a>
       </td>
       <td>
-        <a [href]="videoChangeOwnership.video.url" i18n-title title="Go to the video" target="_blank" rel="noopener noreferrer">
+        <a [href]="videoChangeOwnership.video.url" i18n-title title="Video page" target="_blank" rel="noopener noreferrer">
           {{ videoChangeOwnership.video.name }}
         </a>
       </td>

--- a/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
+++ b/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
@@ -8,14 +8,14 @@
     </a>
 
     <div class="video-channel-info">
-      <a [routerLink]="[ '/video-channels', videoChannel.nameWithHost ]" class="video-channel-names" i18n-title title="Go to the channel">
+      <a [routerLink]="[ '/video-channels', videoChannel.nameWithHost ]" class="video-channel-names" i18n-title title="Channel page">
         <div class="video-channel-display-name">{{ videoChannel.displayName }}</div>
         <div class="video-channel-name">{{ videoChannel.nameWithHost }}</div>
       </a>
 
       <div i18n class="video-channel-followers">{{ videoChannel.followersCount }} subscribers</div>
 
-      <a [routerLink]="[ '/accounts', videoChannel.ownerBy ]" i18n-title title="Go the owner account page" class="actor-owner">
+      <a [routerLink]="[ '/accounts', videoChannel.ownerBy ]" i18n-title title="Owner account page" class="actor-owner">
         <span i18n>Created by {{ videoChannel.ownerBy }}</span>
         <img [src]="videoChannel.ownerAvatarUrl" alt="Owner account avatar" />
       </a>

--- a/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.html
+++ b/client/src/app/+my-account/my-account-video-channels/my-account-video-channels.component.html
@@ -13,7 +13,7 @@
     </a>
 
     <div class="video-channel-info">
-      <a [routerLink]="[ '/video-channels', videoChannel.nameWithHost ]" class="video-channel-names" i18n-title title="Go to the channel">
+      <a [routerLink]="[ '/video-channels', videoChannel.nameWithHost ]" class="video-channel-names" i18n-title title="Channel page">
         <div class="video-channel-display-name">{{ videoChannel.displayName }}</div>
         <div class="video-channel-name">{{ videoChannel.nameWithHost }}</div>
       </a>

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -8,7 +8,7 @@
     <div class="top-left-block">
       <span class="icon icon-menu" (click)="menu.toggleMenu()"></span>
 
-      <a class="peertube-title" [routerLink]="defaultRoute" title="Homepage" i18n-title>
+      <a class="peertube-title" [routerLink]="defaultRoute">
         <span class="icon icon-logo"></span>
         <span class="instance-name">{{ instanceName }}</span>
       </a>

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -168,9 +168,9 @@
 
         <div class="footer-copyleft">
           <small class="d-inline" i18n-title title="powered by PeerTube - CopyLeft 2015-2020">
-            <a href="https://joinpeertube.org" class="mr-1" i18n-title title="PeerTube website" target="_blank" rel="noopener noreferrer" i18n>powered by PeerTube</a>
+            <a href="https://joinpeertube.org" class="mr-1" target="_blank" rel="noopener noreferrer" i18n>powered by PeerTube</a>
 
-            <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" i18n-title title="PeerTube license" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" target="_blank" rel="noopener noreferrer">
               <span aria-label="copyleft" class="d-inline-block" style="transform: rotateY(180deg)">&copy;</span> 2015-2020
             </a>
           </small>

--- a/client/src/app/shared/channel/avatar.component.html
+++ b/client/src/app/shared/channel/avatar.component.html
@@ -1,8 +1,8 @@
 <div class="wrapper" [ngClass]="'avatar-' + size">
   <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" [title]="channelLinkTitle">
-    <img [src]="video.videoChannelAvatarUrl" alt="Channel avatar" />
+    <img [src]="video.videoChannelAvatarUrl" i18n-alt alt="Channel avatar" />
   </a>
   <a [routerLink]="[ '/accounts', video.byAccount ]" [title]="accountLinkTitle">
-    <img [src]="video.accountAvatarUrl" alt="Account avatar" />
+    <img [src]="video.accountAvatarUrl" i18n-alt alt="Account avatar" />
   </a>
 </div>

--- a/client/src/app/shared/channel/avatar.component.ts
+++ b/client/src/app/shared/channel/avatar.component.ts
@@ -20,11 +20,11 @@ export class AvatarComponent implements OnInit {
 
   ngOnInit () {
     this.channelLinkTitle = this.i18n(
-      'Go to the channel page of {{name}} ({{handle}})',
+      '{{name}} (channel page)',
       { name: this.video.channel.name, handle: this.video.byVideoChannel }
     )
     this.accountLinkTitle = this.i18n(
-      'Go to the account page of {{name}} ({{handle}})',
+      '{{name}} (account page)',
       { name: this.video.account.name, handle: this.video.byAccount }
     )
   }

--- a/client/src/app/shared/video/video-miniature.component.ts
+++ b/client/src/app/shared/video/video-miniature.component.ts
@@ -114,7 +114,7 @@ export class VideoMiniatureComponent implements OnInit {
     this.setUpBy()
 
     this.channelLinkTitle = this.i18n(
-      'Go to the channel page of {{name}} ({{handle}})',
+      '{{name}} (channel page)',
       { name: this.video.channel.name, handle: this.video.byVideoChannel }
     )
 

--- a/client/src/app/videos/+video-watch/video-watch.component.html
+++ b/client/src/app/videos/+video-watch/video-watch.component.html
@@ -147,10 +147,10 @@
               <avatar-channel [video]="video"></avatar-channel>
 
               <div class="video-info-channel-left-links ml-1">
-                <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" i18n-title title="Go the channel page">
+                <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" i18n-title title="Channel page">
                   {{ video.channel.displayName }}
                 </a>
-                <a [routerLink]="[ '/accounts', video.byAccount ]" i18n-title title="Go to the account page">
+                <a [routerLink]="[ '/accounts', video.byAccount ]" i18n-title title="Account page">
                   <span i18n>By {{ video.byAccount }}</span>
                 </a>
               </div>

--- a/client/src/assets/player/videojs-components/peertube-link-button.ts
+++ b/client/src/assets/player/videojs-components/peertube-link-button.ts
@@ -24,7 +24,7 @@ class PeerTubeLinkButton extends Button {
     const el = videojs.dom.createEl('a', {
       href: buildVideoLink(),
       innerHTML: 'PeerTube',
-      title: this.player().localize('Go to the video page'),
+      title: this.player().localize('Video page (new window)'),
       className: 'vjs-peertube-link',
       target: '_blank'
     })


### PR DESCRIPTION
This PR will improve a11y with short link title when needed.
Link title should not have verb like "go to" for screen readers.

More improving should be done with all the target="_blank" attribute on another PR with either (new window) in title/text or adding a new window icon with css :) 