### PR TITLE
import media tooltip improvement

### DIFF
--- a/client/src/app/+videos/+video-edit/video-add-components/video-import-torrent.component.html
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-import-torrent.component.html
@@ -14,7 +14,7 @@
       <my-help>
         <ng-template ptTemplate="customHtml">
           <ng-container i18n>
-            You can import any torrent file that points to a mp4 file.
+            You can import any torrent file that points to a media file.
             You should make sure you have diffusion rights over the content it points to, otherwise it could cause legal trouble to yourself and your instance.
           </ng-container>
         </ng-template>

--- a/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.html
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.html
@@ -9,7 +9,7 @@
         <ng-template ptTemplate="customHtml">
           <ng-container i18n>
             You can import any URL <a href='https://rg3.github.io/youtube-dl/supportedsites.html' target='_blank' rel='noopener noreferrer'>supported by youtube-dl</a>
-            or URL that points to a raw MP4 file.
+            or URL that points to a media file.
             You should make sure you have diffusion rights over the content it points to, otherwise it could cause legal trouble to yourself and your instance.
           </ng-container>
         </ng-template>


### PR DESCRIPTION
tooltips on import pages showed "import mp4 file" when we can clearly import many more formats. This must have been put when we would have been only able to import mp4 files. Anyways, i have changed mp4 to say "media file" as we can import audios as well