### PR TITLE
remove Code of Conduct, add DMCA instead

### DIFF
--- a/client/src/app/+about/about-instance/about-instance.component.html
+++ b/client/src/app/+about/about-instance/about-instance.component.html
@@ -67,7 +67,7 @@
       <div [innerHTML]="html.moderationInformation"></div>
     </div>
 
-    <div class="block DMCA" *ngIf="html.DMCA">
+    <div class="block dmca-policy" *ngIf="html.DMCA">
       <h3 i18n class="section-title">DMCA</h3>
 
       <div [innerHTML]="html.DMCA"></div>

--- a/client/src/app/+about/about-instance/about-instance.component.html
+++ b/client/src/app/+about/about-instance/about-instance.component.html
@@ -57,7 +57,7 @@
       <div [innerHTML]="html.description"></div>
     </div>
 
-    <h2 i18n class="middle-title" *ngIf="html.moderationInformation || html.codeOfConduct || html.terms">
+    <h2 i18n class="middle-title" *ngIf="html.moderationInformation || html.DMCA || html.terms">
       MODERATION
     </h2>
 
@@ -67,10 +67,10 @@
       <div [innerHTML]="html.moderationInformation"></div>
     </div>
 
-    <div class="block code-of-conduct" *ngIf="html.codeOfConduct">
-      <h3 i18n class="section-title">Code of conduct</h3>
+    <div class="block DMCA" *ngIf="html.DMCA">
+      <h3 i18n class="section-title">DMCA</h3>
 
-      <div [innerHTML]="html.codeOfConduct"></div>
+      <div [innerHTML]="html.DMCA"></div>
     </div>
 
     <div class="block terms">

--- a/client/src/app/+about/about-instance/about-instance.component.ts
+++ b/client/src/app/+about/about-instance/about-instance.component.ts
@@ -20,7 +20,7 @@ export class AboutInstanceComponent implements OnInit, AfterViewChecked {
   html = {
     description: '',
     terms: '',
-    codeOfConduct: '',
+    DMCA: '',
     moderationInformation: '',
     administrator: '',
     hardwareInformation: ''

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -128,12 +128,12 @@
               </div>
 
               <div class="form-group">
-                <label i18n for="instanceCodeOfConduct">Code of conduct</label><my-help helpType="markdownText"></my-help>
+                <label i18n for="instanceDMCA">DMCA</label><my-help helpType="markdownText"></my-help>
                 <my-markdown-textarea
-                  name="instanceCodeOfConduct" formControlName="codeOfConduct" textareaMaxWidth="500px"
-                  [ngClass]="{ 'input-error': formErrors['instance.codeOfConduct'] }"
+                  name="instanceDMCA" formControlName="DMCA" textareaMaxWidth="500px"
+                  [ngClass]="{ 'input-error': formErrors['instance.DMCA'] }"
                 ></my-markdown-textarea>
-                <div *ngIf="formErrors.instance.codeOfConduct" class="form-error">{{ formErrors.instance.codeOfConduct }}</div>
+                <div *ngIf="formErrors.instance.DMCA" class="form-error">{{ formErrors.instance.DMCA }}</div>
               </div>
 
               <div class="form-group">

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
@@ -115,7 +115,7 @@ export class EditCustomConfigComponent extends FormReactive implements OnInit, A
         defaultNSFWPolicy: null,
 
         terms: null,
-        codeOfConduct: null,
+        DMCA: null,
 
         creationReason: null,
         moderationInformation: null,

--- a/client/src/app/+signup/+register/register-step-user.component.html
+++ b/client/src/app/+signup/+register/register-step-user.component.html
@@ -65,7 +65,7 @@
         <ng-container i18n>
           I am at least 16 years old and agree
           to the <a (click)="onTermsClick($event)" href='#'>Terms</a>
-          <ng-container *ngIf="hasCodeOfConduct"> and to the <a (click)="onCodeOfConductClick($event)" href='#'>Code of Conduct</a></ng-container>
+          <ng-container *ngIf="hasDMCA"> and to the <a (click)="onDMCAClick($event)" href='#'>DMCA</a></ng-container>
           of this instance
         </ng-container>
       </ng-template>

--- a/client/src/app/+signup/+register/register-step-user.component.ts
+++ b/client/src/app/+signup/+register/register-step-user.component.ts
@@ -11,11 +11,11 @@ import { FormReactive, FormValidatorService, UserValidatorsService } from '@app/
   styleUrls: [ './register.component.scss' ]
 })
 export class RegisterStepUserComponent extends FormReactive implements OnInit {
-  @Input() hasCodeOfConduct = false
+  @Input() hasDMCA = false
 
   @Output() formBuilt = new EventEmitter<FormGroup>()
   @Output() termsClick = new EventEmitter<void>()
-  @Output() codeOfConductClick = new EventEmitter<void>()
+  @Output() DMCAClick = new EventEmitter<void>()
 
   constructor (
     protected formValidatorService: FormValidatorService,
@@ -52,9 +52,9 @@ export class RegisterStepUserComponent extends FormReactive implements OnInit {
     this.termsClick.emit()
   }
 
-  onCodeOfConductClick (event: Event) {
+  onDMCAClick (event: Event) {
     event.preventDefault()
-    this.codeOfConductClick.emit()
+    this.DMCAClick.emit()
   }
 
   private onDisplayNameChange (oldDisplayName: string, newDisplayName: string) {

--- a/client/src/app/+signup/+register/register.component.html
+++ b/client/src/app/+signup/+register/register.component.html
@@ -79,7 +79,7 @@
             </ng-template>
           </ngb-panel>
 
-          <ngb-panel *ngIf="aboutHtml.DMCA" id="dmca_policy" i18n-title title="DMCA">
+          <ngb-panel *ngIf="aboutHtml.DMCA" id="dmca-policy" i18n-title title="DMCA">
             <ng-template ngbPanelContent>
               <div class="block" [innerHTML]="aboutHtml.DMCA"></div>
             </ng-template>

--- a/client/src/app/+signup/+register/register.component.html
+++ b/client/src/app/+signup/+register/register.component.html
@@ -12,8 +12,8 @@
       <my-custom-stepper linear *ngIf="!signupDone">
         <cdk-step [stepControl]="formStepUser" i18n-label label="User">
           <my-register-step-user
-            [hasCodeOfConduct]="!!aboutHtml.codeOfConduct"
-            (formBuilt)="onUserFormBuilt($event)" (termsClick)="onTermsClick()" (codeOfConductClick)="onCodeOfConductClick()"
+            [hasDMCA]="!!aboutHtml.DMCA"
+            (formBuilt)="onUserFormBuilt($event)" (termsClick)="onTermsClick()" (DMCAClick)="onDMCAClick()"
           >
           </my-register-step-user>
 
@@ -79,9 +79,9 @@
             </ng-template>
           </ngb-panel>
 
-          <ngb-panel *ngIf="aboutHtml.codeOfConduct" id="code-of-conduct" i18n-title title="Code of conduct">
+          <ngb-panel *ngIf="aboutHtml.DMCA" id="DMCA" i18n-title title="DMCA">
             <ng-template ngbPanelContent>
-              <div class="block" [innerHTML]="aboutHtml.codeOfConduct"></div>
+              <div class="block" [innerHTML]="aboutHtml.DMCA"></div>
             </ng-template>
           </ngb-panel>
 

--- a/client/src/app/+signup/+register/register.component.html
+++ b/client/src/app/+signup/+register/register.component.html
@@ -79,7 +79,7 @@
             </ng-template>
           </ngb-panel>
 
-          <ngb-panel *ngIf="aboutHtml.DMCA" id="DMCA" i18n-title title="DMCA">
+          <ngb-panel *ngIf="aboutHtml.DMCA" id="dmca_policy" i18n-title title="DMCA">
             <ng-template ngbPanelContent>
               <div class="block" [innerHTML]="aboutHtml.DMCA"></div>
             </ng-template>

--- a/client/src/app/+signup/+register/register.component.ts
+++ b/client/src/app/+signup/+register/register.component.ts
@@ -97,7 +97,7 @@ export class RegisterComponent implements OnInit {
   }
 
   onDMCAClick () {
-    if (this.accordion) this.accordion.toggle('DMCA')
+    if (this.accordion) this.accordion.toggle('dmca-policy')
   }
 
   async signup () {

--- a/client/src/app/+signup/+register/register.component.ts
+++ b/client/src/app/+signup/+register/register.component.ts
@@ -26,7 +26,7 @@ export class RegisterComponent implements OnInit {
   aboutHtml = {
     description: '',
     terms: '',
-    codeOfConduct: '',
+    DMCA: '',
     moderationInformation: '',
     administrator: ''
   }
@@ -96,8 +96,8 @@ export class RegisterComponent implements OnInit {
     if (this.accordion) this.accordion.toggle('terms')
   }
 
-  onCodeOfConductClick () {
-    if (this.accordion) this.accordion.toggle('code-of-conduct')
+  onDMCAClick () {
+    if (this.accordion) this.accordion.toggle('DMCA')
   }
 
   async signup () {

--- a/client/src/app/shared/shared-instance/instance.service.ts
+++ b/client/src/app/shared/shared-instance/instance.service.ts
@@ -41,7 +41,7 @@ export class InstanceService {
     const html = {
       description: '',
       terms: '',
-      codeOfConduct: '',
+      DMCA: '',
       moderationInformation: '',
       administrator: '',
       hardwareInformation: ''

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -260,7 +260,7 @@ instance:
   short_description: 'PeerTube, an ActivityPub-federated video streaming platform using P2P directly in your web browser.'
   description: 'Welcome to this PeerTube instance!' # Support markdown
   terms: 'No terms for now.' # Support markdown
-  code_of_conduct: '' # Supports markdown
+  DMCA: '' # Supports markdown
 
   # Who moderates the instance? What is the policy regarding NSFW videos? Political videos? etc
   moderation_information: '' # Supports markdown

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -260,7 +260,7 @@ instance:
   short_description: 'PeerTube, an ActivityPub-federated video streaming platform using P2P directly in your web browser.'
   description: 'Welcome to this PeerTube instance!' # Support markdown
   terms: 'No terms for now.' # Support markdown
-  DMCA: '' # Supports markdown
+  dmca_policy: '' # Supports markdown
 
   # Who moderates the instance? What is the policy regarding NSFW videos? Political videos? etc
   moderation_information: '' # Supports markdown

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -275,7 +275,7 @@ instance:
   short_description: 'PeerTube, a federated (ActivityPub) video streaming platform using P2P (BitTorrent) directly in the web browser with WebTorrent and Angular.'
   description: 'Welcome to this PeerTube instance!' # Support markdown
   terms: 'No terms for now.' # Support markdown
-  DMCA: '' # Supports markdown
+  dmca_policy: '' # Supports markdown
 
   # Who moderates the instance? What is the policy regarding NSFW videos? Political videos? etc
   moderation_information: '' # Supports markdown

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -275,7 +275,7 @@ instance:
   short_description: 'PeerTube, a federated (ActivityPub) video streaming platform using P2P (BitTorrent) directly in the web browser with WebTorrent and Angular.'
   description: 'Welcome to this PeerTube instance!' # Support markdown
   terms: 'No terms for now.' # Support markdown
-  code_of_conduct: '' # Supports markdown
+  DMCA: '' # Supports markdown
 
   # Who moderates the instance? What is the policy regarding NSFW videos? Political videos? etc
   moderation_information: '' # Supports markdown

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -198,7 +198,7 @@ function getAbout (req: express.Request, res: express.Response) {
       shortDescription: CONFIG.INSTANCE.SHORT_DESCRIPTION,
       description: CONFIG.INSTANCE.DESCRIPTION,
       terms: CONFIG.INSTANCE.TERMS,
-      DMCA: CONFIG.INSTANCE.DMCA,
+      DMCA: CONFIG.INSTANCE.DMCA_POLICY,
 
       hardwareInformation: CONFIG.INSTANCE.HARDWARE_INFORMATION,
 
@@ -338,7 +338,7 @@ function customConfig (): CustomConfig {
       shortDescription: CONFIG.INSTANCE.SHORT_DESCRIPTION,
       description: CONFIG.INSTANCE.DESCRIPTION,
       terms: CONFIG.INSTANCE.TERMS,
-      DMCA: CONFIG.INSTANCE.DMCA,
+      DMCA: CONFIG.INSTANCE.DMCA_POLICY,
 
       creationReason: CONFIG.INSTANCE.CREATION_REASON,
       moderationInformation: CONFIG.INSTANCE.MODERATION_INFORMATION,

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -198,7 +198,7 @@ function getAbout (req: express.Request, res: express.Response) {
       shortDescription: CONFIG.INSTANCE.SHORT_DESCRIPTION,
       description: CONFIG.INSTANCE.DESCRIPTION,
       terms: CONFIG.INSTANCE.TERMS,
-      codeOfConduct: CONFIG.INSTANCE.CODE_OF_CONDUCT,
+      DMCA: CONFIG.INSTANCE.DMCA,
 
       hardwareInformation: CONFIG.INSTANCE.HARDWARE_INFORMATION,
 
@@ -338,7 +338,7 @@ function customConfig (): CustomConfig {
       shortDescription: CONFIG.INSTANCE.SHORT_DESCRIPTION,
       description: CONFIG.INSTANCE.DESCRIPTION,
       terms: CONFIG.INSTANCE.TERMS,
-      codeOfConduct: CONFIG.INSTANCE.CODE_OF_CONDUCT,
+      DMCA: CONFIG.INSTANCE.DMCA,
 
       creationReason: CONFIG.INSTANCE.CREATION_REASON,
       moderationInformation: CONFIG.INSTANCE.MODERATION_INFORMATION,

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -230,7 +230,7 @@ const CONFIG = {
     get SHORT_DESCRIPTION () { return config.get<string>('instance.short_description') },
     get DESCRIPTION () { return config.get<string>('instance.description') },
     get TERMS () { return config.get<string>('instance.terms') },
-    get DMCA () { return config.get<string>('instance.DMCA') },
+    get DMCA_POLICY () { return config.get<string>('instance.dmca_policy') },
 
     get CREATION_REASON () { return config.get<string>('instance.creation_reason') },
 

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -230,7 +230,7 @@ const CONFIG = {
     get SHORT_DESCRIPTION () { return config.get<string>('instance.short_description') },
     get DESCRIPTION () { return config.get<string>('instance.description') },
     get TERMS () { return config.get<string>('instance.terms') },
-    get CODE_OF_CONDUCT () { return config.get<string>('instance.code_of_conduct') },
+    get DMCA () { return config.get<string>('instance.DMCA') },
 
     get CREATION_REASON () { return config.get<string>('instance.creation_reason') },
 

--- a/server/tests/api/check-params/config.ts
+++ b/server/tests/api/check-params/config.ts
@@ -27,7 +27,7 @@ describe('Test config API validators', function () {
       shortDescription: 'my short description',
       description: 'my super description',
       terms: 'my super terms',
-      codeOfConduct: 'my super coc',
+      DMCA: 'DMCA',
 
       creationReason: 'my super reason',
       moderationInformation: 'my super moderation information',

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -33,7 +33,7 @@ function checkInitialConfig (server: ServerInfo, data: CustomConfig) {
 
   expect(data.instance.terms).to.equal('No terms for now.')
   expect(data.instance.creationReason).to.be.empty
-  expect(data.instance.codeOfConduct).to.be.empty
+  expect(data.instance.DMCA).to.be.empty
   expect(data.instance.moderationInformation).to.be.empty
   expect(data.instance.administrator).to.be.empty
   expect(data.instance.maintenanceLifetime).to.be.empty
@@ -101,7 +101,7 @@ function checkUpdatedConfig (data: CustomConfig) {
 
   expect(data.instance.terms).to.equal('my super terms')
   expect(data.instance.creationReason).to.equal('my super creation reason')
-  expect(data.instance.codeOfConduct).to.equal('my super coc')
+  expect(data.instance.DMCA).to.equal('my super coc')
   expect(data.instance.moderationInformation).to.equal('my super moderation information')
   expect(data.instance.administrator).to.equal('Kuja')
   expect(data.instance.maintenanceLifetime).to.equal('forever')
@@ -228,7 +228,7 @@ describe('Test config', function () {
         shortDescription: 'my short description',
         description: 'my super description',
         terms: 'my super terms',
-        codeOfConduct: 'my super coc',
+        DMCA: 'DMCA',
 
         creationReason: 'my super creation reason',
         moderationInformation: 'my super moderation information',
@@ -401,7 +401,7 @@ describe('Test config', function () {
     expect(data.instance.shortDescription).to.equal('my short description')
     expect(data.instance.description).to.equal('my super description')
     expect(data.instance.terms).to.equal('my super terms')
-    expect(data.instance.codeOfConduct).to.equal('my super coc')
+    expect(data.instance.DMCA).to.equal('DMCA')
 
     expect(data.instance.creationReason).to.equal('my super creation reason')
     expect(data.instance.moderationInformation).to.equal('my super moderation information')

--- a/shared/extra-utils/server/config.ts
+++ b/shared/extra-utils/server/config.ts
@@ -53,7 +53,7 @@ function updateCustomSubConfig (url: string, token: string, newConfig: DeepParti
       shortDescription: 'my short description',
       description: 'my super description',
       terms: 'my super terms',
-      codeOfConduct: 'my super coc',
+      DMCA: 'DMCA',
 
       creationReason: 'my super creation reason',
       moderationInformation: 'my super moderation information',

--- a/shared/models/server/about.model.ts
+++ b/shared/models/server/about.model.ts
@@ -5,7 +5,7 @@ export interface About {
     description: string
     terms: string
 
-    codeOfConduct: string
+    DMCA: string
     hardwareInformation: string
 
     creationReason: string

--- a/shared/models/server/custom-config.model.ts
+++ b/shared/models/server/custom-config.model.ts
@@ -7,7 +7,7 @@ export interface CustomConfig {
     shortDescription: string
     description: string
     terms: string
-    codeOfConduct: string
+    DMCA: string
 
     creationReason: string
     moderationInformation: string


### PR DESCRIPTION
Having both the CoC and the Terms seems redundant. CoCs are also often seen as political documents. So instead of just removing one [infobox](https://github.com/Chocobozzz/PeerTube/issues/2931) (CoC), I've decided to rename it to DMCA. If someone will want to have an infobox for the CoC, he could create one (once this https://github.com/Chocobozzz/PeerTube/issues/2931 issue will get solved).