### PR TITLE
link to third-party-application raw list in noscript

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -32,7 +32,7 @@
 
       <p>There might be numerous reasons you refuse to use JavaScript. If it just has to do with security (or lack thereof) of JavaScript-based web applications, then depending on your threat menace you might want to go through the code running on the node you are trying to access, and look for security audits.</p>
 
-      <p>There will be other non JS-based clients to access PeerTube, but for now none is available. Be sure we will update this page with a list once alternative clients are developed. You can certainly develop your own in the meantime as our code is open source and libre software under the <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" target="_blank" rel="noopener">GNU AGPLv3.0</a> and documented on <a href="https://docs.joinpeertube.org/api-rest-reference.html">docs.joinpeertube.org</a>.</p>
+      <p>There are other non JS-based unofficial clients to access PeerTube. You can find the list on <a href="https://docs.joinpeertube.org/#/use-third-party-application">the "Third party applications" PeerTube documentation page</a>, but it also requires JavScript. The raw file can be found <a href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md">here</a>. You can also develop your own as our code is open source and libre software under the <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" target="_blank" rel="noopener">GNU AGPLv3.0</a> and documented on <a href="https://docs.joinpeertube.org/api-rest-reference.html">docs.joinpeertube.org</a>.</p>
     </noscript>
 
     <div id="incompatible-browser" class="alert alert-danger" style="display: none">

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -32,7 +32,7 @@
 
       <p>There might be numerous reasons you refuse to use JavaScript. If it just has to do with security (or lack thereof) of JavaScript-based web applications, then depending on your threat menace you might want to go through the code running on the node you are trying to access, and look for security audits.</p>
 
-      <p>There are other non JS-based unofficial clients to access PeerTube. You can find the list on <a href="https://docs.joinpeertube.org/#/use-third-party-application">the "Third party applications" PeerTube documentation page</a>, but it also requires JavScript. The raw file can be found <a href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md">here</a>. You can also develop your own as our code is open source and libre software under the <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" target="_blank" rel="noopener">GNU AGPLv3.0</a> and documented on <a href="https://docs.joinpeertube.org/api-rest-reference.html">docs.joinpeertube.org</a>.</p>
+      <p>There are other non JS-based unofficial clients to access PeerTube. You can find a list maintained by the PeerTube project in <a href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md">the thid-party applications section</a>. You can also develop your own as our code is open source and libre software under the <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" target="_blank" rel="noopener">GNU AGPLv3.0</a> and documented on <a href="https://docs.joinpeertube.org/api-rest-reference.html">docs.joinpeertube.org</a>.</p>
     </noscript>
 
     <div id="incompatible-browser" class="alert alert-danger" style="display: none">


### PR DESCRIPTION
I updated the noscript tag and linked available third party applications for PeerTube, with both official doc link and the raw file because the documentation also requires JavaScript to be enabled.

Should we keep the 

> You can also develop your own as our code is open source and libre software under the <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" target="_blank" rel="noopener">GNU AGPLv3.0</a> and documented on <a href="https://docs.joinpeertube.org/api-rest-reference.html">docs.joinpeertube.org</a>. 

part ?