### PR TITLE
Improve navigation sub-menu and tabs effects

### DIFF
--- a/client/src/app/+admin/admin.component.scss
+++ b/client/src/app/+admin/admin.component.scss
@@ -1,3 +1,12 @@
+@import '_variables';
+
 my-top-menu-dropdown {
   flex-grow: 1;
+}
+
+::ng-deep h1 {
+  font-size: 1.5rem;
+  border-bottom: 2px solid $grey-background-color;
+  padding-bottom: 15px;
+  margin-bottom: $sub-menu-margin-bottom;
 }

--- a/client/src/app/+admin/admin.component.scss
+++ b/client/src/app/+admin/admin.component.scss
@@ -1,12 +1,8 @@
 @import '_variables';
+@import '_mixins';
 
 my-top-menu-dropdown {
   flex-grow: 1;
 }
 
-::ng-deep h1 {
-  font-size: 1.5rem;
-  border-bottom: 2px solid $grey-background-color;
-  padding-bottom: 15px;
-  margin-bottom: $sub-menu-margin-bottom;
-}
+@include sub-menu-h1;

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.html
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.html
@@ -1,3 +1,5 @@
+<h1 i18n>Instances following you</h1>
+
 <p-table
   [value]="followers" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" (onPage)="onPage($event)"

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.html
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>Instances following you</h1>
+<h1>
+  <my-global-icon iconName="follower" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>Instances following you</ng-container>
+</h1>
 
 <p-table
   [value]="followers" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"

--- a/client/src/app/+admin/follows/following-list/following-list.component.html
+++ b/client/src/app/+admin/follows/following-list/following-list.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>Instances you follow</h1>
+<h1>
+  <my-global-icon iconName="following" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>Instances you follow</ng-container>
+</h1>
 
 <p-table
   [value]="following" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"

--- a/client/src/app/+admin/follows/following-list/following-list.component.html
+++ b/client/src/app/+admin/follows/following-list/following-list.component.html
@@ -1,3 +1,5 @@
+<h1 i18n>Instances you follow</h1>
+
 <p-table
   [value]="following" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" (onPage)="onPage($event)"

--- a/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
+++ b/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>Videos redundancies</h1>
+<h1>
+  <my-global-icon iconName="videos" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>Videos redundancies</ng-container>
+</h1>
 
 <div class="admin-sub-header">
   <div class="select-filter-block">

--- a/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
+++ b/client/src/app/+admin/follows/video-redundancies-list/video-redundancies-list.component.html
@@ -1,3 +1,5 @@
+<h1 i18n>Videos redundancies</h1>
+
 <div class="admin-sub-header">
   <div class="select-filter-block">
     <label for="displayType" i18n>Display</label>

--- a/client/src/app/+admin/moderation/abuse-list/abuse-list.component.html
+++ b/client/src/app/+admin/moderation/abuse-list/abuse-list.component.html
@@ -1,3 +1,5 @@
+<h1 i18n>Reports</h1>
+
 <p-table
   [value]="abuses" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id" [resizableColumns]="true" [lazyLoadOnInit]="false"

--- a/client/src/app/+admin/moderation/abuse-list/abuse-list.component.html
+++ b/client/src/app/+admin/moderation/abuse-list/abuse-list.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>Reports</h1>
+<h1>
+  <my-global-icon iconName="flag" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>Reports</ng-container>
+</h1>
 
 <p-table
   [value]="abuses" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"

--- a/client/src/app/+admin/moderation/video-block-list/video-block-list.component.html
+++ b/client/src/app/+admin/moderation/video-block-list/video-block-list.component.html
@@ -1,3 +1,5 @@
+<h1 i18n>Video blocks</h1>
+
 <p-table
   [value]="blocklist" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"

--- a/client/src/app/+admin/moderation/video-block-list/video-block-list.component.html
+++ b/client/src/app/+admin/moderation/video-block-list/video-block-list.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>Video blocks</h1>
+<h1>
+  <my-global-icon iconName="cross" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>Video blocks</ng-container>
+</h1>
 
 <p-table
   [value]="blocklist" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"

--- a/client/src/app/+admin/plugins/plugins.component.html
+++ b/client/src/app/+admin/plugins/plugins.component.html
@@ -1,6 +1,4 @@
 <div class="admin-sub-header">
-  <h1 i18n class="form-sub-title">Plugins/Themes</h1>
-
   <div class="admin-sub-nav">
     <a i18n routerLink="list-installed" routerLinkActive="active">Installed</a>
 

--- a/client/src/app/+admin/plugins/plugins.component.scss
+++ b/client/src/app/+admin/plugins/plugins.component.scss
@@ -1,11 +1,6 @@
 @import '_variables';
 @import '_mixins';
 
-.form-sub-title {
-  flex-grow: 0;
-  margin-right: 30px;
-}
-
 @media screen and (max-width: $small-view) {
   ::ng-deep .plugins .plugin .first-row {
     flex-wrap: wrap;

--- a/client/src/app/+admin/system/system.component.html
+++ b/client/src/app/+admin/system/system.component.html
@@ -1,6 +1,4 @@
 <div class="admin-sub-header">
-  <h1 i18n class="form-sub-title">System</h1>
-
   <div class="admin-sub-nav">
     <a *ngIf="hasJobsRight()" i18n routerLink="jobs" routerLinkActive="active">Jobs</a>
 

--- a/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.html
+++ b/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.html
@@ -1,4 +1,8 @@
-<h1 i18n>My channels</h1>
+<h1>
+  <my-global-icon iconName="channel" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>My channels</ng-container>
+</h1>
+
 <div class="video-channels-header">
   <a class="create-button" routerLink="create">
     <my-global-icon iconName="add" aria-hidden="true"></my-global-icon>

--- a/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.html
+++ b/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.html
@@ -1,4 +1,4 @@
-<h1 class="sr-only" i18n>My channels</h1>
+<h1 i18n>My channels</h1>
 <div class="video-channels-header">
   <a class="create-button" routerLink="create">
     <my-global-icon iconName="add" aria-hidden="true"></my-global-icon>

--- a/client/src/app/+my-account/my-account-history/my-account-history.component.html
+++ b/client/src/app/+my-account/my-account-history/my-account-history.component.html
@@ -1,4 +1,8 @@
-<h1 i18n>My history</h1>
+<h1>
+  <my-global-icon iconName="history" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>My history</ng-container>
+</h1>
+
 <div class="top-buttons">
   <div class="history-switch">
     <p-inputSwitch [(ngModel)]="videosHistoryEnabled" (ngModelChange)="onVideosHistoryChange()"></p-inputSwitch>

--- a/client/src/app/+my-account/my-account-history/my-account-history.component.html
+++ b/client/src/app/+my-account/my-account-history/my-account-history.component.html
@@ -1,4 +1,4 @@
-<h1 class="sr-only" i18n>History</h1>
+<h1 i18n>My history</h1>
 <div class="top-buttons">
   <div class="history-switch">
     <p-inputSwitch [(ngModel)]="videosHistoryEnabled" (ngModelChange)="onVideosHistoryChange()"></p-inputSwitch>

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
@@ -1,4 +1,4 @@
-<h1 class="sr-only" i18n>Ownership changes</h1>
+<h1 i18n>My ownership changes</h1>
 <p-table
     [value]="videoChangeOwnerships"
     [lazy]="true"

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
@@ -1,4 +1,8 @@
-<h1 i18n>My ownership changes</h1>
+<h1>
+  <my-global-icon iconName="download" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>My ownership changes</ng-container>
+</h1>
+
 <p-table
     [value]="videoChangeOwnerships"
     [lazy]="true"

--- a/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
+++ b/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
@@ -1,4 +1,8 @@
-<h1 i18n>My subscriptions</h1>
+<h1>
+  <my-global-icon iconName="subscriptions" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>My subscriptions</ng-container>
+</h1>
+
 <div class="no-results" i18n *ngIf="pagination.totalItems === 0">You don't have any subscriptions yet.</div>
 
 <div class="video-channels" myInfiniteScroller [autoInit]="true" (nearOfBottom)="onNearOfBottom()" [dataObservable]="onDataSubject.asObservable()">

--- a/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
+++ b/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
@@ -1,4 +1,4 @@
-<h1 class="sr-only" i18n>Subscriptions</h1>
+<h1 i18n>My subscriptions</h1>
 <div class="no-results" i18n *ngIf="pagination.totalItems === 0">You don't have any subscriptions yet.</div>
 
 <div class="video-channels" myInfiniteScroller [autoInit]="true" (nearOfBottom)="onNearOfBottom()" [dataObservable]="onDataSubject.asObservable()">

--- a/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
+++ b/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
@@ -1,4 +1,4 @@
-<h1 class="sr-only" i18n>Imports</h1>
+<h1 i18n>My imports</h1>
 <p-table
   [value]="videoImports" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"

--- a/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
+++ b/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
@@ -1,4 +1,8 @@
-<h1 i18n>My imports</h1>
+<h1>
+  <my-global-icon iconName="cloud-download" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>My imports</ng-container>
+</h1>
+
 <p-table
   [value]="videoImports" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" dataKey="id"

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
@@ -1,4 +1,8 @@
-<h1 i18n>My playlists <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h1>
+<h1>
+  <my-global-icon iconName="playlists" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>My playlists</ng-container> <span class="badge badge-secondary">{{ pagination.totalItems }}</span>
+</h1>
+
 
 <div class="video-playlists-header">
   <input type="text" placeholder="Search your playlists" i18n-placeholder [(ngModel)]="videoPlaylistsSearch" (ngModelChange)="onVideoPlaylistSearchChanged()" />

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
@@ -1,6 +1,6 @@
-<div class="video-playlists-header">
-  <h1 i18n>Playlists <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h1>
+<h1 i18n>My playlists <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h1>
 
+<div class="video-playlists-header">
   <input type="text" placeholder="Search your playlists" i18n-placeholder [(ngModel)]="videoPlaylistsSearch" (ngModelChange)="onVideoPlaylistSearchChanged()" />
 
   <a class="create-button" routerLink="create">

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.scss
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.scss
@@ -41,10 +41,6 @@
   input[type=text] {
     @include peertube-input-text(300px);
   }
-
-  h1 {
-    font-size: 1.5rem;
-  }
 }
 
 @media screen and (max-width: $small-view) {

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
@@ -1,9 +1,7 @@
+<h1 i18n>My videos <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h1>
+
 <div class="videos-header">
-  <h1 i18n>Videos <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h1>
-
   <input type="text" placeholder="Search your videos" i18n-placeholder [(ngModel)]="videosSearch" (ngModelChange)="onVideosSearchChanged()" />
-
-  <div class="fake-element"></div>
 </div>
 
 <my-videos-selection

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>My videos <span class="badge badge-secondary">{{ pagination.totalItems }}</span></h1>
+<h1>
+  <my-global-icon iconName="videos" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>My videos</ng-container><span class="badge badge-secondary"> {{ pagination.totalItems }}</span>
+</h1>
 
 <div class="videos-header">
   <input type="text" placeholder="Search your videos" i18n-placeholder [(ngModel)]="videosSearch" (ngModelChange)="onVideosSearchChanged()" />

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.scss
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.scss
@@ -6,12 +6,6 @@
   justify-content: space-between;
   margin: 20px 0 50px;
 
-  h1,
-  .fake-element {
-    flex: 1;
-    font-size: 1.5rem;
-  }
-
   input[type=text] {
     @include peertube-input-text(300px);
   }

--- a/client/src/app/+my-account/my-account.component.scss
+++ b/client/src/app/+my-account/my-account.component.scss
@@ -1,4 +1,5 @@
 @import '_variables';
+@import '_mixins';
 
 .row {
   flex-direction: column;
@@ -8,10 +9,5 @@
     flex-grow: 1;
   }
 
-  ::ng-deep h1 {
-    font-size: 1.5rem;
-    border-bottom: 2px solid $grey-background-color;
-    padding-bottom: 15px;
-    margin-bottom: $sub-menu-margin-bottom;
-  }
+  @include sub-menu-h1;
 }

--- a/client/src/app/+my-account/my-account.component.scss
+++ b/client/src/app/+my-account/my-account.component.scss
@@ -1,8 +1,17 @@
+@import '_variables';
+
 .row {
   flex-direction: column;
   width: 100%;
 
   & > my-top-menu-dropdown:nth-child(1) {
     flex-grow: 1;
+  }
+
+  ::ng-deep h1 {
+    font-size: 1.5rem;
+    border-bottom: 2px solid $grey-background-color;
+    padding-bottom: 15px;
+    margin-bottom: $sub-menu-margin-bottom;
   }
 }

--- a/client/src/app/+videos/+video-edit/video-add.component.scss
+++ b/client/src/app/+videos/+video-edit/video-add.component.scss
@@ -30,15 +30,24 @@ $nav-link-height: 40px;
     padding: 0 30px !important;
     font-size: 15px;
 
+    border: $border-width $border-type transparent;
+
+    span {
+      border-bottom: 2px solid transparent;
+    }
+
     &.active {
-      border: $border-width $border-type $border-color;
-      border-bottom: none;
+      border-color: $border-color;
+      border-bottom-color: transparent;
       background-color: pvar(--submenuColor) !important;
 
       span {
-        border-bottom: 2px solid pvar(--mainColor);
-        font-weight: $font-bold;
+        border-bottom-color: pvar(--mainColor);
       }
+    }
+
+    &:hover:not(.active) {
+      border-color: transparent;
     }
   }
 }
@@ -71,7 +80,7 @@ $nav-link-height: 40px;
 
     /* Hide active tab style to not have a moving tab effect */
     a.nav-link.active {
-      border: none;
+      border-color: transparent;
       background-color: pvar(--mainBackgroundColor) !important;
     }
   }

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -4,7 +4,7 @@
     <a *ngIf="menuEntry.routerLink" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
     <div *ngIf="!menuEntry.routerLink" ngbDropdown class="parent-entry"
-      #dropdown="ngbDropdown" (mouseleave)="closeDropdownIfHovered(dropdown)" autoClose="outside">
+      #dropdown="ngbDropdown" autoClose="outside">
       <span
         *ngIf="isInSmallView"
         [ngClass]="{ active: !!suffixLabels[menuEntry.label] }"
@@ -14,7 +14,7 @@
 
       <span
         *ngIf="!isInSmallView"
-        (mouseenter)="openDropdownOnHover(dropdown)" [ngClass]="{ active: !!suffixLabels[menuEntry.label] }" ngbDropdownAnchor
+        [ngClass]="{ active: !!suffixLabels[menuEntry.label] }" ngbDropdownAnchor
         (click)="dropdownAnchorClicked(dropdown)" role="button" class="title-page title-page-settings"
       >
         <ng-container i18n>{{ menuEntry.label }}</ng-container>

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -7,15 +7,19 @@
       #dropdown="ngbDropdown" autoClose="outside">
       <span
         *ngIf="isInSmallView"
+        tabindex=0
         [ngClass]="{ active: !!suffixLabels[menuEntry.label] }"
-        (click)="openModal(id)" role="button" class="title-page title-page-settings">
+        (click)="openModal(id)" (keydown.enter)="openModal(id)"
+        role="button" class="title-page title-page-settings">
         <ng-container i18n>{{ menuEntry.label }}</ng-container>
       </span>
 
       <span
         *ngIf="!isInSmallView"
+        tabindex=0
         [ngClass]="{ active: !!suffixLabels[menuEntry.label] }" ngbDropdownAnchor
-        (click)="dropdownAnchorClicked(dropdown)" role="button" class="title-page title-page-settings"
+        (click)="dropdownAnchorClicked(dropdown)" (keydown.enter)="dropdownAnchorClicked(dropdown)"
+        role="button" class="title-page title-page-settings"
       >
         <ng-container i18n>{{ menuEntry.label }}</ng-container>
       </span>

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -4,7 +4,7 @@
     <a *ngIf="menuEntry.routerLink" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
     <div *ngIf="!menuEntry.routerLink" ngbDropdown class="parent-entry"
-      #dropdown="ngbDropdown" (mouseleave)="closeDropdownIfHovered(dropdown)">
+      #dropdown="ngbDropdown" (mouseleave)="closeDropdownIfHovered(dropdown)" autoClose="outside">
       <span
         *ngIf="isInSmallView"
         [ngClass]="{ active: !!suffixLabels[menuEntry.label] }"

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -10,7 +10,6 @@
         [ngClass]="{ active: !!suffixLabels[menuEntry.label] }"
         (click)="openModal(id)" role="button" class="title-page title-page-settings">
         <ng-container i18n>{{ menuEntry.label }}</ng-container>
-        <ng-container *ngIf="!!suffixLabels[menuEntry.label]"> - {{ suffixLabels[menuEntry.label] }}</ng-container>
       </span>
 
       <span
@@ -19,11 +18,10 @@
         (click)="dropdownAnchorClicked(dropdown)" role="button" class="title-page title-page-settings"
       >
         <ng-container i18n>{{ menuEntry.label }}</ng-container>
-        <ng-container *ngIf="!!suffixLabels[menuEntry.label]"> - {{ suffixLabels[menuEntry.label] }}</ng-container>
       </span>
 
       <div ngbDropdownMenu>
-        <a *ngFor="let menuChild of menuEntry.children" class="dropdown-item" [ngClass]="{ icon: hasIcons }" [routerLink]="menuChild.routerLink">
+        <a *ngFor="let menuChild of menuEntry.children" class="dropdown-item" [ngClass]="{ icon: hasIcons, active: suffixLabels[menuEntry.label] === menuChild.label }" [routerLink]="menuChild.routerLink">
           <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
 
           {{ menuChild.label }}

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.scss
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.scss
@@ -1,6 +1,12 @@
 @import '_variables';
 @import '_mixins';
 
+:host {
+  display: block;
+  height: $sub-menu-height;
+  margin-bottom: $sub-menu-margin-bottom;
+}
+
 .parent-entry {
   span[role=button] {
     cursor: pointer;

--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.ts
@@ -33,7 +33,6 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
   isModalOpened = false
   currentMenuEntryIndex: number
 
-  private openedOnHover = false
   private routeSub: Subscription
 
   constructor (
@@ -68,30 +67,8 @@ export class TopMenuDropdownComponent implements OnInit, OnDestroy {
     if (this.routeSub) this.routeSub.unsubscribe()
   }
 
-  openDropdownOnHover (dropdown: NgbDropdown) {
-    this.openedOnHover = true
-    dropdown.open()
-
-    // Menu was closed
-    dropdown.openChange
-            .pipe(take(1))
-            .subscribe(() => this.openedOnHover = false)
-  }
-
   dropdownAnchorClicked (dropdown: NgbDropdown) {
-    if (this.openedOnHover) {
-      this.openedOnHover = false
-      return
-    }
-
     return dropdown.toggle()
-  }
-
-  closeDropdownIfHovered (dropdown: NgbDropdown) {
-    if (this.openedOnHover === false) return
-
-    dropdown.close()
-    this.openedOnHover = false
   }
 
   openModal (index: number) {

--- a/client/src/app/shared/shared-moderation/account-blocklist.component.html
+++ b/client/src/app/shared/shared-moderation/account-blocklist.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>Muted accounts</h1>
+<h1>
+  <my-global-icon iconName="user" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>Muted accounts</ng-container>
+</h1>
 
 <p-table
   [value]="blockedAccounts" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"

--- a/client/src/app/shared/shared-moderation/account-blocklist.component.html
+++ b/client/src/app/shared/shared-moderation/account-blocklist.component.html
@@ -1,3 +1,5 @@
+<h1 i18n>Muted accounts</h1>
+
 <p-table
   [value]="blockedAccounts" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" (onPage)="onPage($event)"

--- a/client/src/app/shared/shared-moderation/server-blocklist.component.html
+++ b/client/src/app/shared/shared-moderation/server-blocklist.component.html
@@ -1,4 +1,7 @@
-<h1 i18n>Muted servers</h1>
+<h1>
+  <my-global-icon iconName="server" aria-hidden="true"></my-global-icon>
+  <ng-container i18n>Muted servers</ng-container>
+</h1>
 
 <p-table
   [value]="blockedServers" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"

--- a/client/src/app/shared/shared-moderation/server-blocklist.component.html
+++ b/client/src/app/shared/shared-moderation/server-blocklist.component.html
@@ -1,3 +1,5 @@
+<h1 i18n>Muted servers</h1>
+
 <p-table
   [value]="blockedServers" [lazy]="true" [paginator]="totalRecords > 0" [totalRecords]="totalRecords" [rows]="rowsPerPage" [rowsPerPageOptions]="rowsPerPageOptions"
   [sortField]="sort.field" [sortOrder]="sort.order" (onLazyLoad)="loadLazy($event)" (onPage)="onPage($event)"

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -178,14 +178,16 @@ label {
   font-weight: $font-semibold;
   @include disable-default-a-behaviour;
 
+  border-bottom: 2px solid transparent;
+
   &.active, &.title-page-single {
     margin-top: 30px;
     margin-bottom: 25px;
   }
 
   &.active {
-    font-weight: $font-bold;
-    border-bottom: 2px solid pvar(--mainColor);
+    color: pvar(--mainColor) !important;
+    border-bottom-color: pvar(--mainColor);
   }
 
   &.title-page-single {
@@ -194,6 +196,10 @@ label {
 
   &:hover, &:active, &:focus {
     color: pvar(--mainForegroundColor);
+  }
+
+  &:hover:not(.active) {
+    border-bottom-color: pvar(--mainForegroundColor);
   }
 
   @media screen and (max-width: $mobile-view) {
@@ -205,10 +211,10 @@ label {
 .title-page-settings {
   white-space: nowrap;
   font-size: 115%;
-  font-weight: $font-regular;
+  font-weight: $font-semibold;
 
   &.active {
-    font-weight: $font-semibold;
+    color: pvar(--mainColor);
   }
 }
 
@@ -228,9 +234,9 @@ label {
     color: pvar(--mainForegroundColor);
     padding: 5px 15px;
     border-radius: 0.25rem;
+    font-weight: $font-semibold;
 
     &.active {
-      font-weight: $font-semibold;
       background-color: #f0f0f0;
       color: #000;
     }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -171,6 +171,7 @@ label {
 }
 
 .title-page {
+  opacity: 0.6;
   color: pvar(--mainForegroundColor);
   font-size: 16px;
   display: inline-block;
@@ -186,7 +187,6 @@ label {
   }
 
   &.active {
-    color: pvar(--mainColor) !important;
     border-bottom-color: pvar(--mainColor);
   }
 
@@ -198,8 +198,8 @@ label {
     color: pvar(--mainForegroundColor);
   }
 
-  &:hover:not(.active) {
-    border-bottom-color: pvar(--mainForegroundColor);
+  &.active, &:hover,  &:active, &:focus, &.title-page-single {
+    opacity: 1;
   }
 
   @media screen and (max-width: $mobile-view) {
@@ -211,11 +211,6 @@ label {
 .title-page-settings {
   white-space: nowrap;
   font-size: 115%;
-  font-weight: $font-semibold;
-
-  &.active {
-    color: pvar(--mainColor);
-  }
 }
 
 .admin-sub-header {
@@ -235,10 +230,14 @@ label {
     padding: 5px 15px;
     border-radius: 0.25rem;
     font-weight: $font-semibold;
+    opacity: 0.6;
 
     &.active {
       background-color: #f0f0f0;
-      color: #000;
+    }
+
+    &.active, &:hover, &:active, &:focus {
+      opacity: 1;
     }
   }
 }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -201,6 +201,7 @@ label {
 
   &.active, &:hover,  &:active, &:focus, &.title-page-single {
     opacity: 1;
+    outline: 0px hidden !important;
   }
 
   @media screen and (max-width: $mobile-view) {

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -135,12 +135,13 @@ label {
   .sub-menu {
     background-color: pvar(--submenuColor);
     width: 100%;
-    height: 81px;
-    margin-bottom: $sub-menu-margin-bottom;
+    height: $sub-menu-height;
     display: flex;
     align-items: center;
     padding-left: $not-expanded-horizontal-margins;
     padding-right: $not-expanded-horizontal-margins;
+    position: fixed;
+    z-index: 1;
   }
 
   // Override some properties if the main content is expanded (no menu on the left)

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -180,7 +180,7 @@ label {
 
   border-bottom: 2px solid transparent;
 
-  &.active, &.title-page-single {
+  &.title-page-single {
     margin-top: 30px;
     margin-bottom: 25px;
   }

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -155,8 +155,12 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
   font-size: 16px !important;
   font-weight: $font-semibold !important;
 
-  .nav-link.active {
-    color: pvar(--mainColor)
+  .nav-link {
+    opacity: 0.6 !important;
+
+    &.active, &:hover, &:active, &:focus {
+      opacity: 1 !important;
+    }
   }
 
   a {
@@ -173,16 +177,16 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
   font-weight: $font-semibold;
   border: none;
   border-bottom: 2px solid transparent;
+  opacity: 0.6;
 
   &.active {
-    color: pvar(--mainColor) !important;
+    color: pvar(--mainForegroundColor);
     background-color: pvar(--mainBackgroundColor) !important;
     border-bottom-color: pvar(--mainColor);
   }
 
-  &:hover:not(.active) {
-    color: pvar(--mainColor) !important;
-    border-bottom-color: transparent;
+  &.active, &:hover, &:active, &:focus {
+    opacity: 1;
   }
 }
 

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -153,9 +153,10 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
 
 .nav.nav-pills {
   font-size: 16px !important;
+  font-weight: $font-semibold !important;
 
   .nav-link.active {
-    font-weight: $font-semibold !important;
+    color: pvar(--mainColor)
   }
 
   a {
@@ -165,29 +166,23 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
   }
 }
 
-.nav-tabs {
-
-  .nav-link {
-    @include disable-default-a-behaviour;
-
-    color: pvar(--mainForegroundColor) !important;
-  }
-}
-
 .nav-tabs .nav-link {
-  &:not(.active) {
-    border-bottom: 3px solid transparent;
-  }
+  @include disable-default-a-behaviour;
+
+  color: pvar(--mainForegroundColor);
+  font-weight: $font-semibold;
+  border: none;
+  border-bottom: 2px solid transparent;
+
   &.active {
-    font-weight: $font-semibold;
+    color: pvar(--mainColor) !important;
     background-color: pvar(--mainBackgroundColor) !important;
-    border: none;
-    border-bottom: 2px solid pvar(--mainColor);
+    border-bottom-color: pvar(--mainColor);
   }
-  &:hover {
-    border-top-color: transparent;
-    border-left-color: transparent;
-    border-right-color: transparent;
+
+  &:hover:not(.active) {
+    color: pvar(--mainColor) !important;
+    border-bottom-color: transparent;
   }
 }
 

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -929,3 +929,23 @@
     @content;
   }
 }
+
+@mixin sub-menu-h1 {
+  ::ng-deep h1 {
+    font-size: 1.3rem;
+    border-bottom: 2px solid $grey-background-color;
+    padding-bottom: 15px;
+    margin-bottom: $sub-menu-margin-bottom;
+
+    my-global-icon {
+      margin-right: 10px;
+      vertical-align: bottom;
+      width: 24px;
+      height: 24px;
+    }
+
+    .badge {
+      margin-left: 7px;
+    }
+  }
+}

--- a/client/src/sass/include/_variables.scss
+++ b/client/src/sass/include/_variables.scss
@@ -49,6 +49,7 @@ $menu-width: 240px;
 $menu-lateral-padding: 26px;
 
 $sub-menu-color: #F7F7F7;
+$sub-menu-height: 81px;
 
 $footer-height: 30px;
 $footer-margin: 30px;


### PR DESCRIPTION
Needs https://github.com/Chocobozzz/PeerTube/pull/2977 to update new icons.

This PR proposes to improve the navigation links effects : 

- ~Prefer changing text color instead of text bold when switching between active and non-active link to avoid to resize effects ;~ => use `opacity: 0.6` on non-active links
  
- Add transparent borders on non-active links to avoid involuntary resize between links or tabs ;
- ~Change color on hover event for tabs ;~
- ~Border-bottom black on hover event for links (sub-menu)~ ; => only `opacity: 1`
- Remove margin-top on active link (sub-menu) ; 

- Sub-menu fixed ;
  _usefull on touchdevices_ 
- Improve Dropdown : active class on active link + remove hover open + close outside click only
  _make sure the sub-menu is not too long horizontally - less confusing nav and more common_
- Remove labels Dropdown items and put them in H1 with icons after the sub-menu
  _cleaner, simplier ..._

![1-videos](https://user-images.githubusercontent.com/1877318/87836088-4020ee80-c88f-11ea-9f94-ae87c4ba843c.png)
![1-subscriptions](https://user-images.githubusercontent.com/1877318/87836089-40b98500-c88f-11ea-9623-2e6d812efb4b.png)
![1-reports](https://user-images.githubusercontent.com/1877318/87836091-40b98500-c88f-11ea-83e1-5dfb4a2308d1.png)
![1-playlists](https://user-images.githubusercontent.com/1877318/87836092-41521b80-c88f-11ea-8a67-654d5c9d6303.png)
![1-imports](https://user-images.githubusercontent.com/1877318/87836093-41521b80-c88f-11ea-904e-9e1107de74c5.png)
![1-history](https://user-images.githubusercontent.com/1877318/87836094-41eab200-c88f-11ea-80d5-767fae2b392f.png)
![1-channels](https://user-images.githubusercontent.com/1877318/87836095-42834880-c88f-11ea-97b5-4dadff7a0bfd.png)
