### PR TITLE
removed minimum width css to fit mobile devices with lesser width

### DIFF
--- a/client/src/app/shared/shared-instance/instance-features-table.component.scss
+++ b/client/src/app/shared/shared-instance/instance-features-table.component.scss
@@ -7,9 +7,7 @@ table {
 
   .label,
   .sub-label {
-  
-
-    &.label {
+      &.label {
       font-weight: $font-semibold;
     }
 

--- a/client/src/app/shared/shared-instance/instance-features-table.component.scss
+++ b/client/src/app/shared/shared-instance/instance-features-table.component.scss
@@ -7,7 +7,7 @@ table {
 
   .label,
   .sub-label {
-    min-width: 330px;
+  
 
     &.label {
       font-weight: $font-semibold;


### PR DESCRIPTION
this width caused this page to scroll because the minimum width was set to 330px and phones have less width than that. i have checked the same on peertube2.cpy.re using firefox inspect element responsive design mode.
This is my first pull request, please be gentle ;-)