### PR TITLE
disable vertical scroll instead of hide on desktop browsers

### DIFF
--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -57,6 +57,10 @@ body {
   color: pvar(--mainForegroundColor);
   background-color: pvar(--mainBackgroundColor);
   font-size: 14px;
+  // On desktop browsers, make sure vertical scroll bar is always visible
+  // Allow to disable the scrollbar instead of hide it when the content fit the body
+  // And not move the content and header horizontally sticked to right when the content is updating
+  overflow-y: scroll;
 }
 
 ::selection {

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -143,6 +143,14 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
   }
 }
 
+
+// On desktop browsers, make the content and header horizontally sticked to right not move when modal open and close
+.modal-open {
+  overflow-y: scroll !important; // Make sure vertical scroll bar is always visible on desktop browsers to get disabled scrollbar effect
+  position: fixed; // Fix the body position to disable any scroll content
+  width: 100vw; // Make sure the content fits all the available width when position: fixed
+}
+
 // Nav customizations
 .nav .nav-link {
   display: flex !important;


### PR DESCRIPTION
Small PR which is more a visual fix.

It improves UX/UI nav transitions on desktop browsers where the vertical scrollbar is not floating over the body like touch devices do.

Now, when switching **from a vertical scrolled content to a non-scrolled content / opened modal view**, the vertical scroll will be disabled instead of hide on desktop browsers.

**This way, header (upload button and search input) and content won't be involuntarily moved horizontally to the right**.

![Capture d’écran du 2020-07-14 00-13-24](https://user-images.githubusercontent.com/1877318/87359350-e0ada080-c567-11ea-97b6-9dd6b3b19211.png)

