### PR TITLE
Revert user-menu dropdown active class on sub-menu and close outside-click

### DIFF
--- a/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
+++ b/client/src/app/shared/shared-main/misc/top-menu-dropdown.component.html
@@ -4,12 +4,8 @@
     <a *ngIf="menuEntry.routerLink && isDisplayed(menuEntry)" [routerLink]="menuEntry.routerLink" routerLinkActive="active" class="title-page title-page-settings">{{ menuEntry.label }}</a>
 
     <div *ngIf="!menuEntry.routerLink && isDisplayed(menuEntry)" ngbDropdown class="parent-entry"
-      #dropdown="ngbDropdown" autoClose="outside">
+      #dropdown="ngbDropdown" autoClose="true">
       <span
-        *ngIf="isInSmallView"
-        tabindex=0
-        [ngClass]="{ active: !!suffixLabels[menuEntry.label] }"
-        (click)="openModal(id)" (keydown.enter)="openModal(id)"
         role="button" class="title-page title-page-settings">
         <ng-container i18n>{{ menuEntry.label }}</ng-container>
       </span>
@@ -27,7 +23,7 @@
       <div ngbDropdownMenu>
         <ng-container *ngFor="let menuChild of menuEntry.children">
           <a *ngIf="isDisplayed(menuChild)" class="dropdown-item"
-            [ngClass]="{ icon: hasIcons, active: suffixLabels[menuEntry.label] === menuChild.label }"
+            [ngClass]="{ icon: hasIcons }"
             [routerLink]="menuChild.routerLink">
             <my-global-icon *ngIf="menuChild.iconName" [iconName]="menuChild.iconName" aria-hidden="true"></my-global-icon>
 


### PR DESCRIPTION
This PR reverts the recent proposition to close the dropdown sub-menu only on outside click and showing a background color on active links. 

Now, autoclose is back on click inside and outside and active class is removed, because this active effect class caused some blinking effect on the dropdown.