### PR TITLE
add and document new additional video extensions supported at upload

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -731,7 +731,7 @@
                         i18n-labelText labelText="Allow additional extensions"
                       >
                         <ng-container ngProjectAs="description">
-                          <span i18n>Allows users to upload .mkv, .mov, .avi and .flv videos.</span>
+                          <span i18n>Allows users to upload .mkv, .mov, .avi, .wmv, .flv, .f4v, .3g2, .3gp, .mts, m2ts, .mxf, .nut videos.</span>
                         </ng-container>
                       </my-peertube-checkbox>
                     </div>

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -213,7 +213,7 @@ user:
 # Please, do not disable transcoding since many uploaded videos will not work
 transcoding:
   enabled: true
-  # Allow your users to upload .mkv, .mov, .avi, .flv videos
+  # Allow your users to upload .mkv, .mov, .avi, .wmv, .flv, .f4v, .3g2, .3gp, .mts, m2ts, .mxf, .nut videos
   allow_additional_extensions: true
   # If a user uploads an audio file, PeerTube will create a video by merging the preview file and the audio file
   allow_audio_files: true

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -227,7 +227,7 @@ user:
 # Please, do not disable transcoding since many uploaded videos will not work
 transcoding:
   enabled: true
-  # Allow your users to upload .mkv, .mov, .avi, .flv videos
+  # Allow your users to upload .mkv, .mov, .avi, .wmv, .flv, .f4v, .3g2, .3gp, .mts, m2ts, .mxf, .nut videos
   allow_additional_extensions: true
   # If a user uploads an audio file, PeerTube will create a video by merging the preview file and the audio file
   allow_audio_files: true

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -823,6 +823,7 @@ export {
 
 function buildVideoMimetypeExt () {
   const data = {
+    // streamable formats that warrant cross-browser compatibility
     'video/webm': '.webm',
     'video/ogg': '.ogv',
     'video/mp4': '.mp4'
@@ -831,15 +832,44 @@ function buildVideoMimetypeExt () {
   if (CONFIG.TRANSCODING.ENABLED) {
     if (CONFIG.TRANSCODING.ALLOW_ADDITIONAL_EXTENSIONS) {
       Object.assign(data, {
-        'video/quicktime': '.mov',
-        'video/x-msvideo': '.avi',
-        'video/x-flv': '.flv',
         'video/x-matroska': '.mkv',
-        'video/avi': '.avi',
+        'video/ogg': '.ogg',
+
+        // Developed by Apple
+        'video/quicktime': '.mov', // often used as output format by editing software
         'video/x-m4v': '.m4v',
+        'video/m4v': '.m4v',
+
+        // Developed by the Adobe Flash Platform
+        'video/x-flv': '.flv',
+        'video/x-f4v': '.f4v', // replacement for flv
+
+        // Developed by Microsoft
+        'video/x-ms-wmv': '.wmv',
+        'video/x-msvideo': '.avi',
+        'video/avi': '.avi',
+
+        // Developed by 3GPP
+        // common video formats for cell phones
+        'video/3gpp': '.3gp',
+        'video/3gpp2': '.3g2',
+
+        // Developed by FFmpeg/Mplayer
+        'application/x-nut': '.nut',
+
+        // The standard video format used by many Sony and Panasonic HD camcorders.
+        // It is also used for storing high definition video on Blu-ray discs.
+        'video/mp2t': '.mts',
+        'video/m2ts': '.m2ts',
+
+        // Old formats reliant on MPEG-1/MPEG-2
+        'video/mpv': '.mpv',
+        'video/mpeg2': '.m2v',
+        'video/mpeg': '.mpeg',
+
         // Could be anything
         'application/octet-stream': null,
-        'video/m4v': '.m4v'
+        'application/mxf': '.mxf' // often used as exchange format by editing software
       })
     }
 
@@ -869,7 +899,7 @@ function updateWebserverConfig () {
 }
 
 function buildVideosExtname () {
-  return Object.keys(MIMETYPES.VIDEO.EXT_MIMETYPE)
+  return Object.keys(MIMETYPES.VIDEO.EXT_MIMETYPE).filter(e => e !== 'null')
 }
 
 function loadLanguages () {

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -371,6 +371,7 @@ describe('Test config', function () {
     expect(data.video.file.extensions).to.contain('.webm')
     expect(data.video.file.extensions).to.contain('.ogv')
     expect(data.video.file.extensions).to.contain('.flv')
+    expect(data.video.file.extensions).to.contain('.wmv')
     expect(data.video.file.extensions).to.contain('.mkv')
     expect(data.video.file.extensions).to.contain('.mp3')
     expect(data.video.file.extensions).to.contain('.ogg')


### PR DESCRIPTION
In addition to documenting a bit existing extensions, add `.wmv`, a missing mainstream container. Other containers added are either low-hanging fruits (3GPP, FLV replacement, OGG (`.ogg` can also be a video container), Sony/Panasonic formats which are also found in BluRay, `.nut` as ffmpeg/mplayer developed it).