### PR TITLE
Add alert and hide upload view when no upload is possible

### DIFF
--- a/client/src/app/+admin/admin.component.ts
+++ b/client/src/app/+admin/admin.component.ts
@@ -21,85 +21,76 @@ export class AdminComponent implements OnInit {
   ngOnInit () {
     const federationItems: TopMenuDropdownParam = {
       label: this.i18n('Federation'),
-      isDisplayed: () => true,
       children: [
         {
           label: this.i18n('Instances you follow'),
           routerLink: '/admin/follows/following-list',
-          iconName: 'following',
-          isDisplayed: () => true
+          iconName: 'following'
         },
         {
           label: this.i18n('Instances following you'),
           routerLink: '/admin/follows/followers-list',
-          iconName: 'follower',
-          isDisplayed: () => true
+          iconName: 'follower'
         },
         {
           label: this.i18n('Video redundancies'),
           routerLink: '/admin/follows/video-redundancies-list',
-          iconName: 'videos',
-          isDisplayed: () => true
+          iconName: 'videos'
         }
       ]
     }
 
     const moderationItems: TopMenuDropdownParam = {
       label: this.i18n('Moderation'),
-      children: [],
-      isDisplayed: () => true
+      children: []
     }
 
     if (this.hasAbusesRight()) {
       moderationItems.children.push({
         label: this.i18n('Reports'),
         routerLink: '/admin/moderation/abuses/list',
-        iconName: 'flag',
-        isDisplayed: () => true
+        iconName: 'flag'
       })
     }
     if (this.hasVideoBlocklistRight()) {
       moderationItems.children.push({
         label: this.i18n('Video blocks'),
         routerLink: '/admin/moderation/video-blocks/list',
-        iconName: 'cross',
-        isDisplayed: () => true
+        iconName: 'cross'
       })
     }
     if (this.hasAccountsBlocklistRight()) {
       moderationItems.children.push({
         label: this.i18n('Muted accounts'),
         routerLink: '/admin/moderation/blocklist/accounts',
-        iconName: 'user-x',
-        isDisplayed: () => true
+        iconName: 'user-x'
       })
     }
     if (this.hasServersBlocklistRight()) {
       moderationItems.children.push({
         label: this.i18n('Muted servers'),
         routerLink: '/admin/moderation/blocklist/servers',
-        iconName: 'peertube-x',
-        isDisplayed: () => true
+        iconName: 'peertube-x'
       })
     }
 
     if (this.hasUsersRight()) {
-      this.menuEntries.push({ label: this.i18n('Users'), routerLink: '/admin/users', isDisplayed: () => true })
+      this.menuEntries.push({ label: this.i18n('Users'), routerLink: '/admin/users' })
     }
 
     if (this.hasServerFollowRight()) this.menuEntries.push(federationItems)
     if (this.hasAbusesRight() || this.hasVideoBlocklistRight()) this.menuEntries.push(moderationItems)
 
     if (this.hasConfigRight()) {
-      this.menuEntries.push({ label: this.i18n('Configuration'), routerLink: '/admin/config', isDisplayed: () => true })
+      this.menuEntries.push({ label: this.i18n('Configuration'), routerLink: '/admin/config' })
     }
 
     if (this.hasPluginsRight()) {
-      this.menuEntries.push({ label: this.i18n('Plugins/Themes'), routerLink: '/admin/plugins', isDisplayed: () => true })
+      this.menuEntries.push({ label: this.i18n('Plugins/Themes'), routerLink: '/admin/plugins' })
     }
 
     if (this.hasJobsRight() || this.hasLogsRight() || this.hasDebugRight()) {
-      this.menuEntries.push({ label: this.i18n('System'), routerLink: '/admin/system', isDisplayed: () => true })
+      this.menuEntries.push({ label: this.i18n('System'), routerLink: '/admin/system' })
     }
   }
 

--- a/client/src/app/+admin/admin.component.ts
+++ b/client/src/app/+admin/admin.component.ts
@@ -21,65 +21,86 @@ export class AdminComponent implements OnInit {
   ngOnInit () {
     const federationItems: TopMenuDropdownParam = {
       label: this.i18n('Federation'),
+      isDisplayed: () => true,
       children: [
         {
           label: this.i18n('Instances you follow'),
           routerLink: '/admin/follows/following-list',
-          iconName: 'following'
+          iconName: 'following',
+          isDisplayed: () => true
         },
         {
           label: this.i18n('Instances following you'),
           routerLink: '/admin/follows/followers-list',
-          iconName: 'follower'
+          iconName: 'follower',
+          isDisplayed: () => true
         },
         {
           label: this.i18n('Video redundancies'),
           routerLink: '/admin/follows/video-redundancies-list',
-          iconName: 'videos'
+          iconName: 'videos',
+          isDisplayed: () => true
         }
       ]
     }
 
     const moderationItems: TopMenuDropdownParam = {
       label: this.i18n('Moderation'),
-      children: []
+      children: [],
+      isDisplayed: () => true
     }
 
     if (this.hasAbusesRight()) {
       moderationItems.children.push({
         label: this.i18n('Reports'),
         routerLink: '/admin/moderation/abuses/list',
-        iconName: 'flag'
+        iconName: 'flag',
+        isDisplayed: () => true
       })
     }
     if (this.hasVideoBlocklistRight()) {
       moderationItems.children.push({
         label: this.i18n('Video blocks'),
         routerLink: '/admin/moderation/video-blocks/list',
-        iconName: 'cross'
+        iconName: 'cross',
+        isDisplayed: () => true
       })
     }
     if (this.hasAccountsBlocklistRight()) {
       moderationItems.children.push({
         label: this.i18n('Muted accounts'),
         routerLink: '/admin/moderation/blocklist/accounts',
-        iconName: 'user-x'
+        iconName: 'user-x',
+        isDisplayed: () => true
       })
     }
     if (this.hasServersBlocklistRight()) {
       moderationItems.children.push({
         label: this.i18n('Muted servers'),
         routerLink: '/admin/moderation/blocklist/servers',
-        iconName: 'peertube-x'
+        iconName: 'peertube-x',
+        isDisplayed: () => true
       })
     }
 
-    if (this.hasUsersRight()) this.menuEntries.push({ label: this.i18n('Users'), routerLink: '/admin/users' })
+    if (this.hasUsersRight()) {
+      this.menuEntries.push({ label: this.i18n('Users'), routerLink: '/admin/users', isDisplayed: () => true })
+    }
+
     if (this.hasServerFollowRight()) this.menuEntries.push(federationItems)
     if (this.hasAbusesRight() || this.hasVideoBlocklistRight()) this.menuEntries.push(moderationItems)
-    if (this.hasConfigRight()) this.menuEntries.push({ label: this.i18n('Configuration'), routerLink: '/admin/config' })
-    if (this.hasPluginsRight()) this.menuEntries.push({ label: this.i18n('Plugins/Themes'), routerLink: '/admin/plugins' })
-    if (this.hasJobsRight() || this.hasLogsRight() || this.hasDebugRight()) this.menuEntries.push({ label: this.i18n('System'), routerLink: '/admin/system' })
+
+    if (this.hasConfigRight()) {
+      this.menuEntries.push({ label: this.i18n('Configuration'), routerLink: '/admin/config', isDisplayed: () => true })
+    }
+
+    if (this.hasPluginsRight()) {
+      this.menuEntries.push({ label: this.i18n('Plugins/Themes'), routerLink: '/admin/plugins', isDisplayed: () => true })
+    }
+
+    if (this.hasJobsRight() || this.hasLogsRight() || this.hasDebugRight()) {
+      this.menuEntries.push({ label: this.i18n('System'), routerLink: '/admin/system', isDisplayed: () => true })
+    }
   }
 
   hasUsersRight () {

--- a/client/src/app/+my-account/my-account.component.ts
+++ b/client/src/app/+my-account/my-account.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core'
-import { AuthService, ServerService, User } from '@app/core'
+import { AuthService, ServerService, AuthUser } from '@app/core'
 import { I18n } from '@ngx-translate/i18n-polyfill'
 import { ServerConfig } from '@shared/models'
 import { TopMenuDropdownParam } from '../shared/shared-main/misc/top-menu-dropdown.component'
@@ -11,7 +11,7 @@ import { TopMenuDropdownParam } from '../shared/shared-main/misc/top-menu-dropdo
 })
 export class MyAccountComponent implements OnInit {
   menuEntries: TopMenuDropdownParam[] = []
-  user: User
+  user: AuthUser
 
   private serverConfig: ServerConfig
 
@@ -26,112 +26,91 @@ export class MyAccountComponent implements OnInit {
     this.serverService.getConfig()
         .subscribe(config => this.serverConfig = config)
 
-    const libraryEntries: TopMenuDropdownParam = {
-      label: this.i18n('My library'),
-      children: [
-        {
-          label: this.i18n('My channels'),
-          routerLink: '/my-account/video-channels',
-          iconName: 'channel'
-        },
-        {
-          label: this.i18n('My videos'),
-          routerLink: '/my-account/videos',
-          iconName: 'videos'
-        },
-        {
-          label: this.i18n('My playlists'),
-          routerLink: '/my-account/video-playlists',
-          iconName: 'playlists'
-        },
-        {
-          label: this.i18n('My subscriptions'),
-          routerLink: '/my-account/subscriptions',
-          iconName: 'subscriptions'
-        },
-        {
-          label: this.i18n('My history'),
-          routerLink: '/my-account/history/videos',
-          iconName: 'history'
-        }
-      ]
-    }
-
-    if (this.isVideoImportEnabled()) {
-      libraryEntries.children.push({
-        label: 'My imports',
-        routerLink: '/my-account/video-imports',
-        iconName: 'cloud-download'
-      })
-    }
-
     this.user = this.authService.getUser()
 
     this.authService.userInformationLoaded.subscribe(
       () => {
-        // Cannot see videos links, hide my videos and my imports
-        if (!this.canSeeVideosLink()) {
-          libraryEntries.children.splice(1, 1)
-
-          if (this.isVideoImportEnabled()) {
-            libraryEntries.children.splice(4, 1)
-          }
+        const libraryEntries: TopMenuDropdownParam = {
+          label: this.i18n('My library'),
+          children: [
+            {
+              label: this.i18n('My channels'),
+              routerLink: '/my-account/video-channels',
+              iconName: 'channel'
+            },
+            {
+              label: this.i18n('My videos'),
+              routerLink: '/my-account/videos',
+              iconName: 'videos',
+              isHidden: !this.user.canSeeVideosLink()
+            },
+            {
+              label: this.i18n('My playlists'),
+              routerLink: '/my-account/video-playlists',
+              iconName: 'playlists'
+            },
+            {
+              label: this.i18n('My subscriptions'),
+              routerLink: '/my-account/subscriptions',
+              iconName: 'inbox-full'
+            },
+            {
+              label: this.i18n('My history'),
+              routerLink: '/my-account/history/videos',
+              iconName: 'history'
+            }
+          ]
         }
+
+        if (this.isVideoImportEnabled()) {
+          libraryEntries.children.push({
+            label: 'My imports',
+            routerLink: '/my-account/video-imports',
+            iconName: 'cloud-download',
+            isHidden: !this.user.canSeeVideosLink()
+          })
+        }
+
+        const miscEntries: TopMenuDropdownParam = {
+          label: this.i18n('Misc'),
+          children: [
+            {
+              label: this.i18n('Muted accounts'),
+              routerLink: '/my-account/blocklist/accounts',
+              iconName: 'user-x'
+            },
+            {
+              label: this.i18n('Muted servers'),
+              routerLink: '/my-account/blocklist/servers',
+              iconName: 'peertube-x'
+            },
+            {
+              label: this.i18n('Ownership changes'),
+              routerLink: '/my-account/ownership',
+              iconName: 'download'
+            }
+          ]
+        }
+
+        this.menuEntries = [
+          {
+            label: this.i18n('My settings'),
+            routerLink: '/my-account/settings'
+          },
+          {
+            label: this.i18n('My notifications'),
+            routerLink: '/my-account/notifications'
+          },
+          libraryEntries,
+          miscEntries
+        ]
       }
     )
-
-    const miscEntries: TopMenuDropdownParam = {
-      label: this.i18n('Misc'),
-      children: [
-        {
-          label: this.i18n('Muted accounts'),
-          routerLink: '/my-account/blocklist/accounts',
-          iconName: 'user-x'
-        },
-        {
-          label: this.i18n('Muted servers'),
-          routerLink: '/my-account/blocklist/servers',
-          iconName: 'peertube-x'
-        },
-        {
-          label: this.i18n('Ownership changes'),
-          routerLink: '/my-account/ownership',
-          iconName: 'download'
-        }
-      ]
-    }
-
-    this.menuEntries = [
-      {
-        label: this.i18n('My settings'),
-        routerLink: '/my-account/settings'
-      },
-      {
-        label: this.i18n('My notifications'),
-        routerLink: '/my-account/notifications'
-      },
-      libraryEntries,
-      miscEntries
-    ]
   }
 
   isVideoImportEnabled () {
     const importConfig = this.serverConfig.import.videos
 
     return importConfig.http.enabled || importConfig.torrent.enabled
-  }
-
-  canSeeVideosLink () {
-    const { videoQuota, videoQuotaDaily, videosCount } = this.user
-
-    // can upload
-    if ((videoQuota > 0 || videoQuota === -1) && (videoQuotaDaily > 0 || videoQuotaDaily === -1)) {
-      return true
-    }
-
-    // cannot upload but has already some videos
-    if (videosCount > 0) {
-      return true
-    }
   }
 }

--- a/client/src/app/+my-account/my-account.component.ts
+++ b/client/src/app/+my-account/my-account.component.ts
@@ -32,32 +32,37 @@ export class MyAccountComponent implements OnInit {
       () => {
         const libraryEntries: TopMenuDropdownParam = {
           label: this.i18n('My library'),
+          isDisplayed: () => true,
           children: [
             {
               label: this.i18n('My channels'),
               routerLink: '/my-account/video-channels',
-              iconName: 'channel'
+              iconName: 'channel',
+              isDisplayed: () => true
             },
             {
               label: this.i18n('My videos'),
               routerLink: '/my-account/videos',
               iconName: 'videos',
-              isHidden: !this.user.canSeeVideosLink()
+              isDisplayed: () => this.user.canSeeVideosLink()
             },
             {
               label: this.i18n('My playlists'),
               routerLink: '/my-account/video-playlists',
-              iconName: 'playlists'
+              iconName: 'playlists',
+              isDisplayed: () => true
             },
             {
               label: this.i18n('My subscriptions'),
               routerLink: '/my-account/subscriptions',
-              iconName: 'inbox-full'
+              iconName: 'inbox-full',
+              isDisplayed: () => true
             },
             {
               label: this.i18n('My history'),
               routerLink: '/my-account/history/videos',
-              iconName: 'history'
+              iconName: 'history',
+              isDisplayed: () => true
             }
           ]
         }
@@ -67,27 +72,31 @@ export class MyAccountComponent implements OnInit {
             label: 'My imports',
             routerLink: '/my-account/video-imports',
             iconName: 'cloud-download',
-            isHidden: !this.user.canSeeVideosLink()
+            isDisplayed: () => this.user.canSeeVideosLink()
           })
         }
 
         const miscEntries: TopMenuDropdownParam = {
           label: this.i18n('Misc'),
+          isDisplayed: () => true,
           children: [
             {
               label: this.i18n('Muted accounts'),
               routerLink: '/my-account/blocklist/accounts',
-              iconName: 'user-x'
+              iconName: 'user-x',
+              isDisplayed: () => true
             },
             {
               label: this.i18n('Muted servers'),
               routerLink: '/my-account/blocklist/servers',
-              iconName: 'peertube-x'
+              iconName: 'peertube-x',
+              isDisplayed: () => true
             },
             {
               label: this.i18n('Ownership changes'),
               routerLink: '/my-account/ownership',
-              iconName: 'download'
+              iconName: 'download',
+              isDisplayed: () => true
             }
           ]
         }
@@ -95,11 +104,13 @@ export class MyAccountComponent implements OnInit {
         this.menuEntries = [
           {
             label: this.i18n('My settings'),
-            routerLink: '/my-account/settings'
+            routerLink: '/my-account/settings',
+            isDisplayed: () => true
           },
           {
             label: this.i18n('My notifications'),
-            routerLink: '/my-account/notifications'
+            routerLink: '/my-account/notifications',
+            isDisplayed: () => true
           },
           libraryEntries,
           miscEntries

--- a/client/src/app/+my-account/my-account.component.ts
+++ b/client/src/app/+my-account/my-account.component.ts
@@ -29,93 +29,7 @@ export class MyAccountComponent implements OnInit {
     this.user = this.authService.getUser()
 
     this.authService.userInformationLoaded.subscribe(
-      () => {
-        const libraryEntries: TopMenuDropdownParam = {
-          label: this.i18n('My library'),
-          isDisplayed: () => true,
-          children: [
-            {
-              label: this.i18n('My channels'),
-              routerLink: '/my-account/video-channels',
-              iconName: 'channel',
-              isDisplayed: () => true
-            },
-            {
-              label: this.i18n('My videos'),
-              routerLink: '/my-account/videos',
-              iconName: 'videos',
-              isDisplayed: () => this.user.canSeeVideosLink()
-            },
-            {
-              label: this.i18n('My playlists'),
-              routerLink: '/my-account/video-playlists',
-              iconName: 'playlists',
-              isDisplayed: () => true
-            },
-            {
-              label: this.i18n('My subscriptions'),
-              routerLink: '/my-account/subscriptions',
-              iconName: 'inbox-full',
-              isDisplayed: () => true
-            },
-            {
-              label: this.i18n('My history'),
-              routerLink: '/my-account/history/videos',
-              iconName: 'history',
-              isDisplayed: () => true
-            }
-          ]
-        }
-
-        if (this.isVideoImportEnabled()) {
-          libraryEntries.children.push({
-            label: 'My imports',
-            routerLink: '/my-account/video-imports',
-            iconName: 'cloud-download',
-            isDisplayed: () => this.user.canSeeVideosLink()
-          })
-        }
-
-        const miscEntries: TopMenuDropdownParam = {
-          label: this.i18n('Misc'),
-          isDisplayed: () => true,
-          children: [
-            {
-              label: this.i18n('Muted accounts'),
-              routerLink: '/my-account/blocklist/accounts',
-              iconName: 'user-x',
-              isDisplayed: () => true
-            },
-            {
-              label: this.i18n('Muted servers'),
-              routerLink: '/my-account/blocklist/servers',
-              iconName: 'peertube-x',
-              isDisplayed: () => true
-            },
-            {
-              label: this.i18n('Ownership changes'),
-              routerLink: '/my-account/ownership',
-              iconName: 'download',
-              isDisplayed: () => true
-            }
-          ]
-        }
-
-        this.menuEntries = [
-          {
-            label: this.i18n('My settings'),
-            routerLink: '/my-account/settings',
-            isDisplayed: () => true
-          },
-          {
-            label: this.i18n('My notifications'),
-            routerLink: '/my-account/notifications',
-            isDisplayed: () => true
-          },
-          libraryEntries,
-          miscEntries
-        ]
-      }
+      () => this.buildMenu()
     )
   }
 
@@ -123,5 +37,82 @@ export class MyAccountComponent implements OnInit {
     const importConfig = this.serverConfig.import.videos
 
     return importConfig.http.enabled || importConfig.torrent.enabled
+  }
+
+  private buildMenu () {
+    const libraryEntries: TopMenuDropdownParam = {
+      label: this.i18n('My library'),
+      children: [
+        {
+          label: this.i18n('My channels'),
+          routerLink: '/my-account/video-channels',
+          iconName: 'channel'
+        },
+        {
+          label: this.i18n('My videos'),
+          routerLink: '/my-account/videos',
+          iconName: 'videos',
+          isDisplayed: () => this.user.canSeeVideosLink
+        },
+        {
+          label: this.i18n('My playlists'),
+          routerLink: '/my-account/video-playlists',
+          iconName: 'playlists'
+        },
+        {
+          label: this.i18n('My subscriptions'),
+          routerLink: '/my-account/subscriptions',
+          iconName: 'inbox-full'
+        },
+        {
+          label: this.i18n('My history'),
+          routerLink: '/my-account/history/videos',
+          iconName: 'history'
+        }
+      ]
+    }
+
+    if (this.isVideoImportEnabled()) {
+      libraryEntries.children.push({
+        label: 'My imports',
+        routerLink: '/my-account/video-imports',
+        iconName: 'cloud-download',
+        isDisplayed: () => this.user.canSeeVideosLink
+      })
+    }
+
+    const miscEntries: TopMenuDropdownParam = {
+      label: this.i18n('Misc'),
+      children: [
+        {
+          label: this.i18n('Muted accounts'),
+          routerLink: '/my-account/blocklist/accounts',
+          iconName: 'user-x'
+        },
+        {
+          label: this.i18n('Muted servers'),
+          routerLink: '/my-account/blocklist/servers',
+          iconName: 'peertube-x'
+        },
+        {
+          label: this.i18n('Ownership changes'),
+          routerLink: '/my-account/ownership',
+          iconName: 'download'
+        }
+      ]
+    }
+
+    this.menuEntries = [
+      {
+        label: this.i18n('My settings'),
+        routerLink: '/my-account/settings'
+      },
+      {
+        label: this.i18n('My notifications'),
+        routerLink: '/my-account/notifications'
+      },
+      libraryEntries,
+      miscEntries
+    ]
   }
 }

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!user.canUpload()" class="no-upload">
+<div *ngIf="user.isUploadDisabled()" class="no-upload">
   <div class="alert alert-warning">
     <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
     <a i18n routerLink="/about/instance" class="about-link">Read instance rules for help</a>
@@ -6,7 +6,7 @@
   <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
 </div>
 
-<div *ngIf="user.canUpload()" class="margin-content">
+<div *ngIf="!user.isUploadDisabled()" class="margin-content">
   <div class="alert alert-warning" *ngIf="isRootUser()" i18n>
     We recommend you to not use the <strong>root</strong> user to publish your videos, since it's the super-admin account of your instance.
     <br />

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!canUpload()" class="no-upload">
+<div *ngIf="!user.canUpload()" class="no-upload">
   <div class="alert alert-warning">
     <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
     <a i18n routerLink="/about/instance" class="about-link">Read instance rules for help</a>
@@ -6,7 +6,7 @@
   <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
 </div>
 
-<div *ngIf="canUpload()" class="margin-content">
+<div *ngIf="user.canUpload()" class="margin-content">
   <div class="alert alert-warning" *ngIf="isRootUser()" i18n>
     We recommend you to not use the <strong>root</strong> user to publish your videos, since it's the super-admin account of your instance.
     <br />

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,4 +1,11 @@
-<div class="margin-content">
+<div *ngIf="!canUpload()" class="no-upload">
+  <div class="alert alert-warning" i18n>
+    Sorry, the upload feature is disabled for your account.
+  </div>
+  <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
+</div>
+
+<div *ngIf="canUpload()" class="margin-content">
   <div class="alert alert-warning" *ngIf="isRootUser()" i18n>
     We recommend you to not use the <strong>root</strong> user to publish your videos, since it's the super-admin account of your instance.
     <br />

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="!canUpload()" class="no-upload">
-  <div class="alert alert-warning" i18n>
-    Sorry, the upload feature is disabled for your account.
+  <div class="alert alert-warning">
+    <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
+    <a i18n routerLink="/about/instance" class="about-link">Read instance rules for help</a>
   </div>
   <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
 </div>

--- a/client/src/app/+videos/+video-edit/video-add.component.scss
+++ b/client/src/app/+videos/+video-edit/video-add.component.scss
@@ -6,6 +6,26 @@ $border-type: solid;
 $border-color: #EAEAEA;
 $nav-link-height: 40px;
 
+.no-upload {
+  height: 100%;
+  width: 100%;
+  text-align: center;
+
+  img {
+    margin-top: 10px;
+    margin-bottom: 75px;
+    width: 220px;
+    height: auto;
+  }
+
+  @media screen and (max-height: 600px) {
+    img {
+      margin-top: 5px;
+      width: 160px;
+    }
+  }
+}
+
 .margin-content {
   padding-top: 20px;
 }

--- a/client/src/app/+videos/+video-edit/video-add.component.scss
+++ b/client/src/app/+videos/+video-edit/video-add.component.scss
@@ -11,6 +11,14 @@ $nav-link-height: 40px;
   width: 100%;
   text-align: center;
 
+  .about-link {
+    @include peertube-button-link;
+    @include orange-button;
+
+    height: fit-content;
+    margin-top: 10px;
+  }
+
   img {
     margin-top: 10px;
     margin-bottom: 75px;

--- a/client/src/app/+videos/+video-edit/video-add.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostListener, OnInit, ViewChild } from '@angular/core'
-import { AuthService, CanComponentDeactivate, ServerService, User } from '@app/core'
+import { AuthService, AuthUser, CanComponentDeactivate, ServerService } from '@app/core'
 import { ServerConfig } from '@shared/models'
 import { VideoImportTorrentComponent } from './video-add-components/video-import-torrent.component'
 import { VideoImportUrlComponent } from './video-add-components/video-import-url.component'
@@ -15,7 +15,7 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
   @ViewChild('videoImportUrl') videoImportUrl: VideoImportUrlComponent
   @ViewChild('videoImportTorrent') videoImportTorrent: VideoImportTorrentComponent
 
-  user: User = null
+  user: AuthUser = null
 
   secondStepType: 'upload' | 'import-url' | 'import-torrent'
   videoName: string
@@ -37,6 +37,8 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
 
     this.serverService.getConfig()
       .subscribe(config => this.serverConfig = config)
+
+    this.user = this.auth.getUser()
   }
 
   onFirstStepDone (type: 'upload' | 'import-url' | 'import-torrent', videoName: string) {
@@ -67,12 +69,6 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
     return { canDeactivate: true }
   }
 
-  canUpload () {
-    const { videoQuota, videoQuotaDaily } = this.auth.getUser()
-
-    return (videoQuota > 0 || videoQuota === -1) && (videoQuotaDaily > 0 || videoQuotaDaily === -1)
-  }
-
   isVideoImportHttpEnabled () {
     return this.serverConfig.import.videos.http.enabled
   }
@@ -86,6 +82,6 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
   }
 
   isRootUser () {
-    return this.auth.getUser().username === 'root'
+    return this.user.username === 'root'
   }
 }

--- a/client/src/app/+videos/+video-edit/video-add.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add.component.ts
@@ -67,6 +67,12 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
     return { canDeactivate: true }
   }
 
+  canUpload () {
+    const { videoQuota, videoQuotaDaily } = this.auth.getUser()
+
+    return (videoQuota > 0 || videoQuota === -1) && (videoQuotaDaily > 0 || videoQuotaDaily === -1)
+  }
+
   isVideoImportHttpEnabled () {
     return this.serverConfig.import.videos.http.enabled
   }

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -150,14 +150,12 @@ export class User implements UserServerModel {
     this.account.updateAvatar(newAccountAvatar)
   }
 
-  canUpload (): boolean {
-    if (this.videoQuota === 0 || this.videoQuotaDaily === 0) return false
-
-    return true
+  isUploadDisabled (): boolean {
+    return (this.videoQuota === 0 || this.videoQuotaDaily === 0)
   }
 
   canSeeVideosLink (): boolean {
-    if (this.canUpload()) {
+    if (!this.isUploadDisabled()) {
       return true
     }
 

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -150,20 +150,7 @@ export class User implements UserServerModel {
     this.account.updateAvatar(newAccountAvatar)
   }
 
-  isUploadDisabled (): boolean {
-    return (this.videoQuota === 0 || this.videoQuotaDaily === 0)
-  }
-
-  canSeeVideosLink (): boolean {
-    if (!this.isUploadDisabled()) {
-      return true
-    }
-
-    // cannot upload but has already some videos
-    if (this.videosCount > 0) {
-      return true
-    }
-
-    return false
+  isUploadDisabled () {
+    return this.videoQuota === 0 || this.videoQuotaDaily === 0
   }
 }

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -149,4 +149,23 @@ export class User implements UserServerModel {
   updateAccountAvatar (newAccountAvatar: Avatar) {
     this.account.updateAvatar(newAccountAvatar)
   }
+
+  canUpload (): boolean {
+    if (this.videoQuota === 0 || this.videoQuotaDaily === 0) return false
+
+    return true
+  }
+
+  canSeeVideosLink (): boolean {
+    if (this.canUpload()) {
+      return true
+    }
+
+    // cannot upload but has already some videos
+    if (this.videosCount > 0) {
+      return true
+    }
+
+    return false
+  }
 }

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -81,7 +81,7 @@
       <div *ngIf="isLoggedIn" class="panel-block">
         <div i18n class="block-title">MY LIBRARY</div>
 
-        <a *ngIf="canSeeVideosLink()" routerLink="/my-account/videos" routerLinkActive="active">
+        <a *ngIf="user.canSeeVideosLink()" routerLink="/my-account/videos" routerLinkActive="active">
           <my-global-icon iconName="videos" aria-hidden="true"></my-global-icon>
           <ng-container i18n>Videos</ng-container>
         </a>

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -81,7 +81,7 @@
       <div *ngIf="isLoggedIn" class="panel-block">
         <div i18n class="block-title">MY LIBRARY</div>
 
-        <a routerLink="/my-account/videos" routerLinkActive="active">
+        <a *ngIf="canSeeVideosLink()" routerLink="/my-account/videos" routerLinkActive="active">
           <my-global-icon iconName="videos" aria-hidden="true"></my-global-icon>
           <ng-container i18n>Videos</ng-container>
         </a>

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -81,7 +81,7 @@
       <div *ngIf="isLoggedIn" class="panel-block">
         <div i18n class="block-title">MY LIBRARY</div>
 
-        <a *ngIf="user.canSeeVideosLink()" routerLink="/my-account/videos" routerLinkActive="active">
+        <a *ngIf="user.canSeeVideosLink" routerLink="/my-account/videos" routerLinkActive="active">
           <my-global-icon iconName="videos" aria-hidden="true"></my-global-icon>
           <ng-container i18n>Videos</ng-container>
         </a>

--- a/client/src/app/menu/menu.component.ts
+++ b/client/src/app/menu/menu.component.ts
@@ -114,6 +114,20 @@ export class MenuComponent implements OnInit {
     }
   }
 
+  canSeeVideosLink () {
+    const { videoQuota, videoQuotaDaily, videosCount} = this.user
+
+    // can upload
+    if ((videoQuota > 0 || videoQuota === -1) && (videoQuotaDaily > 0 || videoQuotaDaily === -1)) {
+      return true
+    }
+
+    // cannot upload but has already some videos
+    if (videosCount > 0) {
+      return true
+    }
+  }
+
   isRegistrationAllowed () {
     return this.serverConfig.signup.allowed &&
            this.serverConfig.signup.allowedForCurrentIP

--- a/client/src/app/menu/menu.component.ts
+++ b/client/src/app/menu/menu.component.ts
@@ -1,6 +1,6 @@
 import { HotkeysService } from 'angular2-hotkeys'
 import { Component, OnInit, ViewChild } from '@angular/core'
-import { AuthService, AuthStatus, RedirectService, ScreenService, ServerService, User, UserService } from '@app/core'
+import { AuthService, AuthStatus, RedirectService, ScreenService, ServerService, AuthUser, UserService } from '@app/core'
 import { LanguageChooserComponent } from '@app/menu/language-chooser.component'
 import { QuickSettingsModalComponent } from '@app/modal/quick-settings-modal.component'
 import { I18n } from '@ngx-translate/i18n-polyfill'
@@ -15,7 +15,7 @@ export class MenuComponent implements OnInit {
   @ViewChild('languageChooserModal', { static: true }) languageChooserModal: LanguageChooserComponent
   @ViewChild('quickSettingsModal', { static: true }) quickSettingsModal: QuickSettingsModalComponent
 
-  user: User
+  user: AuthUser
   isLoggedIn: boolean
 
   userHasAdminAccess = false
@@ -111,20 +111,6 @@ export class MenuComponent implements OnInit {
 
       case 'display':
         return this.i18n('display')
-    }
-  }
-
-  canSeeVideosLink () {
-    const { videoQuota, videoQuotaDaily, videosCount } = this.user
-
-    // can upload
-    if ((videoQuota > 0 || videoQuota === -1) && (videoQuotaDaily > 0 || videoQuotaDaily === -1)) {
-      return true
-    }
-
-    // cannot upload but has already some videos
-    if (videosCount > 0) {
-      return true
     }
   }
 

--- a/client/src/app/menu/menu.component.ts
+++ b/client/src/app/menu/menu.component.ts
@@ -115,7 +115,7 @@ export class MenuComponent implements OnInit {
   }
 
   canSeeVideosLink () {
-    const { videoQuota, videoQuotaDaily, videosCount} = this.user
+    const { videoQuota, videoQuotaDaily, videosCount } = this.user
 
     // can upload
     if ((videoQuota > 0 || videoQuota === -1) && (videoQuotaDaily > 0 || videoQuotaDaily === -1)) {

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -1,7 +1,7 @@
 <div class="sub-menu" [ngClass]="{ 'no-scroll': isModalOpened }">
   <ng-container *ngFor="let menuEntry of menuEntries; index as id">
 
-    <a *ngIf="menuEntry.routerLink" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
+    <a *ngIf="menuEntry.routerLink && !menuEntry.isHidden" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
     <div *ngIf="!menuEntry.routerLink" ngbDropdown class="parent-entry"
       #dropdown="ngbDropdown" autoClose="outside">
@@ -25,11 +25,15 @@
       </span>
 
       <div ngbDropdownMenu>
-        <a *ngFor="let menuChild of menuEntry.children" class="dropdown-item" [ngClass]="{ icon: hasIcons, active: suffixLabels[menuEntry.label] === menuChild.label }" [routerLink]="menuChild.routerLink">
-          <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
+        <ng-container *ngFor="let menuChild of menuEntry.children">
+          <a *ngIf="!menuChild.isHidden" class="dropdown-item"
+            [ngClass]="{ icon: hasIcons, active: suffixLabels[menuEntry.label] === menuChild.label }"
+            [routerLink]="menuChild.routerLink">
+            <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
 
-          {{ menuChild.label }}
-        </a>
+            {{ menuChild.label }}
+          </a>
+        </ng-container>
       </div>
     </div>
   </ng-container>
@@ -39,13 +43,15 @@
   <div class="modal-body">
     <ng-container *ngFor="let menuEntry of menuEntries; index as id">
       <div [ngClass]="{ hidden: id !== currentMenuEntryIndex }">
-        <a *ngFor="let menuChild of menuEntry.children"
-          [ngClass]="{ icon: hasIcons }"
-          [routerLink]="menuChild.routerLink" routerLinkActive="active" (click)="dismissOtherModals()">
-          <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
+        <ng-container *ngFor="let menuChild of menuEntry.children">
+          <a *ngIf="!menuChild.isHidden"
+            [ngClass]="{ icon: hasIcons }"
+            [routerLink]="menuChild.routerLink" routerLinkActive="active" (click)="dismissOtherModals()">
+            <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
 
-          {{ menuChild.label }}
-        </a>
+            {{ menuChild.label }}
+          </a>
+        </ng-container>
       </div>
     </ng-container>
   </div>

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -1,9 +1,9 @@
 <div class="sub-menu" [ngClass]="{ 'no-scroll': isModalOpened }">
   <ng-container *ngFor="let menuEntry of menuEntries; index as id">
 
-    <a *ngIf="menuEntry.routerLink && menuEntry.isDisplayed()" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
+    <a *ngIf="menuEntry.routerLink && isDisplayed(menuEntry)" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
-    <div *ngIf="!menuEntry.routerLink && menuEntry.isDisplayed()" ngbDropdown class="parent-entry"
+    <div *ngIf="!menuEntry.routerLink && isDisplayed(menuEntry)" ngbDropdown class="parent-entry"
       #dropdown="ngbDropdown" autoClose="outside">
       <span
         *ngIf="isInSmallView"
@@ -26,7 +26,7 @@
 
       <div ngbDropdownMenu>
         <ng-container *ngFor="let menuChild of menuEntry.children">
-          <a *ngIf="menuChild.isDisplayed()" class="dropdown-item"
+          <a *ngIf="isDisplayed(menuChild)" class="dropdown-item"
             [ngClass]="{ icon: hasIcons, active: suffixLabels[menuEntry.label] === menuChild.label }"
             [routerLink]="menuChild.routerLink">
             <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
@@ -44,7 +44,7 @@
     <ng-container *ngFor="let menuEntry of menuEntries; index as id">
       <div [ngClass]="{ hidden: id !== currentMenuEntryIndex }">
         <ng-container *ngFor="let menuChild of menuEntry.children">
-          <a *ngIf="menuChild.isDisplayed()"
+          <a *ngIf="isDisplayed(menuChild)"
             [ngClass]="{ icon: hasIcons }"
             [routerLink]="menuChild.routerLink" routerLinkActive="active" (click)="dismissOtherModals()">
             <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -1,9 +1,9 @@
 <div class="sub-menu" [ngClass]="{ 'no-scroll': isModalOpened }">
   <ng-container *ngFor="let menuEntry of menuEntries; index as id">
 
-    <a *ngIf="menuEntry.routerLink && !menuEntry.isHidden" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
+    <a *ngIf="menuEntry.routerLink && menuEntry.isDisplayed()" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
-    <div *ngIf="!menuEntry.routerLink" ngbDropdown class="parent-entry"
+    <div *ngIf="!menuEntry.routerLink && menuEntry.isDisplayed()" ngbDropdown class="parent-entry"
       #dropdown="ngbDropdown" autoClose="outside">
       <span
         *ngIf="isInSmallView"
@@ -26,7 +26,7 @@
 
       <div ngbDropdownMenu>
         <ng-container *ngFor="let menuChild of menuEntry.children">
-          <a *ngIf="!menuChild.isHidden" class="dropdown-item"
+          <a *ngIf="menuChild.isDisplayed()" class="dropdown-item"
             [ngClass]="{ icon: hasIcons, active: suffixLabels[menuEntry.label] === menuChild.label }"
             [routerLink]="menuChild.routerLink">
             <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
@@ -44,7 +44,7 @@
     <ng-container *ngFor="let menuEntry of menuEntries; index as id">
       <div [ngClass]="{ hidden: id !== currentMenuEntryIndex }">
         <ng-container *ngFor="let menuChild of menuEntry.children">
-          <a *ngIf="!menuChild.isHidden"
+          <a *ngIf="menuChild.isDisplayed()"
             [ngClass]="{ icon: hasIcons }"
             [routerLink]="menuChild.routerLink" routerLinkActive="active" (click)="dismissOtherModals()">
             <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
@@ -9,12 +9,12 @@ import { NgbDropdown, NgbModal } from '@ng-bootstrap/ng-bootstrap'
 export type TopMenuDropdownParam = {
   label: string
   routerLink?: string
-  isHidden?: boolean
+  isDisplayed(): boolean
 
   children?: {
     label: string
     routerLink: string
-    isHidden?: boolean
+    isDisplayed(): boolean
     iconName?: GlobalIconName
   }[]
 }

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
@@ -9,13 +9,14 @@ import { NgbDropdown, NgbModal } from '@ng-bootstrap/ng-bootstrap'
 export type TopMenuDropdownParam = {
   label: string
   routerLink?: string
-  isDisplayed(): boolean
+  isDisplayed?: () => boolean // Default: () => true
 
   children?: {
     label: string
     routerLink: string
-    isDisplayed(): boolean
     iconName?: GlobalIconName
+
+    isDisplayed?: () => boolean // Default: () => true
   }[]
 }
 
@@ -91,6 +92,12 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
 
   dismissOtherModals () {
     this.modalService.dismissAll()
+  }
+
+  isDisplayed (obj: { isDisplayed?: () => boolean }) {
+    if (typeof obj.isDisplayed !== 'function') return true
+
+    return obj.isDisplayed()
   }
 
   private updateChildLabels (path: string) {

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
@@ -9,11 +9,12 @@ import { NgbDropdown, NgbModal } from '@ng-bootstrap/ng-bootstrap'
 export type TopMenuDropdownParam = {
   label: string
   routerLink?: string
+  isHidden?: boolean
 
   children?: {
     label: string
     routerLink: string
-
+    isHidden?: boolean
     iconName?: GlobalIconName
   }[]
 }


### PR DESCRIPTION
When user video quota or daily upload limit are set to `None - no upload possible`, an alert should inform that upload is disabled for the account and the form view not displayed once clicked on the `Upload button` and accessing to `/videos/upload`.

This PR proposes a way to alert the user and hide the upload form in this case : 

![no-upload](https://user-images.githubusercontent.com/1877318/87461512-dabeca80-c60e-11ea-830d-8ddb1262d35d.png)
