### PR TITLE
correct maximized icon padding since new icons set implemented

### DIFF
--- a/client/src/app/shared/shared-forms/markdown-textarea.component.scss
+++ b/client/src/app/shared/shared-forms/markdown-textarea.component.scss
@@ -43,7 +43,7 @@ $input-border-radius: 3px;
         }
 
         .grey-button {
-          padding: 0 12px 0 12px;
+          padding: 0 7px 0 12px;
         }
       }
     }


### PR DESCRIPTION
Since https://github.com/Chocobozzz/PeerTube/pull/2915 the maximized icon padding in markdown textarea was not correct.

Before: 
![maximized-icon](https://user-images.githubusercontent.com/1877318/87362021-d1315600-c56d-11ea-88d1-3bad4630b30b.png)

After:
![maximized-icon-fixed](https://user-images.githubusercontent.com/1877318/87362033-d68ea080-c56d-11ea-9d8c-f680f35a8241.png)
