### PR TITLE
removed pinch and zoom on touch devices

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/+videos/+video-watch/video-watch.component.scss
@@ -578,9 +578,6 @@ my-video-comments {
   .privacy-concerns {
     width: 100%;
 
-    strong {
-      display: none;
-    }
   }
 }
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
 
     <meta name="theme-color" content="#fff" />
     <meta property="og:platform" content="PeerTube" />

--- a/client/src/standalone/videos/embed.html
+++ b/client/src/standalone/videos/embed.html
@@ -4,7 +4,7 @@
     <title>PeerTube</title>
 
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
     <meta name="robots" content="noindex">
     <meta property="og:platform" content="PeerTube" />
 


### PR DESCRIPTION
added "initial-scale=1".  Currently the user is able to pinch and zoom on all the pages of the website when in mobile mode. this makes the application look out of place. preventing pinch and zoom makes it appear as if the app is native, like many webapps do