### PR TITLE
Notification sorting, users table flexible columns

### DIFF
--- a/client/src/app/+admin/follows/followers-list/followers-list.component.html
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.html
@@ -41,8 +41,12 @@
         </a>
       </td>
 
-      <td *ngIf="follow.state === 'accepted'" i18n>Accepted</td>
-      <td *ngIf="follow.state === 'pending'" i18n>Pending</td>
+      <td *ngIf="follow.state === 'accepted'">
+        <span class="badge badge-green" i18n>Accepted</span>
+      </td>
+      <td *ngIf="follow.state === 'pending'">
+        <span class="badge badge-yellow" i18n>Pending</span>
+      </td>
 
       <td>{{ follow.score }}</td>
       <td>{{ follow.createdAt | date: 'short' }}</td>

--- a/client/src/app/+admin/follows/following-list/following-list.component.html
+++ b/client/src/app/+admin/follows/following-list/following-list.component.html
@@ -45,8 +45,12 @@
         </a>
       </td>
 
-      <td *ngIf="follow.state === 'accepted'" i18n>Accepted</td>
-      <td *ngIf="follow.state === 'pending'" i18n>Pending</td>
+      <td *ngIf="follow.state === 'accepted'">
+        <span class="badge badge-green" i18n>Accepted</span>
+      </td>
+      <td *ngIf="follow.state === 'pending'">
+        <span class="badge badge-yellow" i18n>Pending</span>
+      </td>
 
       <td>{{ follow.createdAt | date: 'short' }}</td>
       <td>

--- a/client/src/app/+admin/follows/follows.component.scss
+++ b/client/src/app/+admin/follows/follows.component.scss
@@ -4,3 +4,7 @@
   flex-grow: 0;
   margin-right: 30px;
 }
+
+.badge {
+  @include table-badge;
+}

--- a/client/src/app/+admin/system/jobs/jobs.component.html
+++ b/client/src/app/+admin/system/jobs/jobs.component.html
@@ -26,10 +26,10 @@
   <ng-template pTemplate="header">
     <tr>
       <th style="width: 40px"></th>
-      <th class="job-id" i18n>ID</th>
-      <th class="job-type" i18n>Type</th>
-      <th class="job-date" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th class="job-state" i18n>State</th>
+      <th style="width: 100%" class="job-id" i18n>ID</th>
+      <th style="width: 200px" class="job-type" i18n>Type</th>
+      <th style="width: 150px" class="job-date" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th style="width: 150px" class="job-state" i18n>State</th>
     </tr>
   </ng-template>
 
@@ -43,7 +43,7 @@
 
       <td class="job-id" [title]="job.id">{{ job.id }}</td>
       <td class="job-type">{{ job.type }}</td>
-      <td class="job-date">{{ job.createdAt }}</td>
+      <td class="job-date">{{ job.createdAt | date: 'short' }}</td>
       <td class="job-state" *ngIf="job.state === 'delayed'" class="text-muted"><span class="glyphicon glyphicon-repeat"></span> <span i18n>Delayed</span></td>
       <td class="job-state" *ngIf="job.state === 'waiting'" class="text-warning"><span class="glyphicon glyphicon-hourglass"></span> <span i18n>Will start soon...</span></td>
       <td class="job-state" *ngIf="job.state === 'active'" class="text-warning"><span class="glyphicon glyphicon-cog"></span> <span i18n>Running...</span></td>

--- a/client/src/app/+admin/users/user-list/user-list.component.html
+++ b/client/src/app/+admin/users/user-list/user-list.component.html
@@ -50,19 +50,41 @@
         <p-tableHeaderCheckbox></p-tableHeaderCheckbox>
       </th>
       <th style="width: 40px"></th>
-      <th pResizableColumn i18n pSortableColumn="username">Username <p-sortIcon field="username"></p-sortIcon></th>
-      <th i18n>Email</th>
-      <th style="width: 140px;" i18n pSortableColumn="videoQuotaUsed">Video quota <p-sortIcon field="videoQuotaUsed"></p-sortIcon></th>
-      <th style="width: 120px;" i18n>Role</th>
-      <th style="width: 140px;" pResizableColumn i18n>Auth plugin</th>
-      <th style="width: 150px;" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
-      <th style="width: 60px;"></th>
+      <th *ngIf="getColumn('username')" pResizableColumn i18n pSortableColumn="username">{{ getColumn('username').label }} <p-sortIcon field="username"></p-sortIcon></th>
+      <th *ngIf="getColumn('email')" i18n>{{ getColumn('email').label }}</th>
+      <th *ngIf="getColumn('quota')" style="width: 160px;" i18n pSortableColumn="videoQuotaUsed">{{ getColumn('quota').label }} <p-sortIcon field="videoQuotaUsed"></p-sortIcon></th>
+      <th *ngIf="getColumn('quotaDaily')" style="width: 160px;" i18n>{{ getColumn('quotaDaily').label }}</th>
+      <th *ngIf="getColumn('role')" style="width: 120px;" i18n pSortableColumn="role">{{ getColumn('role').label }} <p-sortIcon field="role"></p-sortIcon></th>
+      <th *ngIf="getColumn('pluginAuth')" style="width: 140px;" pResizableColumn i18n>{{ getColumn('pluginAuth').label }}</th>
+      <th *ngIf="getColumn('createdAt')" style="width: 150px;" i18n pSortableColumn="createdAt">{{ getColumn('createdAt').label }} <p-sortIcon field="createdAt"></p-sortIcon></th>
+      <th *ngIf="getColumn('lastLoginDate')" style="width: 150px;" i18n pSortableColumn="lastLoginDate">{{ getColumn('lastLoginDate').label }} <p-sortIcon field="lastLoginDate"></p-sortIcon></th>
+      <th style="width: 60px;">
+        <div class="c-hand" ngbDropdown placement="bottom-right auto" container="body" autoClose="outside">
+          <my-global-icon iconName="columns" ngbDropdownToggle></my-global-icon>
+  
+          <div role="menu" class="dropdown-menu" ngbDropdownMenu>
+            <div class="dropdown-header" i18n>Table parameters</div>
+            <div ngbDropdownItem class="dropdown-item">
+              <p-multiSelect
+                [options]="columns" [showToggleAll]="true" [(ngModel)]="selectedColumns" optionLabel="label"
+                emptyFilterMessage="No matching column found" i18n-emptyFilterMessage [filter]="false"
+                selectedItemsLabel="{0} columns displayed" i18n-emptyFilterMessage [showHeader]="false"
+                [maxSelectedLabels]="4"
+              ></p-multiSelect>
+            </div>
+            <div ngbDropdownItem class="dropdown-item">
+              <my-peertube-checkbox inputName="highlightBannedUsers" [(ngModel)]="highlightBannedUsers"
+                i18n-labelText labelText="Highlight banned users"></my-peertube-checkbox>
+            </div>
+          </div>
+        </div>
+      </th>
     </tr>
   </ng-template>
 
   <ng-template pTemplate="body" let-expanded="expanded" let-user>
 
-    <tr [pSelectableRow]="user" [ngClass]="{ banned: user.blocked }">
+    <tr [pSelectableRow]="user" [ngClass]="{ banned: highlightBannedUsers && user.blocked }">
       <td>
         <p-tableCheckbox [value]="user"></p-tableCheckbox>
       </td>
@@ -73,7 +95,7 @@
         </span>
       </td>
 
-      <td>
+      <td *ngIf="getColumn('username')">
         <a i18n-title title="Open account in a new tab" target="_blank" rel="noopener noreferrer" [routerLink]="[ '/accounts/' + user.username ]">
           <div class="chip two-lines">
             <img
@@ -83,17 +105,16 @@
               alt="Avatar"
             >
             <div>
-              <span class="user-table-primary-text">
-                <span *ngIf="user.blocked" i18n-title title="The user was banned" class="glyphicon glyphicon-ban-circle"></span>
-                {{ user.account.displayName }}
-              </span>
+              <span class="user-table-primary-text">{{ user.account.displayName }}</span>
               <span class="text-muted">{{ user.username }}</span>
             </div>
           </div>
         </a>
       </td>
 
-      <td *ngIf="!requiresEmailVerification || user.blocked; else emailWithVerificationStatus" [title]="user.email">{{ user.email }}</td>
+      <td *ngIf="!requiresEmailVerification || user.blocked; else emailWithVerificationStatus" [title]="user.email">
+        <a class="table-email" [href]="'mailto:' + user.email">{{ user.email }}</a>
+      </td>
 
       <ng-template #emailWithVerificationStatus>
         <td *ngIf="user.emailVerified === false; else emailVerifiedNotFalse" i18n-title title="User's email must be verified to login">
@@ -106,14 +127,38 @@
         </ng-template>
       </ng-template>
 
-      <td>{{ user.videoQuotaUsed }} / {{ user.videoQuota }}</td>
-      <td>{{ user.roleLabel }}</td>
+      <td *ngIf="getColumn('quota')">
+        <div class="progress" i18n-title title="Total video quota">
+          <div class="progress-bar" role="progressbar" [style]="{ width: getUserVideoQuotaPercentage(user) + '%' }"
+               [attr.aria-valuenow]="user.rawVideoQuotaUsed" aria-valuemin="0" [attr.aria-valuemax]="user.rawVideoQuota">
+          </div>
+          <span>{{ user.videoQuotaUsed }}</span>
+          <span>{{ user.videoQuota }}</span>
+        </div>
+      </td>
 
-      <td>
+      <td *ngIf="getColumn('quotaDaily')">
+        <div class="progress" i18n-title title="Total daily video quota">
+          <div class="progress-bar secondary" role="progressbar" [style]="{ width: getUserVideoQuotaDailyPercentage(user) + '%' }"
+               [attr.aria-valuenow]="user.rawVideoQuotaUsedDaily" aria-valuemin="0" [attr.aria-valuemax]="user.rawVideoQuotaDaily">
+          </div>
+          <span>{{ user.videoQuotaUsedDaily }}</span>
+          <span>{{ user.videoQuotaDaily }}</span>
+        </div>
+      </td>
+
+      <td *ngIf="getColumn('role')">
+        <span *ngIf="user.blocked" class="badge badge-banned" i18n-title title="The user was banned">{{ user.roleLabel }}</span>
+        <span *ngIf="!user.blocked" class="badge" [ngClass]="getRoleClass(user.role)">{{ user.roleLabel }}</span>
+      </td>
+
+      <td *ngIf="getColumn('pluginAuth')">
         <ng-container *ngIf="user.pluginAuth">{{ user.pluginAuth }}</ng-container>
       </td>
 
-      <td [title]="user.createdAt">{{ user.createdAt | date: 'short' }}</td>
+      <td *ngIf="getColumn('createdAt')" [title]="user.createdAt">{{ user.createdAt | date: 'short' }}</td>
+
+      <td *ngIf="getColumn('lastLoginDate')" [title]="user.lastLoginDate">{{ user.lastLoginDate | date: 'short' }}</td>
 
       <td class="action-cell">
         <my-user-moderation-dropdown

--- a/client/src/app/+admin/users/user-list/user-list.component.html
+++ b/client/src/app/+admin/users/user-list/user-list.component.html
@@ -112,8 +112,10 @@
         </a>
       </td>
 
-      <td *ngIf="!requiresEmailVerification || user.blocked; else emailWithVerificationStatus" [title]="user.email">
-        <a class="table-email" [href]="'mailto:' + user.email">{{ user.email }}</a>
+      <td *ngIf="getColumn('email')" [title]="user.email">
+        <ng-container *ngIf="!requiresEmailVerification || user.blocked; else emailWithVerificationStatus">
+          <a class="table-email" [href]="'mailto:' + user.email">{{ user.email }}</a>
+        </ng-container>
       </td>
 
       <ng-template #emailWithVerificationStatus>

--- a/client/src/app/+admin/users/user-list/user-list.component.scss
+++ b/client/src/app/+admin/users/user-list/user-list.component.scss
@@ -54,7 +54,7 @@ my-global-icon {
 }
 
 .progress {
-  @include progressbar;
+  @include progressbar($small: true);
   width: auto;
   max-width: 100%;
 }

--- a/client/src/app/+admin/users/user-list/user-list.component.scss
+++ b/client/src/app/+admin/users/user-list/user-list.component.scss
@@ -9,6 +9,11 @@ tr.banned > td {
   background-color: lighten($color: $red, $amount: 40) !important;
 }
 
+.table-email {
+  @include disable-default-a-behaviour;
+  color: pvar(--mainForegroundColor);
+}
+
 .banned-info {
   font-style: italic;
 }
@@ -36,8 +41,22 @@ p-tableCheckbox {
   top: -2.5px;
 }
 
+my-global-icon {
+  width: 18px;
+}
+
 .chip {
   @include chip;
+}
+
+.badge {
+  @include table-badge;
+}
+
+.progress {
+  @include progressbar;
+  width: auto;
+  max-width: 100%;
 }
 
 .input-group {

--- a/client/src/app/+admin/users/user-list/user-list.component.ts
+++ b/client/src/app/+admin/users/user-list/user-list.component.ts
@@ -7,6 +7,13 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 import { ServerConfig, User, UserRole } from '@shared/models'
 import { Params, Router, ActivatedRoute } from '@angular/router'
 
+type UserForList = User & {
+  rawVideoQuota: number
+  rawVideoQuotaUsed: number
+  rawVideoQuotaDaily: number
+  rawVideoQuotaUsedDaily: number
+}
+
 @Component({
   selector: 'my-user-list',
   templateUrl: './user-list.component.html',
@@ -24,8 +31,8 @@ export class UserListComponent extends RestTable implements OnInit {
   selectedUsers: User[] = []
   bulkUserActions: DropdownAction<User[]>[][] = []
   columns: { key: string, label: string }[]
-  _selectedColumns: { key: string, label: string }[]
 
+  private _selectedColumns: { key: string, label: string }[]
   private serverConfig: ServerConfig
 
   constructor (
@@ -111,7 +118,7 @@ export class UserListComponent extends RestTable implements OnInit {
       { key: 'role', label: 'Role' },
       { key: 'createdAt', label: 'Created' }
     ]
-    this.selectedColumns = [...this.columns]
+    this.selectedColumns = [ ...this.columns ] // make a full copy of the array
     this.columns.push({ key: 'quotaDaily', label: 'Daily quota' })
     this.columns.push({ key: 'pluginAuth', label: 'Auth plugin' })
     this.columns.push({ key: 'lastLoginDate', label: 'Last login' })
@@ -133,14 +140,14 @@ export class UserListComponent extends RestTable implements OnInit {
   }
 
   getColumn (key: string) {
-    return this.selectedColumns.find((col: any) => col.key === key)
+    return this.selectedColumns.find((col: { key: string }) => col.key === key)
   }
 
-  getUserVideoQuotaPercentage (user: User & { rawVideoQuota: number, rawVideoQuotaUsed: number}) {
+  getUserVideoQuotaPercentage (user: UserForList) {
     return user.rawVideoQuotaUsed * 100 / user.rawVideoQuota
   }
 
-  getUserVideoQuotaDailyPercentage (user: User & { rawVideoQuotaDaily: number, rawVideoQuotaUsedDaily: number}) {
+  getUserVideoQuotaDailyPercentage (user: UserForList) {
     return user.rawVideoQuotaUsedDaily * 100 / user.rawVideoQuotaDaily
   }
 

--- a/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.html
+++ b/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.html
@@ -1,14 +1,21 @@
-<h1>
-  <my-global-icon iconName="channel" aria-hidden="true"></my-global-icon>
-  <ng-container i18n>My channels</ng-container>
-</h1>
+<h1 class="d-flex justify-content-between">
+  <span>
+    <my-global-icon iconName="channel" aria-hidden="true"></my-global-icon>
+    <ng-container i18n>My channels</ng-container>
+    <span class="badge badge-secondary">{{ totalItems }}</span>
+  </span>
 
-<div class="video-channels-header">
+  <div class="has-feedback has-clear">
+    <input type="text" placeholder="Search your channels" i18n-placeholder [(ngModel)]="channelsSearch" (ngModelChange)="onChannelsSearchChanged()" />
+    <a class="glyphicon glyphicon-remove-sign form-control-feedback form-control-clear" (click)="resetSearch()"></a>
+    <span class="sr-only" i18n>Clear filters</span>
+  </div>
+
   <a class="create-button" routerLink="create">
     <my-global-icon iconName="add" aria-hidden="true"></my-global-icon>
     <ng-container i18n>Create video channel</ng-container>
   </a>
-</div>
+</h1>
 
 <div class="video-channels">
   <div *ngFor="let videoChannel of videoChannels; let i = index" class="video-channel">

--- a/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.scss
+++ b/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.scss
@@ -5,6 +5,10 @@
   @include create-button;
 }
 
+input[type=text] {
+  @include peertube-input-text(300px);
+}
+
 ::ng-deep .action-button {
   &.action-button-edit {
     margin-right: 10px;
@@ -53,11 +57,6 @@
     margin-top: 10px;
     min-width: 190px;
   }
-}
-
-.video-channels-header {
-  text-align: right;
-  margin: 20px 0 50px;
 }
 
 ::ng-deep .chartjs-render-monitor {

--- a/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.ts
+++ b/client/src/app/+my-account/+my-account-video-channels/my-account-video-channels.component.ts
@@ -99,7 +99,7 @@ export class MyAccountVideoChannelsComponent implements OnInit {
     }
   }
 
-  resetSearch() {
+  resetSearch () {
     this.channelsSearch = ''
     this.onChannelsSearchChanged()
   }

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
@@ -5,7 +5,15 @@
     Notification preferences
   </a>
 
-  <button class="btn" [disabled]="!hasUnreadNotifications()" (click)="markAllAsRead()">
+  <div class="peertube-select-container peertube-select-button ml-2">
+    <select [(ngModel)]="notificationSortType" (ngModelChange)="onNotificationSortTypeChanged()" class="form-control">
+      <option value="undefined" disabled>Sort by</option>
+      <option value="created" i18n>Newest first</option>
+      <option value="unread-created" i18n>Unread first</option>
+    </select>
+  </div>
+
+  <button class="btn ml-auto" [disabled]="!hasUnreadNotifications()" (click)="markAllAsRead()">
     <ng-container *ngIf="hasUnreadNotifications()">
       <my-global-icon iconName="inbox-full" aria-hidden="true"></my-global-icon>
 

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
@@ -6,10 +6,10 @@
   </a>
 
   <div class="peertube-select-container peertube-select-button ml-2">
-    <select [(ngModel)]="notificationSortType" class="form-control">
+    <select [(ngModel)]="notificationSortType" (ngModelChange)="onChangeSortColumn()" class="form-control">
       <option value="undefined" disabled>Sort by</option>
-      <option value="created" i18n>Newest first</option>
-      <option value="unread-created" i18n>Unread first</option>
+      <option value="createdAt" i18n>Newest first</option>
+      <option value="read" [disabled]="!hasUnreadNotifications()" i18n>Unread first</option>
     </select>
   </div>
 

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
@@ -5,7 +5,7 @@
     Notification preferences
   </a>
 
-  <div class="peertube-select-container peertube-select-button ml-2">
+  <div class="peertube-select-container peertube-select-button ml-2 mr-2">
     <select [(ngModel)]="notificationSortType" (ngModelChange)="onChangeSortColumn()" class="form-control">
       <option value="undefined" disabled>Sort by</option>
       <option value="createdAt" i18n>Newest first</option>

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
@@ -6,7 +6,7 @@
   </a>
 
   <div class="peertube-select-container peertube-select-button ml-2">
-    <select [(ngModel)]="notificationSortType" (ngModelChange)="onNotificationSortTypeChanged()" class="form-control">
+    <select [(ngModel)]="notificationSortType" class="form-control">
       <option value="undefined" disabled>Sort by</option>
       <option value="created" i18n>Newest first</option>
       <option value="unread-created" i18n>Unread first</option>

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.scss
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.scss
@@ -32,8 +32,40 @@ my-user-notifications {
   .header {
     flex-direction: column;
 
-    & >:first-child {
+    & >:first-child, .peertube-select-container {
       margin-bottom: 15px;
+    }
+
+    .peertube-select-container {
+      margin-left: 0 !important;
+    }
+  }
+}
+
+@media screen and (min-width: $mobile-view) and (max-width: $small-view) {
+  .header {
+    a {
+      font-size: 0;
+      padding: 0 13px;
+    }
+
+    .peertube-select-container {
+      width: auto !important;
+    }
+  }
+}
+
+@media screen and (min-width: $mobile-view) and (max-width: #{$small-view + $menu-width}) {
+  :host-context(.main-col:not(.expanded)) {
+    .header {
+      a {
+        font-size: 0;
+        padding: 0 13px;
+      }
+
+      .peertube-select-container {
+        width: auto !important;
+      }
     }
   }
 }

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.scss
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.scss
@@ -3,7 +3,6 @@
 
 .header {
   display: flex;
-  justify-content: space-between;
   font-size: 15px;
   margin-bottom: 20px;
 
@@ -18,7 +17,12 @@
     @include grey-button;
     @include button-with-icon(20px, 3px, -1px);
   }
+
+  .peertube-select-container {
+    @include peertube-select-container(auto);
+  }
 }
+
 
 my-user-notifications {
   font-size: 15px;

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.ts
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.ts
@@ -1,6 +1,8 @@
 import { Component, ViewChild } from '@angular/core'
 import { UserNotificationsComponent } from '@app/shared/shared-main'
 
+type NotificationSortType = 'createdAt' | 'read'
+
 @Component({
   templateUrl: './my-account-notifications.component.html',
   styleUrls: [ './my-account-notifications.component.scss' ]
@@ -8,7 +10,17 @@ import { UserNotificationsComponent } from '@app/shared/shared-main'
 export class MyAccountNotificationsComponent {
   @ViewChild('userNotification', { static: true }) userNotification: UserNotificationsComponent
 
-  notificationSortType = 'created'
+  _notificationSortType: NotificationSortType = 'createdAt'
+
+  get notificationSortType () {
+    return !this.hasUnreadNotifications()
+      ? 'createdAt'
+      : this._notificationSortType
+  }
+
+  set notificationSortType (type: NotificationSortType) {
+    this._notificationSortType = type
+  }
 
   markAllAsRead () {
     this.userNotification.markAllAsRead()
@@ -16,5 +28,9 @@ export class MyAccountNotificationsComponent {
 
   hasUnreadNotifications () {
     return this.userNotification.notifications.filter(n => n.read === false).length !== 0
+  }
+
+  onChangeSortColumn () {
+    this.userNotification.changeSortColumn(this.notificationSortType)
   }
 }

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.ts
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.ts
@@ -17,6 +17,4 @@ export class MyAccountNotificationsComponent {
   hasUnreadNotifications () {
     return this.userNotification.notifications.filter(n => n.read === false).length !== 0
   }
-
-  onNotificationSortTypeChanged () {}
 }

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.ts
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.ts
@@ -8,6 +8,8 @@ import { UserNotificationsComponent } from '@app/shared/shared-main'
 export class MyAccountNotificationsComponent {
   @ViewChild('userNotification', { static: true }) userNotification: UserNotificationsComponent
 
+  notificationSortType = 'created'
+
   markAllAsRead () {
     this.userNotification.markAllAsRead()
   }
@@ -15,4 +17,6 @@ export class MyAccountNotificationsComponent {
   hasUnreadNotifications () {
     return this.userNotification.notifications.filter(n => n.read === false).length !== 0
   }
+
+  onNotificationSortTypeChanged () {}
 }

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.html
@@ -62,7 +62,11 @@
       </td>
 
       <td>{{ videoChangeOwnership.createdAt | date: 'short' }}</td>
-      <td i18n>{{ videoChangeOwnership.status }}</td>
+
+      <td>
+        <span class="badge" [ngClass]="getStatusClass(videoChangeOwnership.status)">{{ videoChangeOwnership.status }}</span>
+      </td>
+
       <td class="action-cell">
         <ng-container *ngIf="videoChangeOwnership.status === 'WAITING'">
           <my-button i18n-label label="Accept" icon="tick" (click)="openAcceptModal(videoChangeOwnership)"></my-button>

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.scss
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.scss
@@ -5,6 +5,10 @@
   @include chip;
 }
 
+.badge {
+  @include table-badge;
+}
+
 .video-table-video {
   display: inline-flex;
 

--- a/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.ts
+++ b/client/src/app/+my-account/my-account-ownership/my-account-ownership.component.ts
@@ -2,7 +2,7 @@ import { SortMeta } from 'primeng/api'
 import { Component, OnInit, ViewChild } from '@angular/core'
 import { Notifier, RestPagination, RestTable } from '@app/core'
 import { VideoOwnershipService, Actor, Video, Account } from '@app/shared/shared-main'
-import { VideoChangeOwnership } from '@shared/models'
+import { VideoChangeOwnership, VideoChangeOwnershipStatus } from '@shared/models'
 import { MyAccountAcceptOwnershipComponent } from './my-account-accept-ownership/my-account-accept-ownership.component'
 import { getAbsoluteAPIUrl } from '@app/helpers'
 
@@ -32,6 +32,17 @@ export class MyAccountOwnershipComponent extends RestTable implements OnInit {
 
   getIdentifier () {
     return 'MyAccountOwnershipComponent'
+  }
+
+  getStatusClass (status: VideoChangeOwnershipStatus) {
+    switch (status) {
+      case VideoChangeOwnershipStatus.ACCEPTED:
+        return 'badge-green'
+      case VideoChangeOwnershipStatus.REFUSED:
+        return 'badge-red'
+      default:
+        return 'badge-yellow'
+    }
   }
 
   switchToDefaultAvatar ($event: Event) {

--- a/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
+++ b/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.html
@@ -1,6 +1,15 @@
-<h1>
-  <my-global-icon iconName="subscriptions" aria-hidden="true"></my-global-icon>
-  <ng-container i18n>My subscriptions</ng-container>
+<h1 class="d-flex justify-content-between">
+  <span>
+    <my-global-icon iconName="subscriptions" aria-hidden="true"></my-global-icon>
+    <ng-container i18n>My subscriptions</ng-container>
+    <span class="badge badge-secondary"> {{ pagination.totalItems }}</span>
+  </span>
+
+  <div class="has-feedback has-clear">
+    <input type="text" placeholder="Search your subscriptions" i18n-placeholder [(ngModel)]="subscriptionsSearch" (ngModelChange)="onSubscriptionsSearchChanged()" />
+    <a class="glyphicon glyphicon-remove-sign form-control-feedback form-control-clear" (click)="resetSearch()"></a>
+    <span class="sr-only" i18n>Clear filters</span>
+  </div>
 </h1>
 
 <div class="no-results" i18n *ngIf="pagination.totalItems === 0">You don't have any subscriptions yet.</div>

--- a/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.scss
+++ b/client/src/app/+my-account/my-account-subscriptions/my-account-subscriptions.component.scss
@@ -1,6 +1,10 @@
 @import '_variables';
 @import '_mixins';
 
+input[type=text] {
+  @include peertube-input-text(300px);
+}
+
 .video-channel {
   @include row-blocks;
 

--- a/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
+++ b/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.html
@@ -45,7 +45,12 @@
         <ng-container *ngIf="isVideoImportFailed(videoImport)"></ng-container>
       </td>
 
-      <td>{{ videoImport.state.label }}</td>
+      <td>
+        <span class="badge" [ngClass]="getVideoImportStateClass(videoImport.state)">
+          {{ videoImport.state.label }}
+        </span>
+      </td>
+
       <td>{{ videoImport.createdAt | date: 'short' }}</td>
 
       <td class="action-cell">

--- a/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.scss
+++ b/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.scss
@@ -8,3 +8,7 @@ pre {
 .video-import-error {
   color: red;
 }
+
+.badge {
+  @include table-badge;
+}

--- a/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.ts
+++ b/client/src/app/+my-account/my-account-video-imports/my-account-video-imports.component.ts
@@ -30,6 +30,19 @@ export class MyAccountVideoImportsComponent extends RestTable implements OnInit 
     return 'MyAccountVideoImportsComponent'
   }
 
+  getVideoImportStateClass (state: VideoImportState) {
+    switch (state) {
+      case VideoImportState.FAILED:
+        return 'badge-red'
+      case VideoImportState.REJECTED:
+        return 'badge-banned'
+      case VideoImportState.PENDING:
+        return 'badge-yellow'
+      default:
+        return 'badge-green'
+    }
+  }
+
   isVideoImportSuccess (videoImport: VideoImport) {
     return videoImport.state.id === VideoImportState.SUCCESS
   }

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.html
@@ -1,17 +1,20 @@
-<h1>
-  <my-global-icon iconName="playlists" aria-hidden="true"></my-global-icon>
-  <ng-container i18n>My playlists</ng-container> <span class="badge badge-secondary">{{ pagination.totalItems }}</span>
-</h1>
+<h1 class="d-flex justify-content-between">
+  <span>
+    <my-global-icon iconName="playlists" aria-hidden="true"></my-global-icon>
+    <ng-container i18n>My playlists</ng-container> <span class="badge badge-secondary">{{ pagination.totalItems }}</span>
+  </span>
 
-
-<div class="video-playlists-header">
-  <input type="text" placeholder="Search your playlists" i18n-placeholder [(ngModel)]="videoPlaylistsSearch" (ngModelChange)="onVideoPlaylistSearchChanged()" />
+  <div class="has-feedback has-clear">
+    <input type="text" placeholder="Search your playlists" i18n-placeholder [(ngModel)]="videoPlaylistsSearch" (ngModelChange)="onVideoPlaylistSearchChanged()" />
+    <a class="glyphicon glyphicon-remove-sign form-control-feedback form-control-clear" (click)="resetSearch()"></a>
+    <span class="sr-only" i18n>Clear filters</span>
+  </div>
 
   <a class="create-button" routerLink="create">
     <my-global-icon iconName="add" aria-hidden="true"></my-global-icon>
     <ng-container i18n>Create playlist</ng-container>
   </a>
-</div>
+</h1>
 
 <div class="video-playlists" myInfiniteScroller [autoInit]="true" (nearOfBottom)="onNearOfBottom()" [dataObservable]="onDataSubject.asObservable()">
   <div *ngFor="let playlist of videoPlaylists" class="video-playlist">

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.scss
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.scss
@@ -5,6 +5,10 @@
   @include create-button;
 }
 
+input[type=text] {
+  @include peertube-input-text(300px);
+}
+
 ::ng-deep .action-button {
   &.action-button-delete {
     margin-right: 10px;
@@ -30,16 +34,6 @@
   .video-playlist-buttons {
     min-width: 190px;
     height: max-content;
-  }
-}
-
-.video-playlists-header {
-  display: flex;
-  justify-content: space-between;
-  margin: 20px 0 50px;
-
-  input[type=text] {
-    @include peertube-input-text(300px);
   }
 }
 

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.ts
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlists.component.ts
@@ -84,6 +84,11 @@ export class MyAccountVideoPlaylistsComponent implements OnInit {
     this.loadVideoPlaylists()
   }
 
+  resetSearch () {
+    this.videoPlaylistsSearch = ''
+    this.onVideoPlaylistSearchChanged()
+  }
+
   onVideoPlaylistSearchChanged () {
     this.videoPlaylistSearchChanged.next()
   }

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.html
@@ -1,11 +1,16 @@
-<h1>
-  <my-global-icon iconName="videos" aria-hidden="true"></my-global-icon>
-  <ng-container i18n>My videos</ng-container><span class="badge badge-secondary"> {{ pagination.totalItems }}</span>
-</h1>
+<h1 class="d-flex justify-content-between">
+  <span>
+    <my-global-icon iconName="videos" aria-hidden="true"></my-global-icon>
+    <ng-container i18n>My videos</ng-container>
+    <span class="badge badge-secondary"> {{ pagination.totalItems }}</span>
+  </span>
 
-<div class="videos-header">
-  <input type="text" placeholder="Search your videos" i18n-placeholder [(ngModel)]="videosSearch" (ngModelChange)="onVideosSearchChanged()" />
-</div>
+  <div class="has-feedback has-clear">
+    <input type="text" placeholder="Search your videos" i18n-placeholder [(ngModel)]="videosSearch" (ngModelChange)="onVideosSearchChanged()" />
+    <a class="glyphicon glyphicon-remove-sign form-control-feedback form-control-clear" (click)="resetSearch()"></a>
+    <span class="sr-only" i18n>Clear filters</span>
+  </div>
+</h1>
 
 <my-videos-selection
   [pagination]="pagination"

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.scss
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.scss
@@ -1,14 +1,8 @@
 @import '_variables';
 @import '_mixins';
 
-.videos-header {
-  display: flex;
-  justify-content: space-between;
-  margin: 20px 0 50px;
-
-  input[type=text] {
-    @include peertube-input-text(300px);
-  }
+input[type=text] {
+  @include peertube-input-text(300px);
 }
 
 .action-button-delete-selection {

--- a/client/src/app/+my-account/my-account-videos/my-account-videos.component.ts
+++ b/client/src/app/+my-account/my-account-videos/my-account-videos.component.ts
@@ -59,11 +59,15 @@ export class MyAccountVideosComponent implements OnInit, DisableForReuseHook {
 
   ngOnInit () {
     this.videosSearchChanged
-      .pipe(
-        debounceTime(500))
+      .pipe(debounceTime(500))
       .subscribe(() => {
         this.videosSelection.reloadVideos()
       })
+  }
+
+  resetSearch () {
+    this.videosSearch = ''
+    this.onVideosSearchChanged()
   }
 
   onVideosSearchChanged () {

--- a/client/src/app/core/users/user.service.ts
+++ b/client/src/app/core/users/user.service.ts
@@ -374,12 +374,22 @@ export class UserService {
   private formatUser (user: UserServerModel) {
     let videoQuota
     if (user.videoQuota === -1) {
-      videoQuota = this.i18n('Unlimited')
+      videoQuota = '∞'
     } else {
       videoQuota = this.bytesPipe.transform(user.videoQuota, 0)
     }
 
     const videoQuotaUsed = this.bytesPipe.transform(user.videoQuotaUsed, 0)
+
+    let videoQuotaDaily
+    let videoQuotaUsedDaily
+    if (user.videoQuotaDaily === -1) {
+      videoQuotaDaily = '∞'
+      videoQuotaUsedDaily = this.bytesPipe.transform(0, 0)
+    } else {
+      videoQuotaDaily = this.bytesPipe.transform(user.videoQuotaDaily, 0)
+      videoQuotaUsedDaily = this.bytesPipe.transform(user.videoQuotaUsedDaily || 0, 0)
+    }
 
     const roleLabels: { [ id in UserRole ]: string } = {
       [UserRole.USER]: this.i18n('User'),
@@ -390,7 +400,13 @@ export class UserService {
     return Object.assign(user, {
       roleLabel: roleLabels[user.role],
       videoQuota,
-      videoQuotaUsed
+      videoQuotaUsed,
+      rawVideoQuota: user.videoQuota,
+      rawVideoQuotaUsed: user.videoQuotaUsed,
+      videoQuotaDaily,
+      videoQuotaUsedDaily,
+      rawVideoQuotaDaily: user.videoQuotaDaily,
+      rawVideoQuotaUsedDaily: user.videoQuotaUsedDaily
     })
   }
 }

--- a/client/src/app/core/users/user.service.ts
+++ b/client/src/app/core/users/user.service.ts
@@ -381,14 +381,14 @@ export class UserService {
 
     const videoQuotaUsed = this.bytesPipe.transform(user.videoQuotaUsed, 0)
 
-    let videoQuotaDaily
-    let videoQuotaUsedDaily
+    let videoQuotaDaily: string
+    let videoQuotaUsedDaily: string
     if (user.videoQuotaDaily === -1) {
       videoQuotaDaily = '∞'
-      videoQuotaUsedDaily = this.bytesPipe.transform(0, 0)
+      videoQuotaUsedDaily = this.bytesPipe.transform(0, 0) + ''
     } else {
-      videoQuotaDaily = this.bytesPipe.transform(user.videoQuotaDaily, 0)
-      videoQuotaUsedDaily = this.bytesPipe.transform(user.videoQuotaUsedDaily || 0, 0)
+      videoQuotaDaily = this.bytesPipe.transform(user.videoQuotaDaily, 0) + ''
+      videoQuotaUsedDaily = this.bytesPipe.transform(user.videoQuotaUsedDaily || 0, 0) + ''
     }
 
     const roleLabels: { [ id in UserRole ]: string } = {

--- a/client/src/app/shared/shared-icons/global-icon.component.ts
+++ b/client/src/app/shared/shared-icons/global-icon.component.ts
@@ -64,7 +64,8 @@ const icons = {
   'go': require('!!raw-loader?!../../../assets/images/feather/arrow-up-right.svg').default,
   'cross': require('!!raw-loader?!../../../assets/images/feather/x.svg').default,
   'tick': require('!!raw-loader?!../../../assets/images/feather/check.svg').default,
-  'repeat': require('!!raw-loader?!../../../assets/images/feather/repeat.svg').default
+  'repeat': require('!!raw-loader?!../../../assets/images/feather/repeat.svg').default,
+  'columns': require('!!raw-loader?!../../../assets/images/feather/columns.svg').default
 }
 
 export type GlobalIconName = keyof typeof icons

--- a/client/src/app/shared/shared-main/buttons/button.component.scss
+++ b/client/src/app/shared/shared-main/buttons/button.component.scss
@@ -7,6 +7,7 @@ my-small-loader ::ng-deep .root {
   width: 20px;
 }
 
+a[class$=-button],
 span[class$=-button] {
   > span {
     margin-left: 5px;

--- a/client/src/app/shared/shared-main/buttons/edit-button.component.html
+++ b/client/src/app/shared/shared-main/buttons/edit-button.component.html
@@ -2,5 +2,5 @@
   <my-global-icon iconName="edit" aria-hidden="true"></my-global-icon>
 
   <span class="button-label" *ngIf="label">{{ label }}</span>
-  <span i18n class="button-label" *ngIf="!label">Update</span>
+  <span class="button-label" i18n *ngIf="!label">Update</span>
 </a>

--- a/client/src/app/shared/shared-main/users/user-notification.service.ts
+++ b/client/src/app/shared/shared-main/users/user-notification.service.ts
@@ -5,6 +5,7 @@ import { ComponentPaginationLight, RestExtractor, RestService, User, UserNotific
 import { ResultList, UserNotification as UserNotificationServer, UserNotificationSetting } from '@shared/models'
 import { environment } from '../../../../environments/environment'
 import { UserNotification } from './user-notification.model'
+import { SortMeta } from 'primeng/api'
 
 @Injectable()
 export class UserNotificationService {
@@ -18,9 +19,16 @@ export class UserNotificationService {
     private userNotificationSocket: UserNotificationSocket
   ) {}
 
-  listMyNotifications (pagination: ComponentPaginationLight, unread?: boolean, ignoreLoadingBar = false) {
+  listMyNotifications (parameters: {
+    pagination: ComponentPaginationLight
+    ignoreLoadingBar?: boolean
+    unread?: boolean,
+    sort?: SortMeta
+  }) {
+    const { pagination, ignoreLoadingBar, unread, sort } = parameters
+
     let params = new HttpParams()
-    params = this.restService.addRestGetParams(params, this.restService.componentPaginationToRestPagination(pagination))
+    params = this.restService.addRestGetParams(params, this.restService.componentPaginationToRestPagination(pagination), sort)
 
     if (unread) params = params.append('unread', `${unread}`)
 
@@ -35,7 +43,7 @@ export class UserNotificationService {
   }
 
   countUnreadNotifications () {
-    return this.listMyNotifications({ currentPage: 1, itemsPerPage: 0 }, true)
+    return this.listMyNotifications({ pagination: { currentPage: 1, itemsPerPage: 0 }, ignoreLoadingBar: true, unread: true })
       .pipe(map(n => n.total))
   }
 

--- a/client/src/app/shared/shared-main/users/user-notifications.component.ts
+++ b/client/src/app/shared/shared-main/users/user-notifications.component.ts
@@ -53,6 +53,7 @@ export class UserNotificationsComponent implements OnInit {
       ignoreLoadingBar: this.ignoreLoadingBar,
       sort: {
         field: this.sortField,
+        // if we order by creation date, we want DESC. all other fields are ASC (like unread).
         order: this.sortField === 'createdAt' ? -1 : 1
       }
     })

--- a/client/src/app/shared/shared-main/users/user-notifications.component.ts
+++ b/client/src/app/shared/shared-main/users/user-notifications.component.ts
@@ -19,6 +19,7 @@ export class UserNotificationsComponent implements OnInit {
   @Output() notificationsLoaded = new EventEmitter()
 
   notifications: UserNotification[] = []
+  sortField = 'createdAt'
 
   // So we can access it in the template
   UserNotificationType = UserNotificationType
@@ -39,18 +40,25 @@ export class UserNotificationsComponent implements OnInit {
       totalItems: null
     }
 
-    this.loadMoreNotifications()
+    this.loadNotifications()
 
     if (this.markAllAsReadSubject) {
       this.markAllAsReadSubject.subscribe(() => this.markAllAsRead())
     }
   }
 
-  loadMoreNotifications () {
-    this.userNotificationService.listMyNotifications(this.componentPagination, undefined, this.ignoreLoadingBar)
+  loadNotifications (reset?: boolean) {
+    this.userNotificationService.listMyNotifications({
+      pagination: this.componentPagination,
+      ignoreLoadingBar: this.ignoreLoadingBar,
+      sort: {
+        field: this.sortField,
+        order: this.sortField === 'createdAt' ? -1 : 1
+      }
+    })
         .subscribe(
           result => {
-            this.notifications = this.notifications.concat(result.data)
+            this.notifications = reset ? result.data : this.notifications.concat(result.data)
             this.componentPagination.totalItems = result.total
 
             this.notificationsLoaded.emit()
@@ -68,7 +76,7 @@ export class UserNotificationsComponent implements OnInit {
     this.componentPagination.currentPage++
 
     if (hasMoreItems(this.componentPagination)) {
-      this.loadMoreNotifications()
+      this.loadNotifications()
     }
   }
 
@@ -96,5 +104,15 @@ export class UserNotificationsComponent implements OnInit {
 
           err => this.notifier.error(err.message)
         )
+  }
+
+  changeSortColumn (column: string) {
+    this.componentPagination = {
+      currentPage: 1,
+      itemsPerPage: this.itemsPerPage,
+      totalItems: null
+    }
+    this.sortField = column
+    this.loadNotifications(true)
   }
 }

--- a/client/src/app/shared/shared-main/users/user-quota.component.html
+++ b/client/src/app/shared/shared-main/users/user-quota.component.html
@@ -1,21 +1,22 @@
 <div class="user-quota mb-3">
   <div>
-    <strong class="user-quota-title" tabindex="0" i18n>Total video quota</strong>
+    <label class="user-quota-title" tabindex="0" i18n>Total video quota</label>
     <div class="progress" tabindex="0" [ngbTooltip]="titleVideoQuota()">
       <div class="progress-bar" tabindex="0" role="progressbar" [style]="{ width: userVideoQuotaPercentage + '%' }"
-        [attr.aria-valuenow]="userVideoQuotaUsed" aria-valuemin="0" [attr.aria-valuemax]="user.videoQuota">
-        {{ userVideoQuotaUsed | bytes: 0 }}</div>
-      <span class="ml-auto mr-2">{{ userVideoQuota }}</span>
+        [attr.aria-valuenow]="userVideoQuotaUsed" aria-valuemin="0" [attr.aria-valuemax]="user.videoQuota"></div>
+      <span>{{ userVideoQuotaUsed | bytes: 1 }}</span>
+      <span>{{ userVideoQuota }}</span>
     </div>
   </div>
 
   <div *ngIf="hasDailyQuota()" class="mt-3">
-    <strong class="user-quota-title" tabindex="0" i18n>Daily video quota</strong>
+    <label class="user-quota-title" tabindex="0" i18n>Daily video quota</label>
     <div class="progress" tabindex="0" [ngbTooltip]="titleVideoQuotaDaily()">
       <div class="progress-bar secondary" role="progressbar" [style]="{ width: userVideoQuotaDailyPercentage + '%' }"
-        [attr.aria-valuenow]="userVideoQuotaUsedDaily" aria-valuemin="0" [attr.aria-valuemax]="user.videoQuotaDaily">
-        {{ userVideoQuotaUsedDaily | bytes: 0 }}</div>
+        [attr.aria-valuenow]="userVideoQuotaUsedDaily" aria-valuemin="0" [attr.aria-valuemax]="user.videoQuotaDaily"></div>
       <span class="ml-auto mr-2">{{ userVideoQuotaDaily }}</span>
+      <span>{{ userVideoQuotaUsedDaily | bytes: 1 }}</span>
+      <span>{{ userVideoQuotaDaily }}</span>
     </div>
   </div>
 </div>

--- a/client/src/app/shared/shared-main/users/user-quota.component.scss
+++ b/client/src/app/shared/shared-main/users/user-quota.component.scss
@@ -1,10 +1,12 @@
 @import '_variables';
 @import '_mixins';
 
-.user-quota {
-  font-size: 15px;
-  margin-top: 20px;
+label {
+  font-weight: $font-regular;
+  font-size: 100%;
+}
 
+.user-quota {
   label {
     margin-right: 5px;
   }
@@ -13,12 +15,9 @@
     width: 100% !important;
   }
 
-  .user-quota-title, .progress {
+  .progress {
     @include disable-outline;
     @include button-focus(pvar(--mainColorLightest));
-  }
-
-  .progress {
     @include progressbar;
 
     height: 2rem;

--- a/client/src/app/shared/shared-main/video-channel/video-channel.service.ts
+++ b/client/src/app/shared/shared-main/video-channel/video-channel.service.ts
@@ -43,7 +43,8 @@ export class VideoChannelService {
   listAccountVideoChannels (
     account: Account,
     componentPagination?: ComponentPaginationLight,
-    withStats = false
+    withStats = false,
+    search?: string
   ): Observable<ResultList<VideoChannel>> {
     const pagination = componentPagination
       ? this.restService.componentPaginationToRestPagination(componentPagination)
@@ -52,6 +53,10 @@ export class VideoChannelService {
     let params = new HttpParams()
     params = this.restService.addRestGetParams(params, pagination)
     params = params.set('withStats', withStats + '')
+
+    if (search) {
+      params = params.set('search', search)
+    }
 
     const url = AccountService.BASE_ACCOUNT_URL + account.nameWithHost + '/video-channels'
     return this.authHttp.get<ResultList<VideoChannelServer>>(url, { params })

--- a/client/src/app/shared/shared-user-subscription/user-subscription.service.ts
+++ b/client/src/app/shared/shared-user-subscription/user-subscription.service.ts
@@ -105,13 +105,18 @@ export class UserSubscriptionService {
                )
   }
 
-  listSubscriptions (componentPagination: ComponentPaginationLight): Observable<ResultList<VideoChannel>> {
+  listSubscriptions (parameters: {
+    pagination: ComponentPaginationLight
+    search: string
+  }): Observable<ResultList<VideoChannel>> {
+    const { pagination, search } = parameters
     const url = UserSubscriptionService.BASE_USER_SUBSCRIPTIONS_URL
 
-    const pagination = this.restService.componentPaginationToRestPagination(componentPagination)
+    const restPagination = this.restService.componentPaginationToRestPagination(pagination)
 
     let params = new HttpParams()
-    params = this.restService.addRestGetParams(params, pagination)
+    params = this.restService.addRestGetParams(params, restPagination)
+    if (search) params = params.append('search', search)
 
     return this.authHttp.get<ResultList<VideoChannelServer>>(url, { params })
                .pipe(

--- a/client/src/assets/images/feather/columns.svg
+++ b/client/src/assets/images/feather/columns.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-columns"><path d="M12 3h7a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-7m0-18H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h7m0-18v18"></path></svg>

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -371,7 +371,7 @@ table {
       input[type=email],
       textarea,
       .peertube-select-container {
-        width: 100% !important;
+        flex-grow: 1;
       }
 
       .caption input[type=text] {

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -310,6 +310,7 @@ ngb-tooltip-window {
     position: absolute;
     right: .5rem;
     height: 95%;
+    font-size: 14px;
 
     &:hover {
       color: rgba(0, 0, 0, 0.7);

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -690,12 +690,11 @@
   overflow: hidden;
   font-size: 0.75rem;
   border-radius: 0.25rem;
-  isolation: isolate;
   position: relative;
 
   span {
     position: absolute;
-    color: rgb(92, 92, 92);
+    color: $grey-foreground-color;
     top: -1px;
 
     &:nth-of-type(1) {

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -332,9 +332,7 @@
 
   select {
     padding: 0 35px 0 12px;
-    width: calc(100% + 2px);
     position: relative;
-    left: 1px;
     border: 1px solid #C6C6C6;
     background: transparent none;
     appearance: none;
@@ -692,7 +690,21 @@
   overflow: hidden;
   font-size: 0.75rem;
   border-radius: 0.25rem;
-  color: gray;
+  isolation: isolate;
+  position: relative;
+
+  span {
+    position: absolute;
+    color: rgb(92, 92, 92);
+    top: -1px;
+
+    &:nth-of-type(1) {
+      left: .2rem;
+    }
+    &:nth-of-type(2) {
+      right: .2rem;
+    }
+  }
 
   .progress-bar {
     color: pvar(--mainBackgroundColor);
@@ -703,24 +715,10 @@
     text-align: center;
     white-space: nowrap;
     transition: width 0.6s ease;
-    isolation: isolate;
-
-    &:after {
-      content: attr(valuenow-formatted);
-      position: absolute;
-      margin-left: .2rem;
-      mix-blend-mode: screen;
-      color: gray;
-    }
 
     &.secondary {
       background-color: pvar(--secondaryColor);
     }
-  }
-
-  .progress-bar + span {
-    position: relative;
-    top: -1px;
   }
 }
 

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -356,6 +356,17 @@
       color: #000;
     }
   }
+
+  &.peertube-select-button {
+    @include grey-button;
+
+    select,
+    option {
+      font-weight: $font-semibold;
+      color: pvar(--greyForegroundColor);
+      border: none;
+    }
+  }
 }
 
 // Thanks: https://codepen.io/triss90/pen/XNEdRe/
@@ -454,6 +465,49 @@
   }
 }
 
+@mixin table-badge {
+  border-radius: 2px;
+  padding: 1/4em 1/2em;
+  text-transform: uppercase;
+  font-weight: $font-bold;
+  font-size: 12px;
+  letter-spacing: 1/3px;
+
+  &.badge-banned,
+  &.badge-red {
+    background-color: #ffcdd2;
+    color: #c63737;
+  }
+
+  &.badge-banned {
+    text-decoration: line-through;
+  }
+
+  &.badge-yellow {
+    background-color: #feedaf;
+    color: #8a5340;
+  }
+
+  &.badge-brown {
+    background-color: #ffd8b2;
+    color: #805b36;
+  }
+
+  &.badge-green {
+    background-color: #c8e6c9;
+    color: #256029;
+  }
+
+  &.badge-blue {
+    background-color: #b3e5fc;
+    color: #23547b;
+  }
+
+  &.badge-purple {
+    background-color: #eccfff;
+    color: #694382;
+  }
+}
 
 @mixin avatar ($size) {
   object-fit: cover;
@@ -638,6 +692,7 @@
   overflow: hidden;
   font-size: 0.75rem;
   border-radius: 0.25rem;
+  color: gray;
 
   .progress-bar {
     color: pvar(--mainBackgroundColor);
@@ -648,10 +703,24 @@
     text-align: center;
     white-space: nowrap;
     transition: width 0.6s ease;
+    isolation: isolate;
+
+    &:after {
+      content: attr(valuenow-formatted);
+      position: absolute;
+      margin-left: .2rem;
+      mix-blend-mode: screen;
+      color: gray;
+    }
 
     &.secondary {
       background-color: pvar(--secondaryColor);
     }
+  }
+
+  .progress-bar + span {
+    position: relative;
+    top: -1px;
   }
 }
 

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -683,7 +683,7 @@
   }
 }
 
-@mixin progressbar {
+@mixin progressbar($small: false) {
   background-color: $grey-background-color;
   display: flex;
   height: 1rem;
@@ -695,7 +695,9 @@
   span {
     position: absolute;
     color: $grey-foreground-color;
-    top: -1px;
+    @if $small {
+      top: -1px;
+    }
 
     &:nth-of-type(1) {
       left: .2rem;

--- a/client/src/sass/primeng-custom.scss
+++ b/client/src/sass/primeng-custom.scss
@@ -92,6 +92,11 @@ p-table {
       &:last-child td {
         border-bottom: none !important;
       }
+
+      &:focus + tr > td,
+      &:focus > td {
+        box-shadow: none !important;
+      }
     }
 
     .expander {

--- a/server/controllers/api/accounts.ts
+++ b/server/controllers/api/accounts.ts
@@ -120,7 +120,8 @@ async function listAccountChannels (req: express.Request, res: express.Response)
     start: req.query.start,
     count: req.query.count,
     sort: req.query.sort,
-    withStats: req.query.withStats
+    withStats: req.query.withStats,
+    search: req.query.search
   }
 
   const resultList = await VideoChannelModel.listByAccount(options)

--- a/server/controllers/api/search.ts
+++ b/server/controllers/api/search.ts
@@ -22,7 +22,7 @@ import {
   setDefaultPagination,
   setDefaultSearchSort,
   videoChannelsSearchSortValidator,
-  videoChannelsSearchValidator,
+  videoChannelsListSearchValidator,
   videosSearchSortValidator,
   videosSearchValidator
 } from '../../middlewares'
@@ -49,7 +49,7 @@ searchRouter.get('/video-channels',
   videoChannelsSearchSortValidator,
   setDefaultSearchSort,
   optionalAuthenticate,
-  videoChannelsSearchValidator,
+  videoChannelsListSearchValidator,
   asyncMiddleware(searchVideoChannels)
 )
 

--- a/server/controllers/api/users/my-subscriptions.ts
+++ b/server/controllers/api/users/my-subscriptions.ts
@@ -13,7 +13,12 @@ import {
   userSubscriptionAddValidator,
   userSubscriptionGetValidator
 } from '../../../middlewares'
-import { areSubscriptionsExistValidator, userSubscriptionsSortValidator, videosSortValidator, userSubscriptionListValidator } from '../../../middlewares/validators'
+import {
+  areSubscriptionsExistValidator,
+  userSubscriptionsSortValidator,
+  videosSortValidator,
+  userSubscriptionListValidator
+} from '../../../middlewares/validators'
 import { VideoModel } from '../../../models/video/video'
 import { buildNSFWFilter, getCountVideos } from '../../../helpers/express-utils'
 import { VideoFilter } from '../../../../shared/models/videos/video-query.type'

--- a/server/controllers/api/users/my-subscriptions.ts
+++ b/server/controllers/api/users/my-subscriptions.ts
@@ -13,7 +13,7 @@ import {
   userSubscriptionAddValidator,
   userSubscriptionGetValidator
 } from '../../../middlewares'
-import { areSubscriptionsExistValidator, userSubscriptionsSortValidator, videosSortValidator } from '../../../middlewares/validators'
+import { areSubscriptionsExistValidator, userSubscriptionsSortValidator, videosSortValidator, userSubscriptionListValidator } from '../../../middlewares/validators'
 import { VideoModel } from '../../../models/video/video'
 import { buildNSFWFilter, getCountVideos } from '../../../helpers/express-utils'
 import { VideoFilter } from '../../../../shared/models/videos/video-query.type'
@@ -45,6 +45,7 @@ mySubscriptionsRouter.get('/me/subscriptions',
   userSubscriptionsSortValidator,
   setDefaultSort,
   setDefaultPagination,
+  userSubscriptionListValidator,
   asyncMiddleware(getUserSubscriptions)
 )
 
@@ -141,7 +142,13 @@ async function getUserSubscriptions (req: express.Request, res: express.Response
   const user = res.locals.oauth.token.User
   const actorId = user.Account.Actor.id
 
-  const resultList = await ActorFollowModel.listSubscriptionsForApi(actorId, req.query.start, req.query.count, req.query.sort)
+  const resultList = await ActorFollowModel.listSubscriptionsForApi({
+    actorId,
+    start: req.query.start,
+    count: req.query.count,
+    sort: req.query.sort,
+    search: req.query.search
+  })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }

--- a/server/controllers/api/video-channel.ts
+++ b/server/controllers/api/video-channel.ts
@@ -16,7 +16,7 @@ import {
   videoPlaylistsSortValidator
 } from '../../middlewares'
 import { VideoChannelModel } from '../../models/video/video-channel'
-import { videoChannelsNameWithHostValidator, videosSortValidator } from '../../middlewares/validators'
+import { videoChannelsNameWithHostValidator, videosSortValidator, videoChannelsOwnSearchValidator } from '../../middlewares/validators'
 import { sendUpdateActor } from '../../lib/activitypub/send'
 import { VideoChannelCreate, VideoChannelUpdate } from '../../../shared'
 import { createLocalVideoChannel, federateAllVideosOfChannel } from '../../lib/video-channel'
@@ -48,6 +48,7 @@ videoChannelRouter.get('/',
   videoChannelsSortValidator,
   setDefaultSort,
   setDefaultPagination,
+  videoChannelsOwnSearchValidator,
   asyncMiddleware(listVideoChannels)
 )
 
@@ -114,7 +115,13 @@ export {
 
 async function listVideoChannels (req: express.Request, res: express.Response) {
   const serverActor = await getServerActor()
-  const resultList = await VideoChannelModel.listForApi(serverActor.id, req.query.start, req.query.count, req.query.sort)
+  const resultList = await VideoChannelModel.listForApi({
+    actorId: serverActor.id,
+    start: req.query.start,
+    count: req.query.count,
+    sort: req.query.sort,
+    search: req.query.search
+  })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }

--- a/server/controllers/api/video-channel.ts
+++ b/server/controllers/api/video-channel.ts
@@ -119,8 +119,7 @@ async function listVideoChannels (req: express.Request, res: express.Response) {
     actorId: serverActor.id,
     start: req.query.start,
     count: req.query.count,
-    sort: req.query.sort,
-    search: req.query.search
+    sort: req.query.sort
   })
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -55,7 +55,7 @@ const WEBSERVER = {
 
 // Sortable columns per schema
 const SORTABLE_COLUMNS = {
-  USERS: [ 'id', 'username', 'videoQuotaUsed', 'createdAt' ],
+  USERS: [ 'id', 'username', 'videoQuotaUsed', 'createdAt', 'lastLoginDate', 'role' ],
   USER_SUBSCRIPTIONS: [ 'id', 'createdAt' ],
   ACCOUNTS: [ 'createdAt' ],
   JOBS: [ 'createdAt' ],
@@ -78,7 +78,7 @@ const SORTABLE_COLUMNS = {
   ACCOUNTS_BLOCKLIST: [ 'createdAt' ],
   SERVERS_BLOCKLIST: [ 'createdAt' ],
 
-  USER_NOTIFICATIONS: [ 'createdAt' ],
+  USER_NOTIFICATIONS: [ 'createdAt', 'read' ],
 
   VIDEO_PLAYLISTS: [ 'displayName', 'createdAt', 'updatedAt' ],
 

--- a/server/middlewares/validators/search.ts
+++ b/server/middlewares/validators/search.ts
@@ -28,7 +28,7 @@ const videosSearchValidator = [
   }
 ]
 
-const videoChannelsSearchValidator = [
+const videoChannelsListSearchValidator = [
   query('search').not().isEmpty().withMessage('Should have a valid search'),
   query('searchTarget').optional().custom(isSearchTargetValid).withMessage('Should have a valid search target'),
 
@@ -57,6 +57,6 @@ const videoChannelsOwnSearchValidator = [
 
 export {
   videosSearchValidator,
-  videoChannelsSearchValidator,
+  videoChannelsListSearchValidator,
   videoChannelsOwnSearchValidator
 }

--- a/server/middlewares/validators/search.ts
+++ b/server/middlewares/validators/search.ts
@@ -41,9 +41,22 @@ const videoChannelsSearchValidator = [
   }
 ]
 
+const videoChannelsOwnSearchValidator = [
+  query('search').optional().not().isEmpty().withMessage('Should have a valid search'),
+
+  (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    logger.debug('Checking video channels search query', { parameters: req.query })
+
+    if (areValidationErrors(req, res)) return
+
+    return next()
+  }
+]
+
 // ---------------------------------------------------------------------------
 
 export {
+  videosSearchValidator,
   videoChannelsSearchValidator,
-  videosSearchValidator
+  videoChannelsOwnSearchValidator
 }

--- a/server/middlewares/validators/user-subscriptions.ts
+++ b/server/middlewares/validators/user-subscriptions.ts
@@ -7,6 +7,18 @@ import { areValidActorHandles, isValidActorHandle } from '../../helpers/custom-v
 import { toArray } from '../../helpers/custom-validators/misc'
 import { WEBSERVER } from '../../initializers/constants'
 
+const userSubscriptionListValidator = [
+  query('search').optional().not().isEmpty().withMessage('Should have a valid search'),
+
+  (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    logger.debug('Checking userSubscriptionListValidator parameters', { parameters: req.query })
+
+    if (areValidationErrors(req, res)) return
+
+    return next()
+  }
+]
+
 const userSubscriptionAddValidator = [
   body('uri').custom(isValidActorHandle).withMessage('Should have a valid URI to follow (username@domain)'),
 
@@ -64,6 +76,7 @@ const userSubscriptionGetValidator = [
 
 export {
   areSubscriptionsExistValidator,
+  userSubscriptionListValidator,
   userSubscriptionAddValidator,
   userSubscriptionGetValidator
 }

--- a/server/models/activitypub/actor-follow.ts
+++ b/server/models/activitypub/actor-follow.ts
@@ -15,8 +15,7 @@ import {
   Max,
   Model,
   Table,
-  UpdatedAt,
-  Sequelize
+  UpdatedAt
 } from 'sequelize-typescript'
 import { FollowState } from '../../../shared/models/actors'
 import { ActorFollow } from '../../../shared/models/actors/follow.model'

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -54,6 +54,7 @@ export enum ScopeNames {
 
 type AvailableForListOptions = {
   actorId: number
+  search?: string
 }
 
 type AvailableWithStatsOptions = {
@@ -309,15 +310,23 @@ export class VideoChannelModel extends Model<VideoChannelModel> {
     return VideoChannelModel.count(query)
   }
 
-  static listForApi (actorId: number, start: number, count: number, sort: string) {
+  static listForApi (parameters: {
+    actorId: number
+    start: number
+    count: number
+    sort: string
+    search?: string
+  }) {
+    const { actorId, search } = parameters
+
     const query = {
-      offset: start,
-      limit: count,
-      order: getSort(sort)
+      offset: parameters.start,
+      limit: parameters.count,
+      order: getSort(parameters.sort)
     }
 
     const scopes = {
-      method: [ ScopeNames.FOR_API, { actorId } as AvailableForListOptions ]
+      method: [ ScopeNames.FOR_API, { actorId, search } as AvailableForListOptions ]
     }
     return VideoChannelModel
       .scope(scopes)

--- a/server/tests/api/users/user-subscriptions.ts
+++ b/server/tests/api/users/user-subscriptions.ts
@@ -96,14 +96,14 @@ describe('Test users subscriptions', function () {
 
   it('Should list subscriptions', async function () {
     {
-      const res = await listUserSubscriptions(servers[0].url, servers[0].accessToken)
+      const res = await listUserSubscriptions({ url: servers[0].url, token: servers[0].accessToken })
       expect(res.body.total).to.equal(0)
       expect(res.body.data).to.be.an('array')
       expect(res.body.data).to.have.lengthOf(0)
     }
 
     {
-      const res = await listUserSubscriptions(servers[0].url, users[0].accessToken, 'createdAt')
+      const res = await listUserSubscriptions({ url: servers[0].url, token: users[0].accessToken, sort: 'createdAt' })
       expect(res.body.total).to.equal(2)
 
       const subscriptions: VideoChannel[] = res.body.data
@@ -154,6 +154,34 @@ describe('Test users subscriptions', function () {
     expect(body['root2_channel@localhost:' + servers[0].port]).to.be.false
     expect(body['root_channel@localhost:' + servers[0].port]).to.be.true
     expect(body['user3_channel@localhost:' + servers[0].port]).to.be.false
+  })
+
+  it('Should search among subscriptions', async function () {
+    {
+      const res = await listUserSubscriptions({
+        url: servers[0].url,
+        token: users[0].accessToken,
+        sort: '-createdAt',
+        search: 'user3_channel'
+      })
+      expect(res.body.total).to.equal(1)
+
+      const subscriptions = res.body.data
+      expect(subscriptions).to.have.lengthOf(1)
+    }
+
+    {
+      const res = await listUserSubscriptions({
+        url: servers[0].url,
+        token: users[0].accessToken,
+        sort: '-createdAt',
+        search: 'toto'
+      })
+      expect(res.body.total).to.equal(0)
+
+      const subscriptions = res.body.data
+      expect(subscriptions).to.have.lengthOf(0)
+    }
   })
 
   it('Should list subscription videos', async function () {

--- a/server/tests/api/videos/video-channels.ts
+++ b/server/tests/api/videos/video-channels.ts
@@ -421,6 +421,32 @@ describe('Test video channels', function () {
     expect(totoChannel.videosCount).to.equal(0)
   })
 
+  it('Should search among account video channels', async function () {
+    {
+      const res = await getAccountVideoChannelsList({
+        url: servers[0].url,
+        accountName: userInfo.account.name + '@' + userInfo.account.host,
+        search: 'root'
+      })
+      expect(res.body.total).to.equal(1)
+
+      const channels = res.body.data
+      expect(channels).to.have.lengthOf(1)
+    }
+
+    {
+      const res = await getAccountVideoChannelsList({
+        url: servers[0].url,
+        accountName: userInfo.account.name + '@' + userInfo.account.host,
+        search: 'does not exist'
+      })
+      expect(res.body.total).to.equal(0)
+
+      const channels = res.body.data
+      expect(channels).to.have.lengthOf(0)
+    }
+  })
+
   after(async function () {
     await cleanupTests(servers)
   })

--- a/shared/extra-utils/users/user-subscriptions.ts
+++ b/shared/extra-utils/users/user-subscriptions.ts
@@ -12,7 +12,14 @@ function addUserSubscription (url: string, token: string, targetUri: string, sta
   })
 }
 
-function listUserSubscriptions (url: string, token: string, sort = '-createdAt', statusCodeExpected = 200) {
+function listUserSubscriptions (parameters: {
+  url: string
+  token: string
+  sort?: string
+  search?: string
+  statusCodeExpected?: number
+}) {
+  const { url, token, sort = '-createdAt', search, statusCodeExpected = 200 } = parameters
   const path = '/api/v1/users/me/subscriptions'
 
   return makeGetRequest({
@@ -20,7 +27,10 @@ function listUserSubscriptions (url: string, token: string, sort = '-createdAt',
     path,
     token,
     statusCodeExpected,
-    query: { sort }
+    query: {
+      sort,
+      search
+    }
   })
 }
 

--- a/shared/extra-utils/videos/video-channels.ts
+++ b/shared/extra-utils/videos/video-channels.ts
@@ -32,8 +32,9 @@ function getAccountVideoChannelsList (parameters: {
   sort?: string
   specialStatus?: number
   withStats?: boolean
+  search?: string
 }) {
-  const { url, accountName, start, count, sort = 'createdAt', specialStatus = 200, withStats = false } = parameters
+  const { url, accountName, start, count, sort = 'createdAt', specialStatus = 200, withStats = false, search } = parameters
 
   const path = '/api/v1/accounts/' + accountName + '/video-channels'
 
@@ -44,7 +45,8 @@ function getAccountVideoChannelsList (parameters: {
       start,
       count,
       sort,
-      withStats
+      withStats,
+      search
     },
     statusCodeExpected: specialStatus
   })


### PR DESCRIPTION
This PR brings two unrelated changes:

1. Sortable notifications
  - notifications sorting can be changed in the notification view, so as to help display notifications with unread shown first.

![Screenshot_2020-07-21 Notifications - PeerTube](https://user-images.githubusercontent.com/6329880/88064456-98940c80-cb6b-11ea-9ee5-7502af65414f.png)

2. Flexible User listing
  - users table could display more information than it currently does ; on small devices - not just mobile - the situation is difficult. Thus being able to toggle columns seems like a good option.
  - statuses in tables are not using labels to provide quickly identifiable information ; I took the label css from primeng's example, which is soft enough to the eye.
  - progress bars were revamped for small column sizes.

![Screenshot_2020-07-21 Users list - PeerTube(1)](https://user-images.githubusercontent.com/6329880/88064338-726e6c80-cb6b-11ea-8c40-c66952cbecb9.png)
![Screenshot_2020-07-21 Users list - PeerTube](https://user-images.githubusercontent.com/6329880/88064342-73070300-cb6b-11ea-89e7-41a34f984faf.png)

Note: Sorry for the grouped PR - the past weeks have been hectic and I didn't find time to split the features in respective branches.