### PR TITLE
Add ability to delete and re-draft a comment with no replies + markdown infos + unicode emojis

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -61,6 +61,7 @@
     "@types/linkifyjs": "^2.1.2",
     "@types/lodash-es": "^4.17.0",
     "@types/markdown-it": "^10.0.1",
+    "@types/markdown-it-emoji": "^1.4.0",
     "@types/node": "^14.0.14",
     "@types/sanitize-html": "1.23.2",
     "@types/socket.io-client": "^1.4.32",

--- a/client/package.json
+++ b/client/package.json
@@ -61,7 +61,6 @@
     "@types/linkifyjs": "^2.1.2",
     "@types/lodash-es": "^4.17.0",
     "@types/markdown-it": "^10.0.1",
-    "@types/markdown-it-emoji": "^1.4.0",
     "@types/node": "^14.0.14",
     "@types/sanitize-html": "1.23.2",
     "@types/socket.io-client": "^1.4.32",

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
@@ -13,6 +13,7 @@
               <li>Links</li>
               <li>Break lines</li>
               <li>Lists</li>
+              <li>Emojis</li>
             </ul>
           </div>
         </ng-template>

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
@@ -10,7 +10,7 @@
                 (keyup.control.enter)="onValidKey()" (keyup.meta.enter)="onValidKey()" #textarea>
 
       </textarea>
-      <my-help class="markdown-guide" helpType="custom" iconName="markdown" tooltipPlacement="left auto" i18n-title title="Markdown compatible">
+      <my-help class="markdown-guide" helpType="custom" iconName="markdown" tooltipPlacement="left auto" autoClose="true" i18n-title title="Markdown compatible">
         <ng-template ptTemplate="customHtml">
           <span i18n>Markdown compatible that supports:</span>
 

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
@@ -3,6 +3,20 @@
     <img [src]="getAvatarUrl()" alt="Avatar" />
 
     <div class="form-group">
+      <my-help class="markdown-guide" helpType="custom" iconName="markdown" i18n-title title="Markdown compatible">
+        <ng-template ptTemplate="customHtml">
+          <div i18n>
+            Markdown compatible that supports:
+
+            <ul>
+              <li>Emphasis: <strong>**bold**</strong>, <i>_italic_</i></li>
+              <li>Links</li>
+              <li>Break lines</li>
+              <li>Lists</li>
+            </ul>
+          </div>
+        </ng-template>
+      </my-help>
       <textarea i18n-placeholder placeholder="Add comment..." myAutoResize
                 [readonly]="(user === null) ? true : false"
                 (click)="openVisitorModal($event)"

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
@@ -3,12 +3,14 @@
     <img [src]="getAvatarUrl()" alt="Avatar" />
 
     <div class="form-group">
-      <textarea i18n-placeholder placeholder="Add comment..." myAutoResize [readonly]="(user === null) ? true : false"
-        (click)="openVisitorModal($event)" formControlName="text" [ngClass]="{ 'input-error': formErrors['text'] }"
-        (keyup.control.enter)="onValidKey()" (keyup.meta.enter)="onValidKey()" #textarea>
+      <textarea i18n-placeholder placeholder="Add comment..." myAutoResize
+                [readonly]="(user === null) ? true : false"
+                (click)="openVisitorModal($event)"
+                formControlName="text" [ngClass]="{ 'input-error': formErrors['text'] }"
+                (keyup.control.enter)="onValidKey()" (keyup.meta.enter)="onValidKey()" #textarea>
 
       </textarea>
-      <my-help class="markdown-guide" helpType="custom" iconName="markdown" i18n-title title="Markdown compatible">
+      <my-help class="markdown-guide" helpType="custom" iconName="markdown" tooltipPlacement="left auto" i18n-title title="Markdown compatible">
         <ng-template ptTemplate="customHtml">
           <span i18n>Markdown compatible that supports:</span>
 
@@ -27,6 +29,7 @@
             <li>
               <span i18n>Emoji markup</span>
               <code>:smile:</code>
+              <div><a href="" (click)="openEmojiModal($event)" i18n>See complete list</a></div>
             </li>
           </ul>
         </ng-template>
@@ -50,7 +53,7 @@
 <ng-template #visitorModal let-modal>
   <div class="modal-header">
     <h4 class="modal-title" id="modal-basic-title" i18n>You are one step away from commenting</h4>
-    <my-global-icon iconName="cross" aria-label="Close" role="button" (click)="hideVisitorModal()"></my-global-icon>
+    <my-global-icon iconName="cross" aria-label="Close" role="button" (click)="hideModals()"></my-global-icon>
   </div>
   <div class="modal-body">
     <span i18n>
@@ -66,12 +69,31 @@
   <div class="modal-footer inputs">
     <input
       type="button" role="button" i18n-value value="Cancel" class="action-button action-button-cancel"
-      (click)="hideVisitorModal()" (key.enter)="hideVisitorModal()"
+      (click)="hideModals()" (key.enter)="hideModals()"
     >
 
     <input
       type="submit" i18n-value value="Login to comment" class="action-button-submit"
       (click)="gotoLogin()"
     >
+  </div>
+</ng-template>
+
+<ng-template #emojiModal>
+  <div class="modal-header">
+    <h4 class="modal-title" id="modal-basic-title" i18n>Markdown Emoji List</h4>
+    <my-global-icon iconName="cross" aria-label="Close" role="button" (click)="hideModals()"></my-global-icon>
+  </div>
+  <div class="modal-body">
+    <table class="table-emoji" *ngFor="let emojiMarkup of emojiMarkupList | keyvalue">
+      <tr>
+        <td>
+          <span>{{ emojiMarkup.value }}</span>
+        </td>
+        <td>
+          <code>:{{ emojiMarkup.key }}:</code>
+        </td>
+      </tr>
+    </table>
   </div>
 </ng-template>

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
@@ -3,28 +3,34 @@
     <img [src]="getAvatarUrl()" alt="Avatar" />
 
     <div class="form-group">
-      <my-help class="markdown-guide" helpType="custom" iconName="markdown" i18n-title title="Markdown compatible">
-        <ng-template ptTemplate="customHtml">
-          <div i18n>
-            Markdown compatible that supports:
-
-            <ul>
-              <li>Emphasis: <strong>**bold**</strong>, <i>_italic_</i></li>
-              <li>Links</li>
-              <li>Break lines</li>
-              <li>Lists</li>
-              <li>Emojis</li>
-            </ul>
-          </div>
-        </ng-template>
-      </my-help>
-      <textarea i18n-placeholder placeholder="Add comment..." myAutoResize
-                [readonly]="(user === null) ? true : false"
-                (click)="openVisitorModal($event)"
-                formControlName="text" [ngClass]="{ 'input-error': formErrors['text'] }"
-                (keyup.control.enter)="onValidKey()" (keyup.meta.enter)="onValidKey()" #textarea>
+      <textarea i18n-placeholder placeholder="Add comment..." myAutoResize [readonly]="(user === null) ? true : false"
+        (click)="openVisitorModal($event)" formControlName="text" [ngClass]="{ 'input-error': formErrors['text'] }"
+        (keyup.control.enter)="onValidKey()" (keyup.meta.enter)="onValidKey()" #textarea>
 
       </textarea>
+      <my-help class="markdown-guide" helpType="custom" iconName="markdown" i18n-title title="Markdown compatible">
+        <ng-template ptTemplate="customHtml">
+          <span i18n>Markdown compatible that supports:</span>
+
+          <ul>
+            <li><span i18n>Auto generated links</span></li>
+            <li><span i18n>Break lines</span></li>
+            <li><span i18n>Lists</span></li>
+            <li>
+              <span i18n>Emphasis</span>
+              <code>**<strong i18n>bold</strong>** _<i i18n>italic</i>_</code>
+            </li>
+            <li>
+              <span i18n>Emoji shortcuts</span>
+              <code>:) &lt;3</code>
+            </li>
+            <li>
+              <span i18n>Emoji markup</span>
+              <code>:smile:</code>
+            </li>
+          </ul>
+        </ng-template>
+      </my-help>
       <div *ngIf="formErrors.text" class="form-error">
         {{ formErrors.text }}
       </div>

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
@@ -20,8 +20,8 @@
     <button *ngIf="isAddButtonDisplayed()" class="cancel-button" (click)="cancelCommentReply()" type="button" i18n>
       Cancel
     </button>
-    <button *ngIf="isAddButtonDisplayed()" [ngClass]="{ disabled: !form.valid || addingComment }" i18n>
-      Reply
+    <button *ngIf="isAddButtonDisplayed()" [ngClass]="{ disabled: !form.valid || addingComment }">
+      {{ addingCommentButtonValue }}
     </button>
   </div>
 </form>

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
@@ -28,11 +28,7 @@ form {
     .markdown-guide {
       position: absolute;
       top: 5px;
-      left: 4px;
-
-      @media screen and (max-width: 600px) {
-        left: 0;
-      }
+      right: 9px;
 
       ::ng-deep .help-tooltip-button {
         my-global-icon {
@@ -40,13 +36,17 @@ form {
           width: $markdown-icon-width;
 
           svg {
-            opacity: 0.5;
+            color: #C6C6C6;
+            fill: #C6C6C6;
+            border-radius: 3px;
           }
         }
 
         &:focus, &:active, &:hover {
           my-global-icon svg {
-            opacity: 1;
+            background-color: #C6C6C6;
+            color: pvar(--mainBackgroundColor);
+            fill: pvar(--mainBackgroundColor);
           }
         }
       }
@@ -56,10 +56,11 @@ form {
       @include peertube-textarea(100%, $peertube-textarea-height);
       @include button-focus(pvar(--mainColorLightest));
 
-      text-indent: $markdown-icon-width;
+      min-height: calc(#{$peertube-textarea-height} - 15px * 2);
+      padding-right: $markdown-icon-width + 15px !important;
 
       @media screen and (max-width: 600px) {
-        text-indent: $markdown-icon-width + 5px;
+        padding-right: $markdown-icon-width + 19px  !important;
       }
 
       &:focus::placeholder {

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
@@ -19,10 +19,48 @@ form {
   .form-group {
     flex-grow: 1;
     margin: 0;
+    position: relative;
+
+    $peertube-textarea-height: 60px;
+    $markdown-icon-height: 18px;
+    $markdown-icon-width: 30px;
+
+    .markdown-guide {
+      position: absolute;
+      top: 5px;
+      left: 4px;
+
+      @media screen and (max-width: 600px) {
+        left: 0;
+      }
+
+      ::ng-deep .help-tooltip-button {
+        my-global-icon {
+          height: $markdown-icon-height;
+          width: $markdown-icon-width;
+
+          svg {
+            opacity: 0.5;
+          }
+        }
+
+        &:focus, &:active, &:hover {
+          my-global-icon svg {
+            opacity: 1;
+          }
+        }
+      }
+    }
 
     textarea {
-      @include peertube-textarea(100%, 60px);
+      @include peertube-textarea(100%, $peertube-textarea-height);
       @include button-focus(pvar(--mainColorLightest));
+
+      text-indent: $markdown-icon-width;
+
+      @media screen and (max-width: 600px) {
+        text-indent: $markdown-icon-width + 5px;
+      }
 
       &:focus::placeholder {
         opacity: 0;

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
@@ -99,6 +99,16 @@ form {
   }
 }
 
+.table-emoji {
+  td {
+    &:first-child {
+      width: 20px;
+    }
+
+    vertical-align: top;
+  }
+}
+
 @media screen and (max-width: 600px) {
   textarea, .comment-buttons button {
     font-size: 14px !important;

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
@@ -22,6 +22,7 @@ form {
 
     textarea {
       @include peertube-textarea(100%, 60px);
+      @include button-focus(pvar(--mainColorLightest));
 
       &:focus::placeholder {
         opacity: 0;

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
@@ -17,11 +17,10 @@ import { I18n } from '@ngx-translate/i18n-polyfill'
 export class VideoCommentAddComponent extends FormReactive implements OnChanges, OnInit {
   @Input() user: User
   @Input() video: Video
-  @Input() parentComment: VideoComment
-  @Input() parentComments: VideoComment[]
+  @Input() parentComment?: VideoComment
+  @Input() parentComments?: VideoComment[]
   @Input() focusOnInit = false
   @Input() textValue?: string
-  @Input() commentThread?: boolean
 
   @Output() commentCreated = new EventEmitter<VideoComment>()
   @Output() cancel = new EventEmitter()
@@ -57,27 +56,13 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
     })
 
     if (this.user) {
-      if (this.commentThread) {
+      if (!this.parentComment) {
         this.addingCommentButtonValue = this.i18n('Comment')
       } else {
         this.addingCommentButtonValue = this.i18n('Reply')
       }
 
-      if (this.textValue) {
-        this.patchTextValue(this.textValue, this.focusOnInit)
-        return
-      }
-
-      if (this.parentComment) {
-        const mentions = this.parentComments
-          .filter(c => c.account && c.account.id !== this.user.account.id) // Don't add mention of ourselves
-          .map(c => '@' + c.by)
-
-        const mentionsSet = new Set(mentions)
-        const mentionsText = Array.from(mentionsSet).join(' ') + ' '
-
-        this.patchTextValue(mentionsText, this.focusOnInit)
-      }
+      this.initTextValue()
     }
   }
 
@@ -174,6 +159,24 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
   private addCommentThread (commentCreate: VideoCommentCreate) {
     return this.videoCommentService
       .addCommentThread(this.video.id, commentCreate)
+  }
+
+  private initTextValue () {
+    if (this.textValue) {
+      this.patchTextValue(this.textValue, this.focusOnInit)
+      return
+    }
+
+    if (this.parentComment) {
+      const mentions = this.parentComments
+        .filter(c => c.account && c.account.id !== this.user.account.id) // Don't add mention of ourselves
+        .map(c => '@' + c.by)
+
+      const mentionsSet = new Set(mentions)
+      const mentionsText = Array.from(mentionsSet).join(' ') + ' '
+
+      this.patchTextValue(mentionsText, this.focusOnInit)
+    }
   }
 
   private patchTextValue (text: string, focus: boolean) {

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
@@ -27,6 +27,7 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
   @Output() cancel = new EventEmitter()
 
   @ViewChild('visitorModal', { static: true }) visitorModal: NgbModal
+  @ViewChild('emojiModal', { static: true }) emojiModal: NgbModal
   @ViewChild('textarea', { static: true }) textareaElement: ElementRef
 
   addingComment = false
@@ -42,6 +43,12 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
     private i18n: I18n
   ) {
     super()
+  }
+
+  get emojiMarkupList () {
+    const emojiMarkup = require('markdown-it-emoji/lib/data/light.json')
+
+    return emojiMarkup
   }
 
   ngOnInit () {
@@ -97,7 +104,12 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
     }
   }
 
-  hideVisitorModal () {
+  openEmojiModal (event: any) {
+    event.preventDefault()
+    this.modalService.open(this.emojiModal, { backdrop: true })
+  }
+
+  hideModals () {
     this.modalService.dismissAll()
   }
 
@@ -145,7 +157,7 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
   }
 
   gotoLogin () {
-    this.hideVisitorModal()
+    this.hideModals()
     this.router.navigate([ '/login' ])
   }
 

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
@@ -7,7 +7,6 @@ import { Video } from '@app/shared/shared-main'
 import { VideoComment, VideoCommentService } from '@app/shared/shared-video-comment'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { VideoCommentCreate } from '@shared/models'
-import { I18n } from '@ngx-translate/i18n-polyfill'
 
 @Component({
   selector: 'my-video-comment-add',
@@ -39,7 +38,6 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
     private videoCommentService: VideoCommentService,
     private modalService: NgbModal,
     private router: Router,
-    private i18n: I18n
   ) {
     super()
   }
@@ -57,9 +55,9 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
 
     if (this.user) {
       if (!this.parentComment) {
-        this.addingCommentButtonValue = this.i18n('Comment')
+        this.addingCommentButtonValue = $localize`Comment`
       } else {
-        this.addingCommentButtonValue = this.i18n('Reply')
+        this.addingCommentButtonValue = $localize`Reply`
       }
 
       this.initTextValue()

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
@@ -7,6 +7,7 @@ import { Video } from '@app/shared/shared-main'
 import { VideoComment, VideoCommentService } from '@app/shared/shared-video-comment'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { VideoCommentCreate } from '@shared/models'
+import { I18n } from '@ngx-translate/i18n-polyfill'
 
 @Component({
   selector: 'my-video-comment-add',
@@ -20,6 +21,7 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
   @Input() parentComments: VideoComment[]
   @Input() focusOnInit = false
   @Input() textValue?: string
+  @Input() commentThread?: boolean
 
   @Output() commentCreated = new EventEmitter<VideoComment>()
   @Output() cancel = new EventEmitter()
@@ -28,6 +30,7 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
   @ViewChild('textarea', { static: true }) textareaElement: ElementRef
 
   addingComment = false
+  addingCommentButtonValue: string
 
   constructor (
     protected formValidatorService: FormValidatorService,
@@ -35,7 +38,8 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
     private notifier: Notifier,
     private videoCommentService: VideoCommentService,
     private modalService: NgbModal,
-    private router: Router
+    private router: Router,
+    private i18n: I18n
   ) {
     super()
   }
@@ -46,6 +50,12 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
     })
 
     if (this.user) {
+      if (this.commentThread) {
+        this.addingCommentButtonValue = this.i18n('Comment')
+      } else {
+        this.addingCommentButtonValue = this.i18n('Reply')
+      }
+
       if (this.textValue) {
         this.patchTextValue(this.textValue, this.focusOnInit)
         return

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!comment.isDeleted || comment.isDeleted && comment.totalReplies !== 0" class="root-comment">
+<div *ngIf="isNotDeletedOrDeletedWithReplies()" class="root-comment">
   <div class="left">
     <a *ngIf="!comment.isDeleted" [href]="comment.account.url" target="_blank" rel="noopener noreferrer">
       <img

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.html
@@ -1,4 +1,4 @@
-<div class="root-comment">
+<div *ngIf="!comment.isDeleted || comment.isDeleted && comment.totalReplies !== 0" class="root-comment">
   <div class="left">
     <a *ngIf="!comment.isDeleted" [href]="comment.account.url" target="_blank" rel="noopener noreferrer">
       <img
@@ -58,7 +58,7 @@
              class="comment-date">{{ comment.createdAt | myFromNow }}</a>
         </div>
 
-        <div *ngIf="comment.isDeleted" class="comment-html comment-html-deleted">
+        <div class="comment-html comment-html-deleted">
           <i i18n>This comment has been deleted</i>
         </div>
       </ng-container>

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.html
@@ -41,12 +41,10 @@
         ></div>
 
         <div class="comment-actions">
-          <div *ngIf="isUserLoggedIn()" (click)="onWantToReply()" class="comment-action-reply" i18n>Reply</div>
-          <div *ngIf="isRemovableByUser()" (click)="onWantToDelete()" class="comment-action-delete" i18n>Delete</div>
-          <div *ngIf="isRedraftableByUser()" (click)="onWantToRedraft()" class="comment-action-redraft" i18n>Delete & re-draft</div>
+          <div *ngIf="isUserLoggedIn()" tabindex=0 (click)="onWantToReply()" class="comment-action-reply" i18n>Reply</div>
 
           <my-user-moderation-dropdown
-            [prependActions]="prependModerationActions"
+            [prependActions]="prependModerationActions" tabindex=0
             buttonSize="small" [account]="commentAccount" [user]="commentUser" i18n-label label="Options" placement="bottom-left auto"
           ></my-user-moderation-dropdown>
         </div>

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.html
@@ -43,6 +43,7 @@
         <div class="comment-actions">
           <div *ngIf="isUserLoggedIn()" (click)="onWantToReply()" class="comment-action-reply" i18n>Reply</div>
           <div *ngIf="isRemovableByUser()" (click)="onWantToDelete()" class="comment-action-delete" i18n>Delete</div>
+          <div *ngIf="isRedraftableByUser()" (click)="onWantToRedraft()" class="comment-action-redraft" i18n>Delete & re-draft</div>
 
           <my-user-moderation-dropdown
             [prependActions]="prependModerationActions"
@@ -72,6 +73,7 @@
         [focusOnInit]="true"
         (commentCreated)="onCommentReplyCreated($event)"
         (cancel)="onResetReply()"
+        [textValue]="redraftValue"
       ></my-video-comment-add>
 
       <div *ngIf="commentTree" class="children">
@@ -84,8 +86,10 @@
             [parentComments]="newParentComments"
             (wantedToReply)="onWantToReply($event)"
             (wantedToDelete)="onWantToDelete($event)"
+            (wantedToRedraft)="onWantToRedraft($event)"
             (resetReply)="onResetReply()"
             (timestampClicked)="handleTimestampClicked($event)"
+            [redraftValue]="redraftValue"
           ></my-video-comment>
         </div>
       </div>

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.scss
@@ -118,14 +118,12 @@
       display: flex;
 
       ::ng-deep .dropdown-toggle,
-      .comment-action-reply,
-      .comment-action-delete,
-      .comment-action-redraft {
+      .comment-action-reply {
         color: pvar(--greyForegroundColor);
         cursor: pointer;
         margin-right: 10px;
 
-        &:hover {
+        &:hover, &:active, &:focus, &:focus-visible {
           color: pvar(--mainForegroundColor);
         }
       }

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.scss
@@ -119,7 +119,8 @@
 
       ::ng-deep .dropdown-toggle,
       .comment-action-reply,
-      .comment-action-delete {
+      .comment-action-delete,
+      .comment-action-redraft {
         color: pvar(--greyForegroundColor);
         cursor: pointer;
         margin-right: 10px;

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -115,6 +115,10 @@ export class VideoCommentComponent implements OnInit, OnChanges {
     return this.comment.account && this.isUserLoggedIn() && this.user.account.id === this.comment.account.id && this.comment.totalReplies === 0
   }
 
+  isReportableByUser() {
+    return this.comment.account && this.isUserLoggedIn() && this.comment.isDeleted === false && this.authService.getUser().account.id !== this.comment.account.id
+  }
+
   switchToDefaultAvatar ($event: Event) {
     ($event.target as HTMLImageElement).src = Actor.GET_DEFAULT_AVATAR_URL()
   }
@@ -146,14 +150,30 @@ export class VideoCommentComponent implements OnInit, OnChanges {
       this.comment.account = null
     }
 
-    if (this.isUserLoggedIn() && this.comment.isDeleted === false && this.authService.getUser().account.id !== this.comment.account.id) {
-      this.prependModerationActions = [
-        {
-          label: $localize`Report comment`,
-          handler: () => this.showReportModal()
-        }
-      ]
-    } else {
+    this.prependModerationActions = []
+
+    if (this.isReportableByUser()) {
+      this.prependModerationActions.push({
+        label: $localize`Report comment`,
+        handler: () => this.showReportModal()
+      })
+    }
+
+    if (this.isRemovableByUser()) {
+      this.prependModerationActions.push({
+        label: $localize`Remove comment`,
+        handler: () => this.onWantToDelete()
+      })
+    }
+
+    if (this.isRedraftableByUser()) {
+      this.prependModerationActions.push({
+        label: $localize`Remove & re-draft comment`,
+        handler: () => this.onWantToRedraft()
+      })
+    }
+
+    if (this.prependModerationActions.length === 0) {
       this.prependModerationActions = undefined
     }
   }

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -125,7 +125,7 @@ export class VideoCommentComponent implements OnInit, OnChanges {
       this.comment.account &&
       this.isUserLoggedIn() &&
       this.comment.isDeleted === false &&
-      this.authService.getUser().account.id !== this.comment.account.id
+      this.user.account.id !== this.comment.account.id
     )
   }
 

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -149,7 +149,7 @@ export class VideoCommentComponent implements OnInit, OnChanges {
   }
 
   private async init () {
-    const html = await this.markdownService.textMarkdownToHTML(this.comment.text, true)
+    const html = await this.markdownService.textMarkdownToHTML(this.comment.text, true, true)
     this.sanitizedCommentHTML = await this.markdownService.processVideoTimestamps(html)
     this.newParentComments = this.parentComments.concat([ this.comment ])
 

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -22,9 +22,11 @@ export class VideoCommentComponent implements OnInit, OnChanges {
   @Input() inReplyToCommentId: number
   @Input() highlightedComment = false
   @Input() firstInThread = false
+  @Input() redraftValue?: string
 
-  @Output() wantedToDelete = new EventEmitter<VideoComment>()
   @Output() wantedToReply = new EventEmitter<VideoComment>()
+  @Output() wantedToDelete = new EventEmitter<VideoComment>()
+  @Output() wantedToRedraft = new EventEmitter<VideoComment>()
   @Output() threadCreated = new EventEmitter<VideoCommentThreadTree>()
   @Output() resetReply = new EventEmitter()
   @Output() timestampClicked = new EventEmitter<number>()
@@ -70,7 +72,10 @@ export class VideoCommentComponent implements OnInit, OnChanges {
       comment: createdComment,
       children: []
     })
+
     this.resetReply.emit()
+
+    delete this.redraftValue
   }
 
   onWantToReply (comment?: VideoComment) {
@@ -79,6 +84,10 @@ export class VideoCommentComponent implements OnInit, OnChanges {
 
   onWantToDelete (comment?: VideoComment) {
     this.wantedToDelete.emit(comment || this.comment)
+  }
+
+  onWantToRedraft (comment?: VideoComment) {
+    this.wantedToRedraft.emit(comment || this.comment)
   }
 
   isUserLoggedIn () {
@@ -100,6 +109,10 @@ export class VideoCommentComponent implements OnInit, OnChanges {
         this.user.account.id === this.video.account.id ||
         this.user.hasRight(UserRight.REMOVE_ANY_VIDEO_COMMENT)
       )
+  }
+
+  isRedraftableByUser () {
+    return this.comment.account && this.isUserLoggedIn() && this.user.account.id === this.comment.account.id && this.comment.totalReplies === 0
   }
 
   switchToDefaultAvatar ($event: Event) {

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -75,7 +75,7 @@ export class VideoCommentComponent implements OnInit, OnChanges {
 
     this.resetReply.emit()
 
-    delete this.redraftValue
+    this.redraftValue = undefined
   }
 
   onWantToReply (comment?: VideoComment) {
@@ -131,6 +131,10 @@ export class VideoCommentComponent implements OnInit, OnChanges {
 
   switchToDefaultAvatar ($event: Event) {
     ($event.target as HTMLImageElement).src = Actor.GET_DEFAULT_AVATAR_URL()
+  }
+
+  isNotDeletedOrDeletedWithReplies () {
+    return !this.comment.isDeleted || this.comment.isDeleted && this.comment.totalReplies !== 0
   }
 
   private getUserIfNeeded (account: Account) {

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -112,11 +112,21 @@ export class VideoCommentComponent implements OnInit, OnChanges {
   }
 
   isRedraftableByUser () {
-    return this.comment.account && this.isUserLoggedIn() && this.user.account.id === this.comment.account.id && this.comment.totalReplies === 0
+    return (
+      this.comment.account &&
+      this.isUserLoggedIn() &&
+      this.user.account.id === this.comment.account.id &&
+      this.comment.totalReplies === 0
+    )
   }
 
-  isReportableByUser() {
-    return this.comment.account && this.isUserLoggedIn() && this.comment.isDeleted === false && this.authService.getUser().account.id !== this.comment.account.id
+  isReportableByUser () {
+    return (
+      this.comment.account &&
+      this.isUserLoggedIn() &&
+      this.comment.isDeleted === false &&
+      this.authService.getUser().account.id !== this.comment.account.id
+    )
   }
 
   switchToDefaultAvatar ($event: Event) {

--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -154,21 +154,24 @@ export class VideoCommentComponent implements OnInit, OnChanges {
 
     if (this.isReportableByUser()) {
       this.prependModerationActions.push({
-        label: $localize`Report comment`,
+        label: $localize`Report`,
+        iconName: 'flag',
         handler: () => this.showReportModal()
       })
     }
 
     if (this.isRemovableByUser()) {
       this.prependModerationActions.push({
-        label: $localize`Remove comment`,
+        label: $localize`Remove`,
+        iconName: 'delete',
         handler: () => this.onWantToDelete()
       })
     }
 
     if (this.isRedraftableByUser()) {
       this.prependModerationActions.push({
-        label: $localize`Remove & re-draft comment`,
+        label: $localize`Remove & re-draft`,
+        iconName: 'edit',
         handler: () => this.onWantToRedraft()
       })
     }

--- a/client/src/app/+videos/+video-watch/comment/video-comments.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comments.component.html
@@ -27,6 +27,7 @@
       [video]="video"
       [user]="user"
       (commentCreated)="onCommentThreadCreated($event)"
+      [textValue]="commentThreadRedraftValue"
     ></my-video-comment-add>
 
     <div *ngIf="componentPagination.totalItems === 0 && comments.length === 0" i18n>No comments.</div>
@@ -50,9 +51,11 @@
           [firstInThread]="true"
           (wantedToReply)="onWantedToReply($event)"
           (wantedToDelete)="onWantedToDelete($event)"
+          (wantedToRedraft)="onWantedToRedraft($event)"
           (threadCreated)="onThreadCreated($event)"
           (resetReply)="onResetReply()"
           (timestampClicked)="handleTimestampClicked($event)"
+          [redraftValue]="commentReplyRedraftValue"
         ></my-video-comment>
       </div>
 
@@ -66,9 +69,11 @@
           [firstInThread]="i + 1 !== comments.length"
           (wantedToReply)="onWantedToReply($event)"
           (wantedToDelete)="onWantedToDelete($event)"
+          (wantedToRedraft)="onWantedToRedraft($event)"
           (threadCreated)="onThreadCreated($event)"
           (resetReply)="onResetReply()"
           (timestampClicked)="handleTimestampClicked($event)"
+          [redraftValue]="commentReplyRedraftValue"
         >
           <div *ngIf="comment.totalReplies !== 0 && !threadComments[comment.id]" (click)="viewReplies(comment.id)" class="view-replies mb-2">
             <span class="glyphicon glyphicon-menu-down"></span>

--- a/client/src/app/+videos/+video-watch/comment/video-comments.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comments.component.html
@@ -28,6 +28,7 @@
       [user]="user"
       (commentCreated)="onCommentThreadCreated($event)"
       [textValue]="commentThreadRedraftValue"
+      [commentThread]="true"
     ></my-video-comment-add>
 
     <div *ngIf="componentPagination.totalItems === 0 && comments.length === 0" i18n>No comments.</div>

--- a/client/src/app/+videos/+video-watch/comment/video-comments.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comments.component.html
@@ -28,7 +28,6 @@
       [user]="user"
       (commentCreated)="onCommentThreadCreated($event)"
       [textValue]="commentThreadRedraftValue"
-      [commentThread]="true"
     ></my-video-comment-add>
 
     <div *ngIf="componentPagination.totalItems === 0 && comments.length === 0" i18n>No comments.</div>

--- a/client/src/app/+videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comments.component.ts
@@ -160,15 +160,15 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
     this.timestampClicked.emit(timestamp)
   }
 
-  async onWantedToDelete (commentToDelete: VideoComment, message = 'Do you really want to delete this comment?'): Promise<boolean> {
+  async onWantedToDelete(commentToDelete: VideoComment, title = $localize`Delete`, message = $localize`Do you really want to delete this comment?`): Promise<boolean> {
     if (commentToDelete.isLocal || this.video.isLocal) {
       message += $localize` The deletion will be sent to remote instances so they can reflect the change.`
     } else {
       message += $localize` It is a remote comment, so the deletion will only be effective on your instance.`
     }
 
-    const res = await this.confirmService.confirm(message, $localize`Delete`)
-    if (res === false) return
+    const res = await this.confirmService.confirm(message, title)
+    if (res === false) return false
 
     this.videoCommentService.deleteVideoComment(commentToDelete.videoId, commentToDelete.id)
       .subscribe(
@@ -189,8 +189,8 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
     return true
   }
 
-  async onWantedToRedraft(commentToRedraft: VideoComment) {
-    const confirm = await this.onWantedToDelete(commentToRedraft, 'Do you really want to delete and re-draft this comment?')
+  async onWantedToRedraft (commentToRedraft: VideoComment) {
+    const confirm = await this.onWantedToDelete(commentToRedraft, $localize`Delete and re-draft`, $localize`Do you really want to delete and re-draft this comment?`)
 
     if (confirm) {
       this.inReplyToCommentId = commentToRedraft.inReplyToCommentId

--- a/client/src/app/+videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comments.component.ts
@@ -133,7 +133,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
 
   onCommentThreadCreated (comment: VideoComment) {
     this.comments.unshift(comment)
-    delete this.commentThreadRedraftValue
+    this.commentThreadRedraftValue = undefined
   }
 
   onWantedToReply (comment: VideoComment) {
@@ -142,7 +142,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
 
   onResetReply () {
     this.inReplyToCommentId = undefined
-    delete this.commentReplyRedraftValue
+    this.commentReplyRedraftValue = undefined
   }
 
   onThreadCreated (commentTree: VideoCommentThreadTree) {

--- a/client/src/app/core/renderer/markdown.service.ts
+++ b/client/src/app/core/renderer/markdown.service.ts
@@ -1,4 +1,5 @@
 import * as MarkdownIt from 'markdown-it'
+import MarkdownItEmoji from 'markdown-it-emoji'
 import { buildVideoLink } from 'src/assets/player/utils'
 import { Injectable } from '@angular/core'
 import { HtmlRendererService } from './html-renderer.service'
@@ -59,20 +60,20 @@ export class MarkdownService {
 
   constructor (private htmlRenderer: HtmlRendererService) {}
 
-  textMarkdownToHTML (markdown: string, withHtml = false) {
-    if (withHtml) return this.render('textWithHTMLMarkdownIt', markdown)
+  textMarkdownToHTML (markdown: string, withHtml = false, withEmoji = false) {
+    if (withHtml) return this.render('textWithHTMLMarkdownIt', markdown, withEmoji)
 
-    return this.render('textMarkdownIt', markdown)
+    return this.render('textMarkdownIt', markdown, withEmoji)
   }
 
-  enhancedMarkdownToHTML (markdown: string, withHtml = false) {
-    if (withHtml) return this.render('enhancedWithHTMLMarkdownIt', markdown)
+  enhancedMarkdownToHTML (markdown: string, withHtml = false, withEmoji = false) {
+    if (withHtml) return this.render('enhancedWithHTMLMarkdownIt', markdown, withEmoji)
 
-    return this.render('enhancedMarkdownIt', markdown)
+    return this.render('enhancedMarkdownIt', markdown, withEmoji)
   }
 
   completeMarkdownToHTML (markdown: string) {
-    return this.render('completeMarkdownIt', markdown)
+    return this.render('completeMarkdownIt', markdown, true)
   }
 
   async processVideoTimestamps (html: string) {
@@ -83,12 +84,16 @@ export class MarkdownService {
     })
   }
 
-  private async render (name: keyof MarkdownParsers, markdown: string) {
+  private async render (name: keyof MarkdownParsers, markdown: string, withEmoji = false) {
     if (!markdown) return ''
 
     const config = this.parsersConfig[ name ]
     if (!this.markdownParsers[ name ]) {
       this.markdownParsers[ name ] = await this.createMarkdownIt(config)
+
+      if (withEmoji) {
+        this.markdownParsers[ name ].use(MarkdownItEmoji)
+      }
     }
 
     let html = this.markdownParsers[ name ].render(markdown)

--- a/client/src/app/core/renderer/markdown.service.ts
+++ b/client/src/app/core/renderer/markdown.service.ts
@@ -1,5 +1,4 @@
 import * as MarkdownIt from 'markdown-it'
-import MarkdownItEmoji from 'markdown-it-emoji'
 import { buildVideoLink } from 'src/assets/player/utils'
 import { Injectable } from '@angular/core'
 import { HtmlRendererService } from './html-renderer.service'
@@ -92,7 +91,9 @@ export class MarkdownService {
       this.markdownParsers[ name ] = await this.createMarkdownIt(config)
 
       if (withEmoji) {
-        this.markdownParsers[ name ].use(MarkdownItEmoji)
+        // TODO: write types
+        const emoji = require('markdown-it-emoji/light')
+        this.markdownParsers[ name ].use(emoji)
       }
     }
 

--- a/client/src/app/shared/shared-icons/global-icon.component.ts
+++ b/client/src/app/shared/shared-icons/global-icon.component.ts
@@ -4,6 +4,7 @@ import { HooksService } from '@app/core/plugins/hooks.service'
 const icons = {
   // misc icons
   'npm': require('!!raw-loader?!../../../assets/images/misc/npm.svg').default,
+  'markdown': require('!!raw-loader?!../../../assets/images/misc/markdown.svg').default,
   'language': require('!!raw-loader?!../../../assets/images/misc/language.svg').default,
   'video-lang': require('!!raw-loader?!../../../assets/images/misc/video-lang.svg').default,
   'support': require('!!raw-loader?!../../../assets/images/misc/support.svg').default,

--- a/client/src/app/shared/shared-main/misc/help.component.html
+++ b/client/src/app/shared/shared-main/misc/help.component.html
@@ -26,8 +26,8 @@
   role="button"
   class="help-tooltip-button"
   container="body"
-  title="Get help"
-  i18n-title
+  [title]="title"
+  tabindex=0
   popoverClass="help-popover"
   [attr.aria-pressed]="isPopoverOpened"
   [ngbPopover]="tooltipTemplate"
@@ -36,5 +36,5 @@
   (onHidden)="onPopoverHidden()"
   (onShown)="onPopoverShown()"
 >
-  <my-global-icon iconName="help"></my-global-icon>
+  <my-global-icon [iconName]="iconName"></my-global-icon>
 </span>

--- a/client/src/app/shared/shared-main/misc/help.component.html
+++ b/client/src/app/shared/shared-main/misc/help.component.html
@@ -32,7 +32,7 @@
   [attr.aria-pressed]="isPopoverOpened"
   [ngbPopover]="tooltipTemplate"
   [placement]="tooltipPlacement"
-  autoClose="outside"
+  [autoClose]="autoClose"
   (onHidden)="onPopoverHidden()"
   (onShown)="onPopoverShown()"
 >

--- a/client/src/app/shared/shared-main/misc/help.component.scss
+++ b/client/src/app/shared/shared-main/misc/help.component.scss
@@ -5,14 +5,17 @@
   cursor: pointer;
   border: none;
 
+  margin: 5px;
+
   my-global-icon {
     width: 17px;
     position: relative;
     top: -1px;
-    margin: 5px;
 
     @include apply-svg-color(pvar(--greyForegroundColor))
   }
+
+  @include disable-outline;
 }
 
 ::ng-deep {

--- a/client/src/app/shared/shared-main/misc/help.component.ts
+++ b/client/src/app/shared/shared-main/misc/help.component.ts
@@ -1,5 +1,6 @@
 import { AfterContentInit, Component, ContentChildren, Input, OnChanges, OnInit, QueryList, TemplateRef } from '@angular/core'
 import { MarkdownService } from '@app/core'
+import { GlobalIconName } from '@app/shared/shared-icons'
 import { PeerTubeTemplateDirective } from '../angular'
 
 @Component({
@@ -11,6 +12,8 @@ import { PeerTubeTemplateDirective } from '../angular'
 export class HelpComponent implements OnInit, OnChanges, AfterContentInit {
   @Input() helpType: 'custom' | 'markdownText' | 'markdownEnhanced' = 'custom'
   @Input() tooltipPlacement = 'right auto'
+  @Input() iconName: GlobalIconName = 'help'
+  @Input() title = $localize`Get help`
 
   @ContentChildren(PeerTubeTemplateDirective) templates: QueryList<PeerTubeTemplateDirective<'preHtml' | 'customHtml' | 'postHtml'>>
 

--- a/client/src/app/shared/shared-main/misc/help.component.ts
+++ b/client/src/app/shared/shared-main/misc/help.component.ts
@@ -14,6 +14,7 @@ export class HelpComponent implements OnInit, OnChanges, AfterContentInit {
   @Input() tooltipPlacement = 'right auto'
   @Input() iconName: GlobalIconName = 'help'
   @Input() title = $localize`Get help`
+  @Input() autoClose = 'outside'
 
   @ContentChildren(PeerTubeTemplateDirective) templates: QueryList<PeerTubeTemplateDirective<'preHtml' | 'customHtml' | 'postHtml'>>
 

--- a/client/src/assets/images/misc/markdown.svg
+++ b/client/src/assets/images/misc/markdown.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="40" height="24" viewBox="0 0 208 128"><rect width="198" height="118" x="5" y="5" ry="10" stroke="#000" stroke-width="10" fill="none"/><path d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="24" viewBox="0 0 208 128"><rect width="198" height="118" x="5" y="5" ry="10" stroke="#C6C6C6" stroke-width="10" fill="none"/><path d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"/></svg>

--- a/client/src/assets/images/misc/markdown.svg
+++ b/client/src/assets/images/misc/markdown.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="24" viewBox="0 0 208 128"><rect width="198" height="118" x="5" y="5" ry="10" stroke="#000" stroke-width="10" fill="none"/><path d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"/></svg>

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -103,6 +103,16 @@ label {
   font-size: 15px;
 }
 
+code {
+  background-color: pvar(--greyBackgroundColor);
+  border-radius: 3px;
+  padding: .2em .4em;
+  margin: auto .4em;
+  font-size: 75%;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 .form-error {
   display: block;
   color: $red;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1569,14 +1569,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/markdown-it-emoji@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@types/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#2102dcb3cdaf15d7ee1c01df0fda00f61ca5fece"
-  integrity sha512-TeSq2kwZZwzt/6mfKW3FXtvVdtt9ne+Fvf5/jiBejOhGcnG3keVfsxQaHSUhy0xyHaCXDfj+kZLSPQrDtR5N4w==
-  dependencies:
-    "@types/markdown-it" "*"
-
-"@types/markdown-it@*", "@types/markdown-it@^10.0.1":
+"@types/markdown-it@^10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-10.0.1.tgz#94e252ab689c8e9ceb9aff2946e0a458390105eb"
   integrity sha512-L1ibTdA5IUe/cRBlf3N3syAOBQSN1WCMGtAWir6mKxibiRl4LmpZM4jLz+7zAqiMnhQuAP1sqZOF9wXgn2kpEg==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1569,7 +1569,14 @@
   dependencies:
     "@types/node" "*"
 
-"@types/markdown-it@^10.0.1":
+"@types/markdown-it-emoji@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#2102dcb3cdaf15d7ee1c01df0fda00f61ca5fece"
+  integrity sha512-TeSq2kwZZwzt/6mfKW3FXtvVdtt9ne+Fvf5/jiBejOhGcnG3keVfsxQaHSUhy0xyHaCXDfj+kZLSPQrDtR5N4w==
+  dependencies:
+    "@types/markdown-it" "*"
+
+"@types/markdown-it@*", "@types/markdown-it@^10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-10.0.1.tgz#94e252ab689c8e9ceb9aff2946e0a458390105eb"
   integrity sha512-L1ibTdA5IUe/cRBlf3N3syAOBQSN1WCMGtAWir6mKxibiRl4LmpZM4jLz+7zAqiMnhQuAP1sqZOF9wXgn2kpEg==
@@ -7375,6 +7382,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+markdown-it-emoji@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
+  integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
 
 markdown-it@^11.0.0:
   version "11.0.0"

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "libxmljs": "0.19.7",
     "maildev": "^1.0.0-rc3",
+    "markdown-it-emoji": "^1.4.0",
     "marked": "^1.1.0",
     "marked-man": "^0.7.0",
     "mocha": "^8.0.1",
@@ -219,7 +220,7 @@
   "_moduleAliases": {
     "@server": "dist/server"
   },
-  "bundlewatch" : {
+  "bundlewatch": {
     "files": [
       {
         "path": "client/dist/en-US/*-es2015.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,6 +4774,11 @@ make-plural@^6.2.1:
   resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-6.2.1.tgz#2790af1d05fb2fc35a111ce759ffdb0aca1339a3"
   integrity sha512-AmkruwJ9EjvyTv6AM8MBMK3TAeOJvhgTv5YQXzF0EP2qawhpvMjDpHvsdOIIT0Vn+BB0+IogmYZ1z+Ulm/m0Fg==
 
+markdown-it-emoji@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
+  integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
+
 marked-man@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/marked-man/-/marked-man-0.7.0.tgz#220ba01d275d16f1a98e4e7fc3c5eac0630c68e4"


### PR DESCRIPTION
- Hide mention of deleted comments without replies ;
- New delete and re-draft action on a comment **only on comments without replies** ;
- Move delete, delete and re-draft actions on options menu ;
- Add icons on delete, delete and re-draft and report actions in options menu ;
- Rename `Reply` value of add comment button to `Comment` **only for comment main thread textarea** ;
- Add Markdown help icon :
- Add uni-code emojis native display (depending on Operating System) https://apps.timwhitlock.info/emoji/tables/unicode.

![Comments-markdown](https://user-images.githubusercontent.com/1877318/89688258-1002c380-d902-11ea-86d1-9689a0f5a110.gif)
