### PR TITLE
Same video multiple times in the same playlist

### DIFF
--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlist-elements.component.scss
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlist-elements.component.scss
@@ -66,11 +66,3 @@
     margin-left: calc(#{var(--expanded-horizontal-margin-content)} * -1);
   }
 }
-
-@media not all and (hover: hover) and (pointer: fine) {
-  .video {
-    .more {
-      opacity: 1;
-    }
-  }
-}

--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlist-elements.component.scss
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlist-elements.component.scss
@@ -65,4 +65,19 @@
     padding-top: 20px;
     margin-left: calc(#{var(--expanded-horizontal-margin-content)} * -1);
   }
+
+  .playlist-elements {
+    padding: 0 !important;
+  }
+
+  ::ng-deep my-video-playlist-element-miniature {
+
+    .video {
+      padding: 5px !important;
+    }
+
+    .position {
+      margin-right: 5px !important;
+    }
+  }
 }

--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.html
@@ -1,4 +1,7 @@
-<div *ngIf="playlist && video" class="playlist" myInfiniteScroller [autoInit]="true" [onItself]="true" (nearOfBottom)="onPlaylistVideosNearOfBottom()">
+<div
+  *ngIf="playlist && currentPlaylistPosition" class="playlist"
+  myInfiniteScroller [autoInit]="true" [onItself]="true" (nearOfBottom)="onPlaylistVideosNearOfBottom()"
+>
   <div class="playlist-info">
     <div class="playlist-display-name">
       {{ playlist.displayName }}
@@ -36,7 +39,7 @@
     </div>
   </div>
 
-  <div *ngFor="let playlistElement of playlistElements">
+  <div *ngFor="let playlistElement of playlistElements" [ngClass]="'element-' + playlistElement.position">
     <my-video-playlist-element-miniature
       [playlistElement]="playlistElement" [playlist]="playlist" [owned]="isPlaylistOwned()" (elementRemoved)="onElementRemoved($event)"
       [playing]="currentPlaylistPosition === playlistElement.position" [accountLink]="false" [position]="playlistElement.position"

--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input } from '@angular/core'
+
+import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { Router } from '@angular/router'
 import { AuthService, ComponentPagination, LocalStorageService, Notifier, SessionStorageService, UserService } from '@app/core'
 import { VideoPlaylist, VideoPlaylistElement, VideoPlaylistService } from '@app/shared/shared-video-playlist'
 import { peertubeLocalStorage, peertubeSessionStorage } from '@root-helpers/peertube-web-storage'
-import { VideoDetails, VideoPlaylistPrivacy } from '@shared/models'
+import { VideoPlaylistPrivacy } from '@shared/models'
 
 @Component({
   selector: 'my-video-watch-playlist',
@@ -14,8 +15,9 @@ export class VideoWatchPlaylistComponent {
   static LOCAL_STORAGE_AUTO_PLAY_NEXT_VIDEO_PLAYLIST = 'auto_play_video_playlist'
   static SESSION_STORAGE_AUTO_PLAY_NEXT_VIDEO_PLAYLIST = 'loop_playlist'
 
-  @Input() video: VideoDetails
   @Input() playlist: VideoPlaylist
+
+  @Output() videoFound = new EventEmitter<string>()
 
   playlistElements: VideoPlaylistElement[] = []
   playlistPagination: ComponentPagination = {
@@ -29,7 +31,8 @@ export class VideoWatchPlaylistComponent {
   loopPlaylist: boolean
   loopPlaylistSwitchText = ''
   noPlaylistVideos = false
-  currentPlaylistPosition = 1
+
+  currentPlaylistPosition: number
 
   constructor (
     private userService: UserService,
@@ -44,6 +47,7 @@ export class VideoWatchPlaylistComponent {
     this.autoPlayNextVideoPlaylist = this.auth.isLoggedIn()
       ? this.auth.getUser().autoPlayNextVideoPlaylist
       : this.localStorageService.getItem(VideoWatchPlaylistComponent.LOCAL_STORAGE_AUTO_PLAY_NEXT_VIDEO_PLAYLIST) !== 'false'
+
     this.setAutoPlayNextVideoPlaylistSwitchText()
 
     // defaults to false
@@ -51,12 +55,12 @@ export class VideoWatchPlaylistComponent {
     this.setLoopPlaylistSwitchText()
   }
 
-  onPlaylistVideosNearOfBottom () {
+  onPlaylistVideosNearOfBottom (position?: number) {
     // Last page
     if (this.playlistPagination.totalItems <= (this.playlistPagination.currentPage * this.playlistPagination.itemsPerPage)) return
 
     this.playlistPagination.currentPage += 1
-    this.loadPlaylistElements(this.playlist,false)
+    this.loadPlaylistElements(this.playlist, false, position)
   }
 
   onElementRemoved (playlistElement: VideoPlaylistElement) {
@@ -83,26 +87,26 @@ export class VideoWatchPlaylistComponent {
     return this.playlist.privacy.id === VideoPlaylistPrivacy.PUBLIC
   }
 
-  loadPlaylistElements (playlist: VideoPlaylist, redirectToFirst = false) {
+  loadPlaylistElements (playlist: VideoPlaylist, redirectToFirst = false, position?: number) {
     this.videoPlaylist.getPlaylistVideos(playlist.uuid, this.playlistPagination)
         .subscribe(({ total, data }) => {
           this.playlistElements = this.playlistElements.concat(data)
           this.playlistPagination.totalItems = total
 
-          const firstAvailableVideos = this.playlistElements.find(e => !!e.video)
-          if (!firstAvailableVideos) {
+          const firstAvailableVideo = this.playlistElements.find(e => !!e.video)
+          if (!firstAvailableVideo) {
             this.noPlaylistVideos = true
             return
           }
 
-          this.updatePlaylistIndex(this.video)
+          if (position) this.updatePlaylistIndex(position)
 
           if (redirectToFirst) {
             const extras = {
               queryParams: {
-                start: firstAvailableVideos.startTimestamp,
-                stop: firstAvailableVideos.stopTimestamp,
-                videoId: firstAvailableVideos.video.uuid
+                start: firstAvailableVideo.startTimestamp,
+                stop: firstAvailableVideo.stopTimestamp,
+                playlistPosition: firstAvailableVideo.position
               },
               replaceUrl: true
             }
@@ -111,18 +115,26 @@ export class VideoWatchPlaylistComponent {
         })
   }
 
-  updatePlaylistIndex (video: VideoDetails) {
-    if (this.playlistElements.length === 0 || !video) return
+  updatePlaylistIndex (position: number) {
+    if (this.playlistElements.length === 0 || !position) return
 
     for (const playlistElement of this.playlistElements) {
-      if (playlistElement.video && playlistElement.video.id === video.id) {
+      // >= if the previous videos were not valid
+      if (playlistElement.video && playlistElement.position >= position) {
         this.currentPlaylistPosition = playlistElement.position
+
+        this.videoFound.emit(playlistElement.video.uuid)
+
+        setTimeout(() => {
+          document.querySelector('.element-' + this.currentPlaylistPosition).scrollIntoView(false)
+        }, 0)
+
         return
       }
     }
 
     // Load more videos to find our video
-    this.onPlaylistVideosNearOfBottom()
+    this.onPlaylistVideosNearOfBottom(position)
   }
 
   findNextPlaylistVideo (position = this.currentPlaylistPosition): VideoPlaylistElement {
@@ -147,9 +159,10 @@ export class VideoWatchPlaylistComponent {
   navigateToNextPlaylistVideo () {
     const next = this.findNextPlaylistVideo(this.currentPlaylistPosition + 1)
     if (!next) return
+
     const start = next.startTimestamp
     const stop = next.stopTimestamp
-    this.router.navigate([],{ queryParams: { videoId: next.video.uuid, start, stop } })
+    this.router.navigate([],{ queryParams: { playlistPosition: next.position, start, stop } })
   }
 
   switchAutoPlayNextVideoPlaylist () {

--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -11,7 +11,8 @@
 
     <my-video-watch-playlist
       #videoWatchPlaylist
-      [video]="video" [playlist]="playlist" class="playlist"
+      [playlist]="playlist" class="playlist"
+      (videoFound)="onPlaylistVideoFound($event)"
     ></my-video-watch-playlist>
   </div>
 

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -362,6 +362,8 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
         const queryParams = this.route.snapshot.queryParams
 
         const urlOptions = {
+          resume: queryParams.resume,
+
           startTime: queryParams.start,
           stopTime: queryParams.stop,
 
@@ -657,16 +659,14 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       const byUrl = urlOptions.startTime !== undefined
       const byHistory = video.userHistory && (!this.playlist || urlOptions.resume !== undefined)
 
-      if (byUrl) {
-        return timeToInt(urlOptions.startTime)
-      } else if (byHistory) {
-        return video.userHistory.currentTime
-      } else {
-        return 0
-      }
+      if (byUrl) return timeToInt(urlOptions.startTime)
+      if (byHistory) return video.userHistory.currentTime
+
+      return 0
     }
 
     let startTime = getStartTime()
+
     // If we are at the end of the video, reset the timer
     if (video.duration - startTime <= 1) startTime = 0
 

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -53,6 +53,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
   video: VideoDetails = null
   videoCaptions: VideoCaption[] = []
 
+  playlistPosition: number
   playlist: VideoPlaylist = null
 
   completeDescriptionShown = false
@@ -140,9 +141,9 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       if (playlistId) this.loadPlaylist(playlistId)
     })
 
-    this.queryParamsSub = this.route.queryParams.subscribe(async queryParams => {
-      const videoId = queryParams[ 'videoId' ]
-      if (videoId) this.loadVideo(videoId)
+    this.queryParamsSub = this.route.queryParams.subscribe(queryParams => {
+      this.playlistPosition = queryParams[ 'playlistPosition' ]
+      this.videoWatchPlaylist.updatePlaylistIndex(this.playlistPosition)
 
       const start = queryParams[ 'start' ]
       if (this.player && start) this.player.currentTime(parseInt(start, 10))
@@ -335,6 +336,10 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     return genericChannelDisplayName.includes(this.video.channel.displayName)
   }
 
+  onPlaylistVideoFound (videoId: string) {
+    this.loadVideo(videoId)
+  }
+
   private loadVideo (videoId: string) {
     // Video did not change
     if (this.video && this.video.uuid === videoId) return
@@ -392,8 +397,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       .subscribe(playlist => {
         this.playlist = playlist
 
-        const videoId = this.route.snapshot.queryParams['videoId']
-        this.videoWatchPlaylist.loadPlaylistElements(playlist, !videoId)
+        this.videoWatchPlaylist.loadPlaylistElements(playlist, !this.playlistPosition, this.playlistPosition)
       })
   }
 
@@ -457,8 +461,6 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     this.completeDescriptionShown = false
     this.remoteServerDown = false
     this.currentTime = undefined
-
-    this.videoWatchPlaylist.updatePlaylistIndex(video)
 
     if (this.isVideoBlur(this.video)) {
       const res = await this.confirmService.confirm(

--- a/client/src/app/shared/shared-forms/timestamp-input.component.ts
+++ b/client/src/app/shared/shared-forms/timestamp-input.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, forwardRef, Input, OnInit } from '@angular/core'
+import { ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core'
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
 import { secondsToTime, timeToInt } from '../../../assets/player/utils'
 
@@ -18,6 +18,8 @@ export class TimestampInputComponent implements ControlValueAccessor, OnInit {
   @Input() maxTimestamp: number
   @Input() timestamp: number
   @Input() disabled = false
+
+  @Output() inputBlur = new EventEmitter()
 
   timestampString: string
 
@@ -57,5 +59,7 @@ export class TimestampInputComponent implements ControlValueAccessor, OnInit {
 
       this.propagateChange(this.timestamp)
     }
+
+    this.inputBlur.emit()
   }
 }

--- a/client/src/app/shared/shared-main/angular/infinite-scroller.directive.ts
+++ b/client/src/app/shared/shared-main/angular/infinite-scroller.directive.ts
@@ -1,6 +1,6 @@
+import { fromEvent, Observable, Subscription } from 'rxjs'
 import { distinctUntilChanged, filter, map, share, startWith, throttleTime } from 'rxjs/operators'
 import { AfterContentChecked, Directive, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core'
-import { fromEvent, Observable, Subscription } from 'rxjs'
 
 @Directive({
   selector: '[myInfiniteScroller]'
@@ -80,7 +80,9 @@ export class InfiniteScrollerDirective implements OnInit, OnDestroy, AfterConten
   }
 
   private getMaximumScroll () {
-    return this.container.scrollHeight - window.innerHeight
+    const elementHeight = this.onItself ? this.container.clientHeight : window.innerHeight
+
+    return this.container.scrollHeight - elementHeight
   }
 
   private hasScroll () {

--- a/client/src/app/shared/shared-share-modal/video-share.component.ts
+++ b/client/src/app/shared/shared-share-modal/video-share.component.ts
@@ -37,6 +37,7 @@ export class VideoShareComponent {
   @Input() video: VideoDetails = null
   @Input() videoCaptions: VideoCaption[] = []
   @Input() playlist: VideoPlaylist = null
+  @Input() playlistPosition: number = null
 
   activeVideoId: TabId = 'url'
   activePlaylistId: TabId = 'url'
@@ -44,8 +45,6 @@ export class VideoShareComponent {
   customizations: Customizations
   isAdvancedCustomizationCollapsed = true
   includeVideoInPlaylist = false
-
-  private playlistPosition: number = null
 
   constructor (private modalService: NgbModal) { }
 
@@ -107,7 +106,7 @@ export class VideoShareComponent {
 
     if (!this.includeVideoInPlaylist) return base
 
-    return base + '?videoId=' + this.video.uuid
+    return base + '?playlistPosition=' + this.playlistPosition
   }
 
   notSecure () {

--- a/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.html
+++ b/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.html
@@ -2,42 +2,6 @@
   <div class="header">
     <div class="first-row">
       <div i18n class="title">Save to</div>
-
-      <div class="options" (click)="displayOptions = !displayOptions">
-        <my-global-icon iconName="cog" aria-hidden="true"></my-global-icon>
-
-        <span i18n>Options</span>
-      </div>
-    </div>
-
-    <div class="options-row" *ngIf="displayOptions">
-      <div>
-        <my-peertube-checkbox
-          inputName="startAt" [(ngModel)]="timestampOptions.startTimestampEnabled"
-          i18n-labelText labelText="Start at"
-        ></my-peertube-checkbox>
-
-        <my-timestamp-input
-          [timestamp]="timestampOptions.startTimestamp"
-          [maxTimestamp]="video.duration"
-          [disabled]="!timestampOptions.startTimestampEnabled"
-          [(ngModel)]="timestampOptions.startTimestamp"
-        ></my-timestamp-input>
-      </div>
-
-      <div>
-        <my-peertube-checkbox
-          inputName="stopAt" [(ngModel)]="timestampOptions.stopTimestampEnabled"
-          i18n-labelText labelText="Stop at"
-        ></my-peertube-checkbox>
-
-        <my-timestamp-input
-          [timestamp]="timestampOptions.stopTimestamp"
-          [maxTimestamp]="video.duration"
-          [disabled]="!timestampOptions.stopTimestampEnabled"
-          [(ngModel)]="timestampOptions.stopTimestamp"
-        ></my-timestamp-input>
-      </div>
     </div>
   </div>
 
@@ -46,14 +10,52 @@
   </div>
 
   <div class="playlists">
-    <div class="playlist dropdown-item" *ngFor="let playlist of videoPlaylists" (click)="togglePlaylist($event, playlist)">
-      <my-peertube-checkbox [inputName]="'in-playlist-' + playlist.id" [(ngModel)]="playlist.inPlaylist" [onPushWorkaround]="true"></my-peertube-checkbox>
+    <div
+      *ngFor="let playlist of videoPlaylists"
+      class="playlist dropdown-item" [ngClass]="{ 'has-optional-row': playlist.optionalRowDisplayed }"
+    >
+      <div class="primary-row">
+        <my-peertube-checkbox
+          [disabled]="isPresentMultipleTimes(playlist) || playlist.optionalRowDisplayed" [inputName]="getPrimaryInputName(playlist)"
+          [ngModel]="isPrimaryCheckboxChecked(playlist)" [onPushWorkaround]="true"
+          (click)="toggleMainPlaylist($event, playlist)"
+        ></my-peertube-checkbox>
 
-      <div class="display-name">
-        {{ playlist.displayName }}
+        <label class="display-name" (click)="toggleMainPlaylist($event, playlist)">
+          {{ playlist.displayName }}
+        </label>
 
-        <div *ngIf="playlist.inPlaylist && (playlist.startTimestamp || playlist.stopTimestamp)" class="timestamp-info">
-          {{ formatTimestamp(playlist) }}
+        <div class="optional-row-icon" *ngIf="isPrimaryCheckboxChecked(playlist)" (click)="toggleOptionalRow(playlist)">
+          <my-global-icon iconName="add" aria-hidden="true"></my-global-icon>
+        </div>
+      </div>
+
+      <div class="optional-rows" *ngIf="playlist.optionalRowDisplayed">
+        <div class="labels">
+          <div i18n>Start at</div>
+          <div i18n>Stop at</div>
+        </div>
+
+        <div *ngFor="let element of buildOptionalRowElements(playlist)">
+          <my-peertube-checkbox
+            [inputName]="getOptionalInputName(playlist, element)"
+            [ngModel]="element.enabled" [onPushWorkaround]="true"
+            (click)="toggleOptionalPlaylist($event, playlist, element, startAt.timestamp, stopAt.timestamp)"
+          ></my-peertube-checkbox>
+
+          <my-timestamp-input
+            [maxTimestamp]="video.duration"
+            [(ngModel)]="element.startTimestamp"
+            (inputBlur)="onElementTimestampUpdate(playlist, element)"
+            #startAt
+          ></my-timestamp-input>
+
+          <my-timestamp-input
+            [maxTimestamp]="video.duration"
+            [(ngModel)]="element.stopTimestamp"
+            (inputBlur)="onElementTimestampUpdate(playlist, element)"
+            #stopAt
+          ></my-timestamp-input>
         </div>
       </div>
     </div>

--- a/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.scss
+++ b/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.scss
@@ -1,6 +1,10 @@
 @import '_variables';
 @import '_mixins';
 
+$optional-rows-checkbox-width: 34px;
+$timestamp-width: 50px;
+$timestamp-margin-right: 10px;
+
 .header,
 .dropdown-item,
 .input-container {
@@ -24,31 +28,6 @@
       font-size: 18px;
       flex-grow: 1;
     }
-
-    .options {
-      display: flex;
-      align-items: center;
-      font-size: 14px;
-      cursor: pointer;
-
-      my-global-icon {
-        @include apply-svg-color(#333);
-
-        width: 16px;
-        height: 23px;
-        margin-right: 3px;
-      }
-    }
-  }
-
-  .options-row {
-    margin-top: 10px;
-    padding-left: 10px;
-
-    > div {
-      display: flex;
-      align-items: center;
-    }
   }
 }
 
@@ -58,8 +37,16 @@
 }
 
 .playlist {
-  display: inline-flex;
-  cursor: pointer;
+  padding: 8px 10px 8px 24px;
+
+  &.has-optional-row:hover {
+    background-color: inherit;
+  }
+}
+
+.primary-row,
+.optional-rows > div {
+  display: flex;
 
   my-peertube-checkbox {
     margin-right: 10px;
@@ -69,11 +56,58 @@
   .display-name {
     display: flex;
     align-items: flex-end;
+    flex-grow: 1;
+    margin: 0;
+    font-weight: $font-regular;
+    cursor: pointer;
+  }
 
-    .timestamp-info {
-      font-size: 0.9em;
-      color: pvar(--greyForegroundColor);
-      margin-left: 5px;
+  .optional-row-icon {
+    display: flex;
+    align-items: center;
+    font-size: 14px;
+    cursor: pointer;
+
+    my-global-icon {
+      @include apply-svg-color(#333);
+
+      width: 19px;
+      height: 19px;
+      margin-right: 0;
+    }
+  }
+
+  my-timestamp-input {
+    margin-right: $timestamp-margin-right;
+
+    ::ng-deep .ui-inputtext {
+      padding: 0;
+      width: $timestamp-width;
+    }
+  }
+}
+
+.optional-rows {
+  > div {
+    padding: 8px 5px 5px 10px;
+  }
+
+  my-peertube-checkbox {
+    display: block;
+    width: $optional-rows-checkbox-width;
+    margin-right: 0 !important;
+  }
+
+  .labels {
+    margin-left: $optional-rows-checkbox-width;
+    font-size: 13px;
+    color: pvar(--greyForegroundColor);
+    padding-top: 5px;
+    padding-bottom: 0;
+
+    div {
+      margin-right: $timestamp-margin-right;
+      width: $timestamp-width;
     }
   }
 }

--- a/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.scss
+++ b/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.scss
@@ -7,6 +7,10 @@
   padding: 8px 24px;
 }
 
+.dropdown-item:active {
+  color: inherit;
+}
+
 .header {
   min-width: 240px;
   margin-bottom: 10px;

--- a/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.ts
+++ b/client/src/app/shared/shared-video-playlist/video-add-to-playlist.component.ts
@@ -4,11 +4,17 @@ import { debounceTime, filter } from 'rxjs/operators'
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core'
 import { AuthService, DisableForReuseHook, Notifier } from '@app/core'
 import { FormReactive, FormValidatorService } from '@app/shared/shared-forms'
-import { Video, VideoExistInPlaylist, VideoPlaylistCreate, VideoPlaylistElementCreate, VideoPlaylistPrivacy, VideoPlaylistElementUpdate } from '@shared/models'
+import {
+  Video,
+  VideoExistInPlaylist,
+  VideoPlaylistCreate,
+  VideoPlaylistElementCreate,
+  VideoPlaylistElementUpdate,
+  VideoPlaylistPrivacy
+} from '@shared/models'
 import { secondsToTime } from '../../../assets/player/utils'
 import { VIDEO_PLAYLIST_DISPLAY_NAME_VALIDATOR } from '../form-validators/video-playlist-validators'
 import { CachedPlaylist, VideoPlaylistService } from './video-playlist.service'
-import { invoke, last } from 'lodash'
 
 const logger = debug('peertube:playlists:VideoAddToPlaylistComponent')
 

--- a/client/src/app/shared/shared-video-playlist/video-playlist-element-miniature.component.scss
+++ b/client/src/app/shared/shared-video-playlist/video-playlist-element-miniature.component.scss
@@ -22,11 +22,15 @@ my-video-thumbnail,
 }
 
 .video {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr auto;
   background-color: pvar(--mainBackgroundColor);
   padding: 10px;
   border-bottom: 1px solid $separator-border-color;
+
+  .more {
+    display: flex;
+  }
 
   &:hover {
     background-color: rgba(0, 0, 0, 0.05);
@@ -164,6 +168,7 @@ my-video-thumbnail,
       my-edit-button {
         display: inline-flex;
         height: max-content;
+        margin: auto;
       }
     }
 

--- a/client/src/app/shared/shared-video-playlist/video-playlist-element-miniature.component.ts
+++ b/client/src/app/shared/shared-video-playlist/video-playlist-element-miniature.component.ts
@@ -78,7 +78,7 @@ export class VideoPlaylistElementMiniatureComponent implements OnInit {
     if (!this.playlistElement || !this.playlistElement.video) return {}
 
     return {
-      videoId: this.playlistElement.video.uuid,
+      playlistPosition: this.playlistElement.position,
       start: this.playlistElement.startTimestamp,
       stop: this.playlistElement.stopTimestamp,
       resume: true

--- a/client/src/app/shared/shared-video-playlist/video-playlist.service.ts
+++ b/client/src/app/shared/shared-video-playlist/video-playlist.service.ts
@@ -1,7 +1,7 @@
 import * as debug from 'debug'
 import { uniq } from 'lodash-es'
 import { asyncScheduler, merge, Observable, of, ReplaySubject, Subject } from 'rxjs'
-import { bufferTime, catchError, filter, map, observeOn, share, switchMap, tap } from 'rxjs/operators'
+import { bufferTime, catchError, filter, map, observeOn, share, switchMap, tap, distinctUntilChanged } from 'rxjs/operators'
 import { HttpClient, HttpParams } from '@angular/common/http'
 import { Injectable, NgZone } from '@angular/core'
 import { AuthUser, ComponentPaginationLight, RestExtractor, RestService, ServerService } from '@app/core'
@@ -53,6 +53,7 @@ export class VideoPlaylistService {
   ) {
     this.videoExistsInPlaylistObservable = merge(
       this.videoExistsInPlaylistNotifier.pipe(
+        distinctUntilChanged(),
         // We leave Angular zone so Protractor does not get stuck
         bufferTime(500, leaveZone(this.ngZone, asyncScheduler)),
         filter(videoIds => videoIds.length !== 0),

--- a/client/src/app/shared/shared-video-playlist/video-playlist.service.ts
+++ b/client/src/app/shared/shared-video-playlist/video-playlist.service.ts
@@ -233,7 +233,11 @@ export class VideoPlaylistService {
                  tap(() => {
                    if (!videoId) return
 
-                   this.videoExistsCache[videoId] = this.videoExistsCache[videoId].filter(e => e.playlistElementId !== playlistElementId)
+                   if (this.videoExistsCache[videoId]) {
+                     this.videoExistsCache[videoId] = this.videoExistsCache[videoId]
+                       .filter(e => e.playlistElementId !== playlistElementId)
+                   }
+
                    this.runPlaylistCheck(videoId)
                  }),
                  catchError(err => this.restExtractor.handleError(err))

--- a/client/src/app/shared/shared-video-playlist/video-playlist.service.ts
+++ b/client/src/app/shared/shared-video-playlist/video-playlist.service.ts
@@ -215,10 +215,13 @@ export class VideoPlaylistService {
                  map(this.restExtractor.extractDataBool),
                  tap(() => {
                    const existsResult = this.videoExistsCache[videoId]
-                   const elem = existsResult.find(e => e.playlistElementId === playlistElementId)
 
-                   elem.startTimestamp = body.startTimestamp
-                   elem.stopTimestamp = body.stopTimestamp
+                   if (existsResult) {
+                     const elem = existsResult.find(e => e.playlistElementId === playlistElementId)
+
+                     elem.startTimestamp = body.startTimestamp
+                     elem.stopTimestamp = body.stopTimestamp
+                   }
 
                    this.runPlaylistCheck(videoId)
                  }),

--- a/server/controllers/activitypub/client.ts
+++ b/server/controllers/activitypub/client.ts
@@ -159,7 +159,7 @@ activityPubClientRouter.get('/video-playlists/:playlistId',
   asyncMiddleware(videoPlaylistsGetValidator('all')),
   asyncMiddleware(videoPlaylistController)
 )
-activityPubClientRouter.get('/video-playlists/:playlistId/:videoId',
+activityPubClientRouter.get('/video-playlists/:playlistId/videos/:playlistElementId',
   executeIfActivityPub,
   asyncMiddleware(videoPlaylistElementAPGetValidator),
   videoPlaylistElementController

--- a/server/controllers/api/video-playlist.ts
+++ b/server/controllers/api/video-playlist.ts
@@ -297,13 +297,15 @@ async function addVideoInPlaylist (req: express.Request, res: express.Response) 
     const position = await VideoPlaylistElementModel.getNextPositionOf(videoPlaylist.id, t)
 
     const playlistElement = await VideoPlaylistElementModel.create({
-      url: getVideoPlaylistElementActivityPubUrl(videoPlaylist, video),
       position,
       startTimestamp: body.startTimestamp || null,
       stopTimestamp: body.stopTimestamp || null,
       videoPlaylistId: videoPlaylist.id,
       videoId: video.id
     }, { transaction: t })
+
+    playlistElement.url = getVideoPlaylistElementActivityPubUrl(videoPlaylist, playlistElement)
+    await playlistElement.save({ transaction: t })
 
     videoPlaylist.changed('updatedAt', true)
     await videoPlaylist.save({ transaction: t })

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -23,7 +23,7 @@ import { CONFIG, registerConfigChangedHandler } from './config'
 
 // ---------------------------------------------------------------------------
 
-const LAST_MIGRATION_VERSION = 525
+const LAST_MIGRATION_VERSION = 530
 
 // ---------------------------------------------------------------------------
 

--- a/server/initializers/migrations/0530-playlist-multiple-video.ts
+++ b/server/initializers/migrations/0530-playlist-multiple-video.ts
@@ -1,0 +1,46 @@
+import * as Sequelize from 'sequelize'
+import { WEBSERVER } from '../constants'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction
+  queryInterface: Sequelize.QueryInterface
+  sequelize: Sequelize.Sequelize
+}): Promise<void> {
+  {
+    const field = {
+      type: Sequelize.STRING,
+      allowNull: true
+    }
+    await utils.queryInterface.changeColumn('videoPlaylistElement', 'url', field)
+  }
+
+  {
+    await utils.sequelize.query('DROP INDEX IF EXISTS video_playlist_element_video_playlist_id_video_id;')
+  }
+
+  {
+    const selectPlaylistUUID = 'SELECT "uuid" FROM "videoPlaylist" WHERE "id" = "videoPlaylistElement"."videoPlaylistId"'
+    const url = `'${WEBSERVER.URL}' || '/video-playlists/' || (${selectPlaylistUUID}) || '/videos/' || "videoPlaylistElement"."id"`
+
+    const query = `
+      UPDATE "videoPlaylistElement" SET "url" = ${url} WHERE id IN (
+        SELECT "videoPlaylistElement"."id" FROM "videoPlaylistElement"
+        INNER JOIN "videoPlaylist" ON "videoPlaylist".id = "videoPlaylistElement"."videoPlaylistId"
+        INNER JOIN account ON account.id = "videoPlaylist"."ownerAccountId"
+        INNER JOIN actor ON actor.id = account."actorId"
+        WHERE actor."serverId" IS NULL
+      )`
+
+    await utils.sequelize.query(query)
+  }
+
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export {
+  up,
+  down
+}

--- a/server/lib/activitypub/url.ts
+++ b/server/lib/activitypub/url.ts
@@ -8,7 +8,8 @@ import {
   MVideoId,
   MVideoUrl,
   MVideoUUID,
-  MAbuseId
+  MAbuseId,
+  MVideoPlaylistElement
 } from '../../types/models'
 import { MVideoPlaylist, MVideoPlaylistUUID } from '../../types/models/video/video-playlist'
 import { MVideoFileVideoUUID } from '../../types/models/video/video-file'
@@ -22,8 +23,8 @@ function getVideoPlaylistActivityPubUrl (videoPlaylist: MVideoPlaylist) {
   return WEBSERVER.URL + '/video-playlists/' + videoPlaylist.uuid
 }
 
-function getVideoPlaylistElementActivityPubUrl (videoPlaylist: MVideoPlaylistUUID, video: MVideoUUID) {
-  return WEBSERVER.URL + '/video-playlists/' + videoPlaylist.uuid + '/' + video.uuid
+function getVideoPlaylistElementActivityPubUrl (videoPlaylist: MVideoPlaylistUUID, videoPlaylistElement: MVideoPlaylistElement) {
+  return WEBSERVER.URL + '/video-playlists/' + videoPlaylist.uuid + '/videos/' + videoPlaylistElement.id
 }
 
 function getVideoCacheFileActivityPubUrl (videoFile: MVideoFileVideoUUID) {

--- a/server/middlewares/validators/videos/video-playlists.ts
+++ b/server/middlewares/validators/videos/video-playlists.ts
@@ -199,16 +199,6 @@ const videoPlaylistsAddVideoValidator = [
     if (!await doesVideoExist(req.body.videoId, res, 'only-video')) return
 
     const videoPlaylist = getPlaylist(res)
-    const video = res.locals.onlyVideo
-
-    const videoPlaylistElement = await VideoPlaylistElementModel.loadByPlaylistAndVideo(videoPlaylist.id, video.id)
-    if (videoPlaylistElement) {
-      res.status(409)
-         .json({ error: 'This video in this playlist already exists' })
-         .end()
-
-      return
-    }
 
     if (!checkUserCanManageVideoPlaylist(res.locals.oauth.token.User, videoPlaylist, UserRight.UPDATE_ANY_VIDEO_PLAYLIST, res)) {
       return
@@ -258,15 +248,18 @@ const videoPlaylistsUpdateOrRemoveVideoValidator = [
 const videoPlaylistElementAPGetValidator = [
   param('playlistId')
     .custom(isIdOrUUIDValid).withMessage('Should have a valid playlist id/uuid'),
-  param('videoId')
-    .custom(isIdOrUUIDValid).withMessage('Should have an video id/uuid'),
+  param('playlistElementId')
+    .custom(isIdValid).withMessage('Should have an playlist element id'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoPlaylistElementAPGetValidator parameters', { parameters: req.params })
 
     if (areValidationErrors(req, res)) return
 
-    const videoPlaylistElement = await VideoPlaylistElementModel.loadByPlaylistAndVideoForAP(req.params.playlistId, req.params.videoId)
+    const playlistElementId = parseInt(req.params.playlistElementId + '', 10)
+    const playlistId = req.params.playlistId
+
+    const videoPlaylistElement = await VideoPlaylistElementModel.loadByPlaylistAndElementIdForAP(playlistId, playlistElementId)
     if (!videoPlaylistElement) {
       res.status(404)
          .json({ error: 'Video playlist element not found' })

--- a/server/models/video/video-playlist-element.ts
+++ b/server/models/video/video-playlist-element.ts
@@ -44,10 +44,6 @@ import { MUserAccountId } from '@server/types/models'
       fields: [ 'videoId' ]
     },
     {
-      fields: [ 'videoPlaylistId', 'videoId' ],
-      unique: true
-    },
-    {
       fields: [ 'url' ],
       unique: true
     }
@@ -60,8 +56,8 @@ export class VideoPlaylistElementModel extends Model<VideoPlaylistElementModel> 
   @UpdatedAt
   updatedAt: Date
 
-  @AllowNull(false)
-  @Is('VideoPlaylistUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'url'))
+  @AllowNull(true)
+  @Is('VideoPlaylistUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'url', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_PLAYLISTS.URL.max))
   url: string
 
@@ -185,12 +181,11 @@ export class VideoPlaylistElementModel extends Model<VideoPlaylistElementModel> 
     return VideoPlaylistElementModel.findByPk(playlistElementId)
   }
 
-  static loadByPlaylistAndVideoForAP (
+  static loadByPlaylistAndElementIdForAP (
     playlistId: number | string,
-    videoId: number | string
+    playlistElementId: number
   ): Bluebird<MVideoPlaylistElementVideoUrlPlaylistPrivacy> {
     const playlistWhere = validator.isUUID('' + playlistId) ? { uuid: playlistId } : { id: playlistId }
-    const videoWhere = validator.isUUID('' + videoId) ? { uuid: videoId } : { id: videoId }
 
     const query = {
       include: [
@@ -201,10 +196,12 @@ export class VideoPlaylistElementModel extends Model<VideoPlaylistElementModel> 
         },
         {
           attributes: [ 'url' ],
-          model: VideoModel.unscoped(),
-          where: videoWhere
+          model: VideoModel.unscoped()
         }
-      ]
+      ],
+      where: {
+        id: playlistElementId
+      }
     }
 
     return VideoPlaylistElementModel.findOne(query)

--- a/server/tests/api/check-params/video-playlists.ts
+++ b/server/tests/api/check-params/video-playlists.ts
@@ -346,11 +346,6 @@ describe('Test video playlists API validator', function () {
       const res = await addVideoInPlaylist(params)
       playlistElementId = res.body.videoPlaylistElement.id
     })
-
-    it('Should fail if the video was already added in the playlist', async function () {
-      const params = getBase({}, { expectedStatus: 409 })
-      await addVideoInPlaylist(params)
-    })
   })
 
   describe('When updating an element in a playlist', function () {

--- a/server/tests/api/videos/video-playlists.ts
+++ b/server/tests/api/videos/video-playlists.ts
@@ -552,6 +552,9 @@ describe('Test video playlists', function () {
       {
         const res = await addVideo({ videoId: nsfwVideoServer1, startTimestamp: 5 })
         playlistElementNSFW = res.body.videoPlaylistElement.id
+
+        await addVideo({ videoId: nsfwVideoServer1, startTimestamp: 4 })
+        await addVideo({ videoId: nsfwVideoServer1 })
       }
 
       await waitJobs(servers)
@@ -563,10 +566,10 @@ describe('Test video playlists', function () {
       for (const server of servers) {
         const res = await getPlaylistVideos(server.url, server.accessToken, playlistServer1UUID, 0, 10)
 
-        expect(res.body.total).to.equal(6)
+        expect(res.body.total).to.equal(8)
 
         const videoElements: VideoPlaylistElement[] = res.body.data
-        expect(videoElements).to.have.lengthOf(6)
+        expect(videoElements).to.have.lengthOf(8)
 
         expect(videoElements[0].video.name).to.equal('video 0 server 1')
         expect(videoElements[0].position).to.equal(1)
@@ -597,6 +600,16 @@ describe('Test video playlists', function () {
         expect(videoElements[5].position).to.equal(6)
         expect(videoElements[5].startTimestamp).to.equal(5)
         expect(videoElements[5].stopTimestamp).to.be.null
+
+        expect(videoElements[6].video.name).to.equal('NSFW video')
+        expect(videoElements[6].position).to.equal(7)
+        expect(videoElements[6].startTimestamp).to.equal(4)
+        expect(videoElements[6].stopTimestamp).to.be.null
+
+        expect(videoElements[7].video.name).to.equal('NSFW video')
+        expect(videoElements[7].position).to.equal(8)
+        expect(videoElements[7].startTimestamp).to.be.null
+        expect(videoElements[7].stopTimestamp).to.be.null
 
         const res3 = await getPlaylistVideos(server.url, server.accessToken, playlistServer1UUID, 0, 2)
         expect(res3.body.data).to.have.lengthOf(2)
@@ -807,6 +820,8 @@ describe('Test video playlists', function () {
             'video 1 server 3',
             'video 3 server 1',
             'video 4 server 1',
+            'NSFW video',
+            'NSFW video',
             'NSFW video'
           ])
         }
@@ -836,6 +851,8 @@ describe('Test video playlists', function () {
             'video 2 server 3',
             'video 1 server 3',
             'video 4 server 1',
+            'NSFW video',
+            'NSFW video',
             'NSFW video'
           ])
         }
@@ -865,7 +882,9 @@ describe('Test video playlists', function () {
             'video 2 server 3',
             'NSFW video',
             'video 1 server 3',
-            'video 4 server 1'
+            'video 4 server 1',
+            'NSFW video',
+            'NSFW video'
           ])
 
           for (let i = 1; i <= elements.length; i++) {
@@ -1023,10 +1042,10 @@ describe('Test video playlists', function () {
       for (const server of servers) {
         const res = await getPlaylistVideos(server.url, server.accessToken, playlistServer1UUID, 0, 10)
 
-        expect(res.body.total).to.equal(4)
+        expect(res.body.total).to.equal(6)
 
         const elements: VideoPlaylistElement[] = res.body.data
-        expect(elements).to.have.lengthOf(4)
+        expect(elements).to.have.lengthOf(6)
 
         expect(elements[0].video.name).to.equal('video 0 server 1')
         expect(elements[0].position).to.equal(1)
@@ -1039,6 +1058,12 @@ describe('Test video playlists', function () {
 
         expect(elements[3].video.name).to.equal('video 4 server 1')
         expect(elements[3].position).to.equal(4)
+
+        expect(elements[4].video.name).to.equal('NSFW video')
+        expect(elements[4].position).to.equal(5)
+
+        expect(elements[5].video.name).to.equal('NSFW video')
+        expect(elements[5].position).to.equal(6)
       }
     })
 


### PR DESCRIPTION
See https://github.com/Chocobozzz/PeerTube/issues/3084

Remove constraints so a playlist can have multiple instances of a video.

Updated the video add to playlist dropdown:
  * When a video is added in a playlist, we display an `+` icon
  * On click, it opens the *advanced settings* pane where the user can update the timestamps of the video
  * The user can also add more instances of the video in the playlist
  * When the user opens the dropdown, the *advanced settings* pane is automatically opened if the playlist contains several instances of the video **or** if the video was added to the playlist with custom timestamps

![screen_2020-08-18-15:51:38](https://user-images.githubusercontent.com/5180488/90522073-9376ad00-e16b-11ea-980c-447aceb8f6d3.png)

![screen_2020-08-18-15:51:27](https://user-images.githubusercontent.com/5180488/90522079-940f4380-e16b-11ea-898f-5e8cc6a52fa0.png)
