### PR TITLE
Add database.name config option

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -33,7 +33,7 @@ rates_limit:
 trust_proxy:
   - 'loopback'
 
-# Your database name will be "peertube"+database.suffix
+# Your database name will be database.name OR "peertube"+database.suffix
 database:
   hostname: 'localhost'
   port: 5432

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -32,7 +32,7 @@ rates_limit:
 trust_proxy:
   - 'loopback'
 
-# Your database name will be "peertube"+database.suffix
+# Your database name will be database.name OR "peertube"+database.suffix
 database:
   hostname: 'localhost'
   port: 5432

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -20,7 +20,7 @@ const CONFIG = {
     HOSTNAME: config.get<string>('listen.hostname')
   },
   DATABASE: {
-    DBNAME: 'peertube' + config.get<string>('database.suffix'),
+    DBNAME: config.has('database.name') ? config.get<string>('database.name') : 'peertube' + config.get<string>('database.suffix'),
     HOSTNAME: config.get<string>('database.hostname'),
     PORT: config.get<number>('database.port'),
     USERNAME: config.get<string>('database.username'),

--- a/support/docker/production/config/production.yaml
+++ b/support/docker/production/config/production.yaml
@@ -26,7 +26,7 @@ trust_proxy:
   - 'linklocal'
   - 'uniquelocal'
 
-# Your database name will be "peertube"+database.suffix
+# Your database name will be database.name or "peertube"+database.suffix
 database:
   hostname: 'postgres'
   port: 5432


### PR DESCRIPTION
If database.name is set, we use it as the complete database name.
If unset, we use the "peertube"+database.suffix as the complete database
name.

Fixes #1620