### PR TITLE
Add new anchors in my-settings and handle offset sub-menu height

### DIFF
--- a/client/src/app/+admin/admin.component.scss
+++ b/client/src/app/+admin/admin.component.scss
@@ -6,3 +6,7 @@ my-top-menu-dropdown {
 }
 
 @include sub-menu-h1;
+
+::ng-deep .anchor {
+  top: #{-($header-height + $sub-menu-height + 20px)}; // offsetTop scrollToAnchor
+}

--- a/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
+++ b/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
@@ -1,6 +1,7 @@
 <h1 class="sr-only" i18n>Settings</h1>
-<div class="anchor" id="top"></div> <!-- top anchor -->
 <div class="form-row"> <!-- preview -->
+  <div class="anchor" id="top"></div> <!-- top anchor -->
+
   <div class="form-group col-12 col-lg-4 col-xl-3"></div>
 
   <div class="form-group form-group-right col-12 col-lg-8 col-xl-9">

--- a/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
+++ b/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
@@ -1,4 +1,5 @@
 <h1 class="sr-only" i18n>Settings</h1>
+<div class="anchor" id="top"></div> <!-- top anchor -->
 <div class="form-row"> <!-- preview -->
   <div class="form-group col-12 col-lg-4 col-xl-3"></div>
 

--- a/client/src/app/+my-account/my-account.component.scss
+++ b/client/src/app/+my-account/my-account.component.scss
@@ -11,3 +11,7 @@
 
   @include sub-menu-h1;
 }
+
+::ng-deep .anchor {
+  top: #{-($header-height + $sub-menu-height + 20px)}; // offsetTop scrollToAnchor
+}

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -67,10 +67,9 @@ const routes: Routes = [
   imports: [
     RouterModule.forRoot(routes, {
       useHash: Boolean(history.pushState) === false,
-      scrollPositionRestoration: 'enabled',
+      scrollPositionRestoration: 'disabled',
       preloadingStrategy: PreloadSelectedModulesList,
-      anchorScrolling: 'enabled',
-      scrollOffset: [0, 81] // sub-menu-height
+      anchorScrolling: 'disabled'
     })
   ],
   providers: [

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -67,9 +67,10 @@ const routes: Routes = [
   imports: [
     RouterModule.forRoot(routes, {
       useHash: Boolean(history.pushState) === false,
-      scrollPositionRestoration: 'disabled',
+      scrollPositionRestoration: 'enabled',
       preloadingStrategy: PreloadSelectedModulesList,
-      anchorScrolling: 'disabled'
+      anchorScrolling: 'enabled',
+      scrollOffset: [0, 81] // sub-menu-height
     })
   ],
   providers: [

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -114,6 +114,8 @@ export class AppComponent implements OnInit, AfterViewInit {
     let resetScroll = true
     const eventsObs = this.router.events
 
+    this.viewportScroller.setOffset([0, 81]) // sub-menu-height
+
     const scrollEvent = eventsObs.pipe(filter((e: Event): e is Scroll => e instanceof Scroll))
 
     scrollEvent.subscribe(e => {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -117,16 +117,17 @@ export class AppComponent implements OnInit, AfterViewInit {
     const scrollEvent = eventsObs.pipe(filter((e: Event): e is Scroll => e instanceof Scroll))
 
     scrollEvent.subscribe(e => {
-      if (e.position) {
-        return this.viewportScroller.scrollToPosition(e.position)
-      }
-
+      // scrollToAnchor first to preserve anchor position when using history navigation
       if (e.anchor) {
         setTimeout(() => {
           this.viewportScroller.scrollToAnchor(e.anchor)
         })
 
         return
+      }
+
+      if (e.position) {
+        return this.viewportScroller.scrollToPosition(e.position)
       }
 
       if (resetScroll) {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -114,8 +114,6 @@ export class AppComponent implements OnInit, AfterViewInit {
     let resetScroll = true
     const eventsObs = this.router.events
 
-    this.viewportScroller.setOffset([0, 81]) // sub-menu-height
-
     const scrollEvent = eventsObs.pipe(filter((e: Event): e is Scroll => e instanceof Scroll))
 
     scrollEvent.subscribe(e => {
@@ -124,7 +122,11 @@ export class AppComponent implements OnInit, AfterViewInit {
       }
 
       if (e.anchor) {
-        return this.viewportScroller.scrollToAnchor(e.anchor)
+        setTimeout(() => {
+          this.viewportScroller.scrollToAnchor(e.anchor)
+        })
+
+        return
       }
 
       if (resetScroll) {

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -21,7 +21,7 @@
 
             <div class="dropdown-divider"></div>
 
-            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account">
+            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="">
               <my-global-icon iconName="user" aria-hidden="true"></my-global-icon> <ng-container i18n>Account settings</ng-container>
             </a>
 
@@ -37,13 +37,13 @@
               <span class="ml-auto text-muted">{{ language }}</span>
             </a>
 
-            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="video-settings">
+            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="video-languages-subtitles">
               <my-global-icon iconName="video-lang" aria-hidden="true"></my-global-icon>
               <span i18n>Videos:</span>
               <span class="ml-auto text-muted">{{ videoLanguages.join(', ') }}</span>
             </a>
 
-            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="video-settings">
+            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="video-sensitive-content-policy">
               <my-global-icon class="hover-display-toggle" [ngClass]="{ 'not-displayed': user.nsfwPolicy === 'display' }" iconName="sensitive" aria-hidden="true"></my-global-icon>
               <my-global-icon class="hover-display-toggle" [ngClass]="{ 'not-displayed': user.nsfwPolicy !== 'display' }" iconName="unsensitive" aria-hidden="true"></my-global-icon>
               <span i18n>Sensitive:</span>
@@ -56,7 +56,7 @@
               <input type="checkbox" [checked]="user.webTorrentEnabled"/><label class="ml-auto" for="switch">Toggle p2p</label>
             </a>
 
-            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account">
+            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="">
               <my-global-icon iconName="more-horizontal" aria-hidden="true"></my-global-icon> <ng-container i18n>More account settings</ng-container>
             </a>
 

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -21,7 +21,7 @@
 
             <div class="dropdown-divider"></div>
 
-            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="">
+            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="top">
               <my-global-icon iconName="user" aria-hidden="true"></my-global-icon> <ng-container i18n>Account settings</ng-container>
             </a>
 
@@ -56,7 +56,7 @@
               <input type="checkbox" [checked]="user.webTorrentEnabled"/><label class="ml-auto" for="switch">Toggle p2p</label>
             </a>
 
-            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="">
+            <a ngbDropdownItem ngbDropdownToggle class="dropdown-item" routerLink="/my-account/settings" fragment="top">
               <my-global-icon iconName="more-horizontal" aria-hidden="true"></my-global-icon> <ng-container i18n>More account settings</ng-container>
             </a>
 

--- a/client/src/app/shared/shared-user-settings/user-video-settings.component.html
+++ b/client/src/app/shared/shared-user-settings/user-video-settings.component.html
@@ -1,5 +1,6 @@
 <form role="form" (ngSubmit)="updateDetails()" [formGroup]="form">
   <div class="form-group form-group-select">
+    <div class="anchor" id="video-sensitive-content-policy"></div> <!-- video-sensitive-content-policy anchor -->
     <label i18n for="nsfwPolicy">Default policy on videos containing sensitive content</label>
     <my-help>
       <ng-template ptTemplate="customHtml">
@@ -20,6 +21,7 @@
   </div>
 
   <div class="form-group form-group-select">
+    <div class="anchor" id="video-languages-subtitles"></div> <!-- video-languages-subtitles anchor -->
     <label i18n for="videoLanguages">Only display videos in the following languages/subtitles</label>
     <my-help>
       <ng-template ptTemplate="customHtml">

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -19,6 +19,10 @@ $assets-path: '../assets/';
   display: none !important;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   /*** theme ***/
   // now beware node-sass requires interpolation
@@ -298,7 +302,7 @@ table {
 
 .anchor {
   position: relative;
-  top: #{-($header-height + 20px)};
+  top: #{-($header-height + 20px)}; // offsetTop scrollToAnchor
 }
 
 @media screen and (max-width: #{breakpoint(xxl)}) {


### PR DESCRIPTION
All links in the user dropdown-menu refered to `/my-account/settings` with an anchor `#video-settings`, does not scroll exactly to the the target element, plus when we are on my-settings all these links can't work properly since they have the same anchor.

It also handle the offset with the fixed sub-menu.

![image](https://user-images.githubusercontent.com/1877318/89181131-61722200-d593-11ea-9435-c5a2dd5646ed.png)