### PR TITLE
changed video rating popover text with link to login page

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -59,9 +59,13 @@
               </div>
 
               <div class="video-actions-rates">
+                <ng-template #ratePopoverText>
+                  <span [innerHTML]="getRatePopoverText()"></span>
+                </ng-template>
+
                 <div class="video-actions fullWidth justify-content-end">
                   <button
-                    [ngbPopover]="getRatePopoverText()" [ngClass]="{ 'activated': userRating === 'like' }" (click)="setLike()" (keyup.enter)="setLike()"
+                    [ngbPopover]="getRatePopoverText() && ratePopoverText" [ngClass]="{ 'activated': userRating === 'like' }" (click)="setLike()" (keyup.enter)="setLike()"
                     class="action-button action-button-like" [attr.aria-pressed]="userRating === 'like'" [attr.aria-label]="tooltipLike"
                     [ngbTooltip]="tooltipLike"
                     placement="bottom auto"
@@ -71,7 +75,7 @@
                 </button>
 
                   <button
-                    [ngbPopover]="getRatePopoverText()" [ngClass]="{ 'activated': userRating === 'dislike' }" (click)="setDislike()" (keyup.enter)="setDislike()"
+                    [ngbPopover]="getRatePopoverText() && ratePopoverText" [ngClass]="{ 'activated': userRating === 'dislike' }" (click)="setDislike()" (keyup.enter)="setDislike()"
                     class="action-button action-button-dislike" [attr.aria-pressed]="userRating === 'dislike'" [attr.aria-label]="tooltipDislike"
                     [ngbTooltip]="tooltipDislike"
                     placement="bottom auto"

--- a/client/src/app/+videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/+videos/+video-watch/video-watch.component.scss
@@ -577,10 +577,6 @@ my-video-comments {
 
   .privacy-concerns {
     width: 100%;
-
-    strong {
-      display: none;
-    }
   }
 }
 

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -189,7 +189,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
   getRatePopoverText () {
     if (this.isUserLoggedIn()) return undefined
 
-    return $localize`You need to be logged in to rate this video.`
+    return $localize`You need to be <a href="/login">logged in</a> to rate this video.`
   }
 
   showMoreDescription () {

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -189,7 +189,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
   getRatePopoverText () {
     if (this.isUserLoggedIn()) return undefined
 
-    return $localize`You need to be connected to rate this content.`
+    return $localize`You need to be logged in to rate this video.`
   }
 
   showMoreDescription () {


### PR DESCRIPTION
this aims to solve https://github.com/Chocobozzz/PeerTube/issues/3167 and a separate issue where i found the warning about p2p sharing which is initially shown to all users does not show up correctly on mobile devices as is currently hidden. this pr aims to fix those things

@rigelk i was unable to add a link 
![Screenshot_20200920_232731](https://user-images.githubusercontent.com/39449563/93718611-0e801880-fb9b-11ea-9470-807d7c56883f.png)

also, i have used the word "video" instead of "content" as was earlier because the word video is already used in the UI at multiple places like in share > embed> "display video title". if this isnt acceptable, i can change it back, just let me know.

