### PR TITLE
switch from `apicache` to `apicache-plus` to unblock nodejs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Feel free to reach out if you have any questions or ideas! :speech_balloon:
   * nginx
   * **PostgreSQL >= 9.6**
   * **Redis >= 2.8.18**
-  * **NodeJS >= 10.x**
+  * **NodeJS >= 10.x <15**
   * **yarn >= 1.x**
   * **FFmpeg >= 3.x**
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "licence": "AGPL-3.0",
   "engines": {
-    "node": ">=10.x <13",
+    "node": ">=10.x <15",
     "yarn": ">=1.x"
   },
   "bin": {
@@ -83,7 +83,7 @@
     "http-signature": "1.3.4"
   },
   "dependencies": {
-    "apicache": "^1.4.0",
+    "apicache-plus": "^2.1.3",
     "async": "^3.0.1",
     "async-lru": "^1.1.1",
     "bcrypt": "5.0.0",

--- a/server/middlewares/cache.ts
+++ b/server/middlewares/cache.ts
@@ -1,21 +1,24 @@
 import { Redis } from '../lib/redis'
-import * as apicache from 'apicache'
+import * as apicache from 'apicache-plus'
 
 // Ensure Redis is initialized
 Redis.Instance.init()
 
 const defaultOptions = {
   redisClient: Redis.Instance.getClient(),
-  appendKey: () => Redis.Instance.getPrefix(),
+  append: () => Redis.Instance.getPrefix(),
   statusCodes: {
     exclude: [ 404, 403 ]
+  },
+  headers: {
+    'cache-control': 'no-transform' // disable compression of cache contents
   }
 }
 
 const cacheRoute = (extraOptions = {}) => apicache.options({
   ...defaultOptions,
   ...extraOptions
-}).middleware
+})
 
 // ---------------------------------------------------------------------------
 

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -27,7 +27,7 @@
 
 3. Install certbot (choose instructions for nginx and your distribution) :    
 [https://certbot.eff.org/all-instructions](https://certbot.eff.org/all-instructions)
-4. Install NodeJS 10.x:    
+4. Install NodeJS 10.x:
 [https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)
 5. Install yarn, and be sure to have [a recent version](https://github.com/yarnpkg/yarn/releases/latest):    
 [https://yarnpkg.com/en/docs/install#linux-tab](https://yarnpkg.com/en/docs/install#linux-tab)

--- a/support/doc/tools.md
+++ b/support/doc/tools.md
@@ -39,7 +39,7 @@ You need to follow all the following steps even if you are on a PeerTube server 
 ### Dependencies
 
 Install the [PeerTube dependencies](dependencies.md) except PostgreSQL and Redis.
-PeerTube only supports NodeJS 10.x.
+PeerTube only supports NodeJS 10.x up to 14.x (included).
 
 ### Installation
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,7 +880,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.4, accepts@~1.3.7:
+accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -1021,10 +1021,16 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apicache@^1.4.0:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/apicache/-/apicache-1.5.3.tgz#8977b358bf7d579d55fe3d183c907ae5dbcfb357"
-  integrity sha512-n1h39Bt7tMiJMV0u0tFlhigig8Uo/wJmKoj6WE/OwvZ+WbFchn7jnXleotZOzZTUBtr0Tg9iJshHnJDAGQbAEQ==
+apicache-plus@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/apicache-plus/-/apicache-plus-2.1.3.tgz#950010d28608ea74abe802282ea52e18fe74c387"
+  integrity sha512-2Frg/+7GmXlCasW0ejvZGTuFLQ31di9XtVZJZ8EcU0d+QMcKv2/WSZCZgqkDLyUKhuOqwAILKExQZpbynjPDWg==
+  dependencies:
+    accepts "^1.3.7"
+    compressible "^2.0.18"
+    json.sortify "^2.2.2"
+    redlock "^4.1.0"
+    uuid "^8.0.0"
 
 append-field@^1.0.0:
   version "1.0.0"
@@ -1404,7 +1410,7 @@ bluebird@^2.10.0:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
-bluebird@^3.0.5, bluebird@^3.1.1, bluebird@^3.5.0, bluebird@^3.5.1:
+bluebird@^3.0.5, bluebird@^3.1.1, bluebird@^3.3.3, bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -2009,6 +2015,13 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
   integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
+
+compressible@^2.0.18:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
+  integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
+  dependencies:
+    mime-db ">= 1.43.0 < 2"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -4306,6 +4319,11 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json.sortify@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json.sortify/-/json.sortify-2.2.2.tgz#1ade7704581c469aaf3f021350d174d1c5617276"
+  integrity sha512-wwFLdDffs747s5cqLA3htIKp9wdID2rWNofJKxwDjFo+rqqt5Vg7SnYOh7mc7MW6Iw43rrOFhr6MKytOtNceSA==
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -4870,7 +4888,7 @@ methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-mime-db@1.44.0:
+mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
@@ -6445,6 +6463,13 @@ redis@^3.0.2:
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
 
+redlock@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/redlock/-/redlock-4.1.0.tgz#2c8d6a348d1b8a10af61574fa3664eced003babc"
+  integrity sha512-6EdtGpk5aoZZJtclZGHAd77OJmBtMekD0t8fWUbBsm53pqHwLP+EqAEn3+a6lG+VZzClwjkLbePxpNaP1deGXw==
+  dependencies:
+    bluebird "^3.3.3"
+
 referrer-policy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.2.0.tgz#b99cfb8b57090dc454895ef897a4cc35ef67a98e"
@@ -7885,7 +7910,7 @@ uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.1.0:
+uuid@^8.0.0, uuid@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
   integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==


### PR DESCRIPTION
[apicache](https://github.com/kwhitley/apicache/) seems loosely maintained, especially regarding the support for nodejs 13 & 14. Hopefully, someone took care of the package and published it as [apicache-plus](https://github.com/arthurfranca/apicache-plus), retaining retro-compatibility and adding the lacking engine support.

fixes #2700