### PR TITLE
Do not display videojs poster when video is starting to avoid blinking effect

### DIFF
--- a/client/src/sass/player/peertube-skin.scss
+++ b/client/src/sass/player/peertube-skin.scss
@@ -124,6 +124,14 @@ body {
     }
   }
 
+  // Do not display poster when video is starting
+  &.vjs-has-autoplay:not(.vjs-has-started) {
+    .vjs-poster {
+      opacity: 0;
+      visibility: hidden;
+    }
+  }
+
   // Hide the big play button on autoplay
   &.vjs-has-autoplay {
     .vjs-big-play-button {


### PR DESCRIPTION
fixes: https://github.com/Chocobozzz/PeerTube/issues/3055