### PR TITLE
Hide generic channel display name and avatar on watch view

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -147,12 +147,20 @@
               <avatar-channel [video]="video"></avatar-channel>
 
               <div class="video-info-channel-left-links ml-1">
-                <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" i18n-title title="Channel page">
-                  {{ video.channel.displayName }}
-                </a>
-                <a [routerLink]="[ '/accounts', video.byAccount ]" i18n-title title="Account page">
-                  <span i18n>By {{ video.byAccount }}</span>
-                </a>
+                <ng-container *ngIf="!isChannelDisplayNameGeneric()">
+                  <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" i18n-title title="Channel page">
+                    {{ video.channel.displayName }}
+                  </a>
+                  <a [routerLink]="[ '/accounts', video.byAccount ]" i18n-title title="Account page">
+                    <span i18n>By {{ video.byAccount }}</span>
+                  </a>
+                </ng-container>
+
+                <ng-container *ngIf="isChannelDisplayNameGeneric()">
+                  <a [routerLink]="[ '/accounts', video.byAccount ]" class="single-link" i18n-title title="Account page">
+                    <span i18n>{{ video.byAccount }}</span>
+                  </a>
+                </ng-container>
               </div>
             </div>
 

--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -144,7 +144,7 @@
 
           <div class="pt-3 border-top video-info-channel d-flex">
             <div class="video-info-channel-left d-flex">
-              <avatar-channel [video]="video"></avatar-channel>
+              <avatar-channel [video]="video" [genericChannel]="isChannelDisplayNameGeneric()"></avatar-channel>
 
               <div class="video-info-channel-left-links ml-1">
                 <ng-container *ngIf="!isChannelDisplayNameGeneric()">

--- a/client/src/app/+videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/+videos/+video-watch/video-watch.component.scss
@@ -192,6 +192,10 @@ $video-info-margin-left: 44px;
               font-weight: 500;
               font-size: 90%;
             }
+
+            a.single-link {
+              margin-top: 7px;
+            }
           }
         }
 

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -308,9 +308,12 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
   }
 
   isChannelDisplayNameGeneric () {
-    const genericChannelDisplayName = `Main ${this.video.channel.ownerAccount.name} channel`
+    const genericChannelDisplayName = [
+      `Main ${this.video.channel.ownerAccount.name} channel`,
+      `Default ${this.video.channel.ownerAccount.name} channel`
+    ]
 
-    return this.video.channel.displayName === genericChannelDisplayName
+    return genericChannelDisplayName.includes(this.video.channel.displayName)
   }
 
   private loadVideo (videoId: string) {

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -307,6 +307,12 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     )
   }
 
+  isChannelDisplayNameGeneric () {
+    const genericChannelDisplayName = `Main ${this.video.channel.ownerAccount.name} channel`
+
+    return this.video.channel.displayName === genericChannelDisplayName
+  }
+
   private loadVideo (videoId: string) {
     // Video did not change
     if (this.video && this.video.uuid === videoId) return

--- a/client/src/app/shared/shared-main/account/avatar.component.html
+++ b/client/src/app/shared/shared-main/account/avatar.component.html
@@ -1,8 +1,26 @@
 <div class="wrapper" [ngClass]="'avatar-' + size">
-  <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" [title]="channelLinkTitle">
-    <img [src]="video.videoChannelAvatarUrl" i18n-alt alt="Channel avatar" />
-  </a>
-  <a [routerLink]="[ '/accounts', video.byAccount ]" [title]="accountLinkTitle">
-    <img [src]="video.accountAvatarUrl" i18n-alt alt="Account avatar" />
-  </a>
+  <ng-container *ngIf="!isChannelAvatarNull() && !genericChannel">
+    <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" [title]="channelLinkTitle">
+      <img [src]="video.videoChannelAvatarUrl" i18n-alt alt="Channel avatar" />
+    </a>
+    <a [routerLink]="[ '/accounts', video.byAccount ]" [title]="accountLinkTitle">
+      <img [src]="video.accountAvatarUrl" i18n-alt alt="Account avatar" />
+    </a>
+  </ng-container>
+
+  <ng-container *ngIf="!isChannelAvatarNull() && genericChannel">
+    <a [routerLink]="[ '/accounts', video.byAccount ]" [title]="accountLinkTitle">
+      <img [src]="video.accountAvatarUrl" i18n-alt alt="Account avatar" />
+    </a>
+
+    <a [routerLink]="[ '/video-channels', video.byVideoChannel ]" [title]="channelLinkTitle">
+      <img [src]="video.videoChannelAvatarUrl" i18n-alt alt="Channel avatar" />
+    </a>
+  </ng-container>
+
+  <ng-container *ngIf="isChannelAvatarNull()">
+    <a [routerLink]="[ '/accounts', video.byAccount ]" [title]="accountLinkTitle">
+      <img [src]="video.accountAvatarUrl" i18n-alt alt="Account avatar" />
+    </a>
+  </ng-container>
 </div>

--- a/client/src/app/shared/shared-main/account/avatar.component.ts
+++ b/client/src/app/shared/shared-main/account/avatar.component.ts
@@ -10,6 +10,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 export class AvatarComponent implements OnInit {
   @Input() video: Video
   @Input() size: 'md' | 'sm' = 'md'
+  @Input() genericChannel: boolean
 
   channelLinkTitle = ''
   accountLinkTitle = ''
@@ -27,5 +28,9 @@ export class AvatarComponent implements OnInit {
       '{{name}} (account page)',
       { name: this.video.account.name, handle: this.video.byAccount }
     )
+  }
+
+  isChannelAvatarNull () {
+    return this.video.channel.avatar === null
   }
 }


### PR DESCRIPTION
First stab at : https://github.com/Chocobozzz/PeerTube/issues/2987
fixes #2953

- No avatar channel and generic display name (Main *username* channel) channel :
*the big avatar and account name redirect to the account page*
![no-avatar-and-channel](https://user-images.githubusercontent.com/1877318/87959621-75a62180-cab3-11ea-9cdb-06acb4d759d3.png)

- Generic display name (Main *username* channel) and a channel avatar is uploaded
*the small avatar is the channel avatar and redirect to the channel page*
![no-channel-avatar-not-null](https://user-images.githubusercontent.com/1877318/87959620-750d8b00-cab3-11ea-955e-c54f12951d71.png)

- Display name channel and avatar channel customized
*back to regular display*
![n-avatar-and-channel](https://user-images.githubusercontent.com/1877318/87959624-75a62180-cab3-11ea-8b7d-b9cdaa4f054a.png)
