### PR TITLE
On touchscreens add content overlay for opened menu

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -180,8 +180,8 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     eventsObs.pipe(
       filter((e: Event): e is GuardsCheckStart => e instanceof GuardsCheckStart),
-      filter(() => this.screenService.isInSmallView())
-    ).subscribe(() => this.menu.isMenuDisplayed = false) // User clicked on a link in the menu, change the page
+      filter(() => this.screenService.isInSmallView() || !!this.screenService.isInTouchScreen())
+    ).subscribe(() => this.menu.setMenuDisplay(false)) // User clicked on a link in the menu, change the page
   }
 
   private injectBroadcastMessage () {

--- a/client/src/app/core/menu/menu.service.ts
+++ b/client/src/app/core/menu/menu.service.ts
@@ -32,6 +32,7 @@ export class MenuService {
     if (this.screenService.isInTouchScreen()) {
       if (this.isMenuDisplayed) {
         document.body.classList.add('menu-open')
+        this.screenService.onFingerSwipe('left', () => { this.setMenuDisplay(false) })
       } else {
         document.body.classList.remove('menu-open')
       }

--- a/client/src/app/core/menu/menu.service.ts
+++ b/client/src/app/core/menu/menu.service.ts
@@ -13,7 +13,7 @@ export class MenuService {
     private screenService: ScreenService
   ) {
     // Do not display menu on small or touch screens
-    if (this.screenService.isInSmallView() || !!this.screenService.isInTouchScreen()) {
+    if (this.screenService.isInSmallView() || this.screenService.isInTouchScreen()) {
       this.setMenuDisplay(false)
     }
 

--- a/client/src/app/core/menu/menu.service.ts
+++ b/client/src/app/core/menu/menu.service.ts
@@ -17,9 +17,7 @@ export class MenuService {
       this.setMenuDisplay(false)
     }
 
-    fromEvent(window, 'resize')
-      .pipe(debounceTime(200))
-      .subscribe(() => this.onResize())
+    this.handleWindowResize()
   }
 
   toggleMenu () {
@@ -29,9 +27,29 @@ export class MenuService {
 
   setMenuDisplay (display: boolean) {
     this.isMenuDisplayed = display
+
+    // On touch screens, lock body scroll and display content overlay when memu is opened
+    if (this.screenService.isInTouchScreen()) {
+      if (this.isMenuDisplayed) {
+        document.body.classList.add('menu-open')
+      } else {
+        document.body.classList.remove('menu-open')
+      }
+    }
   }
 
   onResize () {
-    this.isMenuDisplayed = window.innerWidth >= 800 && !this.screenService.isInTouchScreen() && !this.isMenuChangedByUser
+    this.isMenuDisplayed = window.innerWidth >= 800 && !this.isMenuChangedByUser
+  }
+
+  private handleWindowResize () {
+    // On touch screens, do not handle window resize event since opened menu is handled with a content overlay
+    if (this.screenService.isInTouchScreen()) {
+      return
+    }
+
+    fromEvent(window, 'resize')
+      .pipe(debounceTime(200))
+      .subscribe(() => this.onResize())
   }
 }

--- a/client/src/app/core/menu/menu.service.ts
+++ b/client/src/app/core/menu/menu.service.ts
@@ -12,9 +12,9 @@ export class MenuService {
   constructor (
     private screenService: ScreenService
   ) {
-    // Do not display menu on small screens
-    if (this.screenService.isInSmallView()) {
-      this.isMenuDisplayed = false
+    // Do not display menu on small or touch screens
+    if (this.screenService.isInSmallView() || !!this.screenService.isInTouchScreen()) {
+      this.setMenuDisplay(false)
     }
 
     fromEvent(window, 'resize')
@@ -23,11 +23,15 @@ export class MenuService {
   }
 
   toggleMenu () {
-    this.isMenuDisplayed = !this.isMenuDisplayed
+    this.setMenuDisplay(!this.isMenuDisplayed)
     this.isMenuChangedByUser = true
   }
 
+  setMenuDisplay (display: boolean) {
+    this.isMenuDisplayed = display
+  }
+
   onResize () {
-    this.isMenuDisplayed = window.innerWidth >= 800 && !this.isMenuChangedByUser
+    this.isMenuDisplayed = window.innerWidth >= 800 && !this.screenService.isInTouchScreen() && !this.isMenuChangedByUser
   }
 }

--- a/client/src/app/core/routing/menu-guard.service.ts
+++ b/client/src/app/core/routing/menu-guard.service.ts
@@ -15,7 +15,7 @@ abstract class MenuGuard implements CanActivate, CanDeactivate<any> {
     // small screens already have the site-wide onResize from screenService
     // > medium screens have enough space to fit the administrative menus
     if (!this.screen.isInMobileView() && this.screen.isInMediumView()) {
-      this.menu.isMenuDisplayed = this.display
+      this.menu.setMenuDisplay(this.display)
     }
     return true
   }

--- a/client/src/app/core/wrappers/screen.service.ts
+++ b/client/src/app/core/wrappers/screen.service.ts
@@ -54,6 +54,64 @@ export class ScreenService {
     return this.windowInnerWidth
   }
 
+  // https://stackoverflow.com/questions/2264072/detect-a-finger-swipe-through-javascript-on-the-iphone-and-android
+  onFingerSwipe (direction: 'left' | 'right' | 'up' | 'down', action: () => void, removeEventOnEnd = true) {
+    let touchDownClientX: number
+    let touchDownClientY: number
+
+    const onTouchStart = (event: TouchEvent) => {
+      const firstTouch = event.touches[0]
+      touchDownClientX = firstTouch.clientX
+      touchDownClientY = firstTouch.clientY
+    }
+
+    const onTouchMove = (event: TouchEvent) => {
+      if (!touchDownClientX || !touchDownClientY) {
+        return
+      }
+
+      const touchUpClientX = event.touches[0].clientX
+      const touchUpClientY = event.touches[0].clientY
+
+      const touchClientX = Math.abs(touchDownClientX - touchUpClientX)
+      const touchClientY = Math.abs(touchDownClientY - touchUpClientY)
+
+      if (touchClientX > touchClientY) {
+        if (touchClientX > 0) {
+          if (direction === 'left') {
+            if (removeEventOnEnd) this.removeFingerSwipeEventListener(onTouchStart, onTouchMove)
+            action()
+          }
+        } else {
+          if (direction === 'right') {
+            if (removeEventOnEnd) this.removeFingerSwipeEventListener(onTouchStart, onTouchMove)
+            action()
+          }
+        }
+      } else {
+        if (touchClientY > 0) {
+          if (direction === 'up') {
+            if (removeEventOnEnd) this.removeFingerSwipeEventListener(onTouchStart, onTouchMove)
+            action()
+          }
+        } else {
+          if (direction === 'down') {
+            if (removeEventOnEnd) this.removeFingerSwipeEventListener(onTouchStart, onTouchMove)
+            action()
+          }
+        }
+      }
+    }
+
+    document.addEventListener('touchstart', onTouchStart, false)
+    document.addEventListener('touchmove', onTouchMove, false)
+  }
+
+  private removeFingerSwipeEventListener (onTouchStart: (event: TouchEvent) => void, onTouchMove: (event: TouchEvent) => void) {
+    document.removeEventListener('touchstart', onTouchStart)
+    document.removeEventListener('touchmove', onTouchMove)
+  }
+
   private refreshWindowInnerWidth () {
     this.lastFunctionCallTime = new Date().getTime()
 

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -152,8 +152,24 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
 
 // On touchscreen devices, simply overflow: hidden to avoid detached overlay on scroll
 @media (hover: none) and (pointer: coarse) {
-  .modal-open {
+  .modal-open, .menu-open {
     overflow: hidden !important;
+  }
+
+  // On touchscreen devices display content overlay when opened menu
+  .menu-open {
+    .main-col {
+      &::before {
+        background-color: black;
+        width: 100vw;
+        height: 100vh;
+        opacity: 0.75;
+        content: '';
+        display: block;
+        position: fixed;
+        z-index: z('header');
+      }
+    }
   }
 }
 

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -167,7 +167,7 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
         content: '';
         display: block;
         position: fixed;
-        z-index: z('header');
+        z-index: z('header') - 1;
       }
     }
   }

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -150,6 +150,13 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
   width: 100vw; // Make sure the content fits all the available width
 }
 
+// On touchscreen devices, simply overflow: hidden to avoid detached overlay on scroll
+@media (hover: none) and (pointer: coarse) {
+  .modal-open {
+    overflow: hidden !important;
+  }
+}
+
 // Nav customizations
 .nav .nav-link {
   display: flex !important;


### PR DESCRIPTION
fixes: https://github.com/Chocobozzz/PeerTube/issues/3087

This PR changes the behaviour of the menu on touchscreens : 
- On all resolution open menu only by user, by default it's closed
- On opened menu, a content overlay is displayed and body scroll locked **to avoid the blinking detached menu effect** when scroll.

Also on modal opened (and only for touchscreens) body scroll is locked.

![overlay-when-menu-opened-touchscreens](https://user-images.githubusercontent.com/1877318/90313982-b0637400-df10-11ea-82aa-55034ff27e36.gif)
