### PR TITLE
privacy label improved to make more sense

### DIFF
--- a/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlist-edit.component.html
+++ b/client/src/app/+my-account/my-account-video-playlists/my-account-video-playlist-edit.component.html
@@ -54,7 +54,7 @@
 
       <div class="col-md-12 col-xl-6">
         <div class="form-group">
-          <label i18n for="privacy">Privacy</label>
+          <label i18n for="privacy">Privacy: Who can Watch?</label>
           <div class="peertube-select-container">
             <select id="privacy" formControlName="privacy" class="form-control">
               <option *ngFor="let privacy of videoPlaylistPrivacies" [value]="privacy.id">{{ privacy.label }}</option>

--- a/client/src/app/+videos/+video-edit/shared/video-edit.component.html
+++ b/client/src/app/+videos/+video-edit/shared/video-edit.component.html
@@ -94,7 +94,7 @@
             </div>
 
             <div class="form-group">
-              <label i18n for="privacy">Privacy</label>
+              <label i18n for="privacy">Privacy: Who can Watch?</label>
               <my-select-options
                 labelForId="privacy" [items]="videoPrivacies" formControlName="privacy" [clearable]="false"
               ></my-select-options>

--- a/client/src/app/+videos/+video-edit/video-add-components/video-import-torrent.component.html
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-import-torrent.component.html
@@ -31,7 +31,7 @@
     </div>
 
     <div class="form-group">
-      <label i18n for="first-step-privacy">Privacy</label>
+      <label i18n for="first-step-privacy">Privacy: Who can Watch?</label>
       <my-select-options
         labelForId="first-step-privacy" [items]="videoPrivacies" [(ngModel)]="firstStepPrivacyId"
       ></my-select-options>

--- a/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.html
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.html
@@ -26,7 +26,7 @@
     </div>
 
     <div class="form-group">
-      <label i18n for="first-step-privacy">Privacy</label>
+      <label i18n for="first-step-privacy">Privacy: Who can Watch?</label>
       <my-select-options
         labelForId="first-step-privacy" [items]="videoPrivacies" [(ngModel)]="firstStepPrivacyId"
       ></my-select-options>

--- a/client/src/app/+videos/+video-edit/video-add-components/video-upload.component.html
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-upload.component.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="form-group">
-      <label i18n for="first-step-privacy">Privacy</label>
+      <label i18n for="first-step-privacy">Privacy: Who can Watch?</label>
       <my-select-options
         labelForId="first-step-privacy" [items]="videoPrivacies" [(ngModel)]="firstStepPrivacyId"
       ></my-select-options>

--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.html
@@ -6,9 +6,9 @@
     <div class="playlist-display-name">
       {{ playlist.displayName }}
 
-      <span *ngIf="isUnlistedPlaylist()" class="badge badge-warning" i18n>Unlisted</span>
-      <span *ngIf="isPrivatePlaylist()" class="badge badge-danger" i18n>Private</span>
-      <span *ngIf="isPublicPlaylist()" class="badge badge-info" i18n>Public</span>
+      <span *ngIf="isUnlistedPlaylist()" class="badge badge-warning" i18n>Unlisted- People with a Private Link</span>
+      <span *ngIf="isPrivatePlaylist()" class="badge badge-danger" i18n>Private- Only me</span>
+      <span *ngIf="isPublicPlaylist()" class="badge badge-info" i18n>Public- Anyone</span>
     </div>
 
     <div class="playlist-by-index">

--- a/client/src/app/shared/shared-main/video/video.service.ts
+++ b/client/src/app/shared/shared-main/video/video.service.ts
@@ -338,19 +338,19 @@ export class VideoService implements VideosProvider {
     const base = [
       {
         id: VideoPrivacy.PRIVATE,
-        description: $localize`Only I can see this video`
+        description: $localize`Private- Only me`
       },
       {
         id: VideoPrivacy.UNLISTED,
-        description: $localize`Only shareable via a private link`
+        description: $localize`Unlisted- People with a Private Link`
       },
       {
         id: VideoPrivacy.PUBLIC,
-        description: $localize`Anyone can see this video`
+        description: $localize`Public- Anyone`
       },
       {
         id: VideoPrivacy.INTERNAL,
-        description: $localize`Only users of this instance can see this video`
+        description: $localize`Internal- Only users of this instance`
       }
     ]
 


### PR DESCRIPTION
improved the wording of "privacy" in upload as well as in playlists to make a little bit more sense. Attached is screenshots of new and old privacy labels. 
I have taken help of vimeo in how they make use of their text.
https://vimeo.zendesk.com/hc/en-us/articles/224817847-Privacy-settings-overview
This also helped because the first upload page only said "private" "unlisted" "public" "internal" and in the actual description page these words were absent. 
![Screenshot_20200819_193125](https://user-images.githubusercontent.com/39449563/90644897-ee370400-e252-11ea-9f69-a1de8337a27f.png)

![Screenshot_20200819_193453](https://user-images.githubusercontent.com/39449563/90645039-16266780-e253-11ea-91a3-0af7f4fbb85c.png)

