### PR TITLE
Add ability to override client assets : logo - favicon - PWA icons - PWA manifest name and description

### DIFF
--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -62,7 +62,7 @@
 
       .icon.icon-logo {
         display: inline-block;
-        background: url('../assets/images/logo.svg') no-repeat;
+        background-repeat: no-repeat;
         width: 23px;
         height: 24px;
         margin-right: .5rem;

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -7,14 +7,14 @@
     <meta name="theme-color" content="#fff" />
     <meta property="og:platform" content="PeerTube" />
     <!-- Web Manifest file -->
-    <link rel="manifest" href="/manifest.webmanifest">
+    <link rel="manifest" href="/manifest.webmanifest?[manifestContentHash]">
 
-    <link rel="icon" type="image/png" href="/client/assets/images/favicon.png" />
+    <link rel="icon" type="image/png" href="/client/assets/images/favicon.png?[faviconContentHash]" />
 
     <!-- logo background-image -->
     <style type="text/css">
       .icon-logo {
-        background-image: url(/client/assets/images/logo.svg);
+        background-image: url(/client/assets/images/logo.svg?[logoContentHash]);
       }
     </style>
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -11,6 +11,13 @@
 
     <link rel="icon" type="image/png" href="/client/assets/images/favicon.png" />
 
+    <!-- logo background-image -->
+    <style type="text/css">
+      .icon-logo {
+        background-image: url(/client/assets/images/logo.svg);
+      }
+    </style>
+
     <!-- base url -->
     <base href="/">
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -85,6 +85,11 @@ storage:
   captions: 'storage/captions/'
   cache: 'storage/cache/'
   plugins: 'storage/plugins/'
+  # Overridable client files : logo.svg, favicon.png and icons/*.png (PWA) in client/dist/assets/images
+  # Could contain for example assets/images/favicon.png
+  # If the file exists, peertube will serve it
+  # If not, peertube will fallback to the default fil
+  client_overrides: 'storage/client-overrides/'
 
 log:
   level: 'info' # debug/info/warning/error

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -86,6 +86,11 @@ storage:
   captions: '/var/www/peertube/storage/captions/'
   cache: '/var/www/peertube/storage/cache/'
   plugins: '/var/www/peertube/storage/plugins/'
+  # Overridable client files : logo.svg, favicon.png and icons/*.png (PWA) in client/dist/assets/images
+  # Could contain for example assets/images/favicon.png
+  # If the file exists, peertube will serve it
+  # If not, peertube will fallback to the default fil
+  client_overrides: '/var/www/peertube/storage/client-overrides/'
 
 log:
   level: 'info' # debug/info/warning/error

--- a/config/test-1.yaml
+++ b/config/test-1.yaml
@@ -22,6 +22,7 @@ storage:
   captions: 'test1/captions/'
   cache: 'test1/cache/'
   plugins: 'test1/plugins/'
+  client_overrides: 'test1/client-overrides/'
 
 admin:
   email: 'admin1@example.com'

--- a/config/test-2.yaml
+++ b/config/test-2.yaml
@@ -22,6 +22,7 @@ storage:
   captions: 'test2/captions/'
   cache: 'test2/cache/'
   plugins: 'test2/plugins/'
+  client_overrides: 'test2/client-overrides/'
 
 admin:
   email: 'admin2@example.com'

--- a/config/test-3.yaml
+++ b/config/test-3.yaml
@@ -22,6 +22,7 @@ storage:
   captions: 'test3/captions/'
   cache: 'test3/cache/'
   plugins: 'test3/plugins/'
+  client_overrides: 'test3/client-overrides/'
 
 admin:
   email: 'admin3@example.com'

--- a/config/test-4.yaml
+++ b/config/test-4.yaml
@@ -22,6 +22,7 @@ storage:
   captions: 'test4/captions/'
   cache: 'test4/cache/'
   plugins: 'test4/plugins/'
+  client_overrides: 'test4/client-overrides/'
 
 admin:
   email: 'admin4@example.com'

--- a/config/test-5.yaml
+++ b/config/test-5.yaml
@@ -22,6 +22,7 @@ storage:
   captions: 'test5/captions/'
   cache: 'test5/cache/'
   plugins: 'test5/plugins/'
+  client_overrides: 'test5/client-overrides/'
 
 admin:
   email: 'admin5@example.com'

--- a/config/test-6.yaml
+++ b/config/test-6.yaml
@@ -22,6 +22,7 @@ storage:
   captions: 'test6/captions/'
   cache: 'test6/cache/'
   plugins: 'test6/plugins/'
+  client_overrides: 'test6/client-overrides/'
 
 admin:
   email: 'admin6@example.com'

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -41,7 +41,6 @@ clientsRouter.use(
 
 // Static HTML/CSS/JS client files
 const staticClientFiles = [
-  'manifest.webmanifest',
   'ngsw-worker.js',
   'ngsw.json'
 ]
@@ -53,6 +52,9 @@ for (const staticClientFile of staticClientFiles) {
     res.sendFile(path, { maxAge: STATIC_MAX_AGE.SERVER })
   })
 }
+
+// Dynamic PWA manifest
+clientsRouter.get('/manifest.webmanifest', asyncMiddleware(generateManifest))
 
 // Static client overrides
 const staticClientOverrides = [
@@ -148,6 +150,18 @@ function sendHTML (html: string, res: express.Response) {
   res.set('Content-Type', 'text/html; charset=UTF-8')
 
   return res.send(html)
+}
+
+async function generateManifest (req: express.Request, res: express.Response) {
+  const manifestPhysicalPath = join(root(), 'client', 'dist', 'manifest.webmanifest')
+  const manifestJson = await fs.readFile(manifestPhysicalPath, 'utf8')
+  const manifest = JSON.parse(manifestJson)
+
+  manifest.name = CONFIG.INSTANCE.NAME
+  manifest.short_name = CONFIG.INSTANCE.NAME
+  manifest.description = CONFIG.INSTANCE.SHORT_DESCRIPTION
+
+  res.json(manifest)
 }
 
 function serveClientOverride (path: string) {

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -68,7 +68,8 @@ const CONFIG = {
     CAPTIONS_DIR: buildPath(config.get<string>('storage.captions')),
     TORRENTS_DIR: buildPath(config.get<string>('storage.torrents')),
     CACHE_DIR: buildPath(config.get<string>('storage.cache')),
-    PLUGINS_DIR: buildPath(config.get<string>('storage.plugins'))
+    PLUGINS_DIR: buildPath(config.get<string>('storage.plugins')),
+    CLIENT_OVERRIDES_DIR: buildPath(config.get<string>('storage.client_overrides'))
   },
   WEBSERVER: {
     SCHEME: config.get<boolean>('webserver.https') === true ? 'https' : 'http',

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -1,4 +1,5 @@
 import { join } from 'path'
+import { randomBytes } from 'crypto'
 import { JobType, VideoRateType, VideoResolution, VideoState } from '../../shared/models'
 import { ActivityPubActorType } from '../../shared/models/activitypub'
 import { FollowState } from '../../shared/models/actors'
@@ -709,6 +710,14 @@ registerConfigChangedHandler(() => {
 
 // ---------------------------------------------------------------------------
 
+const FILES_CONTENT_HASH = {
+  MANIFEST: generateContentHash(),
+  FAVICON: generateContentHash(),
+  LOGO: generateContentHash()
+}
+
+// ---------------------------------------------------------------------------
+
 export {
   WEBSERVER,
   API_VERSION,
@@ -791,8 +800,10 @@ export {
   VIDEO_PLAYLIST_PRIVACIES,
   PLUGIN_EXTERNAL_AUTH_TOKEN_LIFETIME,
   ASSETS_PATH,
+  FILES_CONTENT_HASH,
   loadLanguages,
-  buildLanguages
+  buildLanguages,
+  generateContentHash
 }
 
 // ---------------------------------------------------------------------------
@@ -893,4 +904,8 @@ function buildLanguages () {
   languages['el'] = 'Greek'
 
   return languages
+}
+
+function generateContentHash () {
+  return randomBytes(20).toString('hex')
 }

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { buildFileLocale, getDefaultLocale, is18nLocale, POSSIBLE_LOCALES } from '../../shared/models/i18n/i18n'
-import { CUSTOM_HTML_TAG_COMMENTS, EMBED_SIZE, PLUGIN_GLOBAL_CSS_PATH, WEBSERVER } from '../initializers/constants'
+import { CUSTOM_HTML_TAG_COMMENTS, EMBED_SIZE, PLUGIN_GLOBAL_CSS_PATH, WEBSERVER, FILES_CONTENT_HASH } from '../initializers/constants'
 import { join } from 'path'
 import { escapeHTML, sha256 } from '../helpers/core-utils'
 import { VideoModel } from '../models/video/video'
@@ -101,6 +101,9 @@ export class ClientHtml {
     let html = buffer.toString()
 
     if (paramLang) html = ClientHtml.addHtmlLang(html, paramLang)
+    html = ClientHtml.addManifestContentHash(html)
+    html = ClientHtml.addFaviconContentHash(html)
+    html = ClientHtml.addLogoContentHash(html)
     html = ClientHtml.addCustomCSS(html)
     html = await ClientHtml.addAsyncPluginCSS(html)
 
@@ -134,6 +137,18 @@ export class ClientHtml {
 
   private static addHtmlLang (htmlStringPage: string, paramLang: string) {
     return htmlStringPage.replace('<html>', `<html lang="${paramLang}">`)
+  }
+
+  private static addManifestContentHash (htmlStringPage: string) {
+    return htmlStringPage.replace('[manifestContentHash]', FILES_CONTENT_HASH.MANIFEST)
+  }
+
+  private static addFaviconContentHash(htmlStringPage: string) {
+    return htmlStringPage.replace('[faviconContentHash]', FILES_CONTENT_HASH.FAVICON)
+  }
+
+  private static addLogoContentHash(htmlStringPage: string) {
+    return htmlStringPage.replace('[logoContentHash]', FILES_CONTENT_HASH.LOGO)
   }
 
   private static addTitleTag (htmlStringPage: string, title?: string) {

--- a/support/docker/production/config/production.yaml
+++ b/support/docker/production/config/production.yaml
@@ -54,6 +54,11 @@ storage:
   captions: '../data/captions/'
   cache: '../data/cache/'
   plugins: '../data/plugins/'
+  # Overridable client files : logo.svg, favicon.png and icons/*.png (PWA) in client/dist/assets/images
+  # Could contain for example assets/images/favicon.png
+  # If the file exists, peertube will serve it
+  # If not, peertube will fallback to the default fil
+  client_overrides: '../data/client-overrides/'
 
 log:
   level: 'info' # debug/info/warning/error


### PR DESCRIPTION
This PR allows to customize main assets like logo, favicon and PWA icons, PWA manifest name and description :

- [x] Add client-overrides directory storage to config files ; 
- [x] Serve overrides files (logo, favicon, PWA icons) from client-overrides dir with dist dir as fallback ;
- [x] Move logo `background-image` from CSS bundle to `<style>` tag header in `index.html` ;
- [x] Handle cache for all overrides files with a querystring `?[fileContentHash]`  ;
- [x] Make the PWA manifest a dynamic JSON to update `description`, `name`, `short_name` with instance config ;
~Add ability in the admin panel to upload a SVG / PNG logo and generate favicon - PWA icons.~

To test it the client must be built with `npm run clean:client` and `npm run dev:server`