### PR TITLE
Fedora guide updgrade

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -160,10 +160,10 @@ dnf upgrade
 2. Add a user with sudoers group access:
 
 ```
-useradd peertube
-passwd peertube
-usermod peertube -a -G wheel	# Add peertube to sudoers
-su peertube
+useradd my-peertube-user
+passwd my-peertube-user
+usermod my-peertube-user -a -G wheel	# Add my-peertube-user to sudoers
+su my-peertube-user
 ```
 
 3. (Optional) Install certbot (choose instructions for nginx and your distribution):
@@ -185,7 +185,7 @@ This is necessary because `ffmpeg` is not in the Fedora repos.
 7. Run:
 
 ```
-sudo dnf install nginx ffmpeg postgresql-server postgresql-contrib openssl gcc-c++ make redis git
+sudo dnf install nginx ffmpeg postgresql-server postgresql-contrib openssl gcc-c++ make redis git vim
 ffmpeg -version # Should be >= 4.1
 g++ -v # Should be >= 5.x
 ```

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -185,7 +185,7 @@ This is necessary because `ffmpeg` is not in the Fedora repos.
 7. Run:
 
 ```
-sudo dnf install nginx ffmpeg postgresql-server postgresql-contrib openssl gcc-c++ make redis git vim
+sudo dnf install nginx ffmpeg postgresql-server postgresql-contrib openssl gcc-c++ make redis git vim oidentd
 ffmpeg -version # Should be >= 4.1
 g++ -v # Should be >= 5.x
 ```

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -190,7 +190,20 @@ ffmpeg -version # Should be >= 4.1
 g++ -v # Should be >= 5.x
 ```
 
-8. Post-installation
+8. Configure nginx
+
+```
+sudo mkdir /etc/nginx/sites-available
+sudo mkdir /etc/nginx/sites-enabled
+```
+
+Add the following line in /etc/nginx/nginx.conf (below `include /etc/nginx/conf.d/*.conf`)
+
+```
+include /etc/nginx/sites-enabled/*;
+```
+
+9. Post-installation
 
 _from [PostgreSQL documentation](https://www.postgresql.org/download/linux/redhat/):_
 > Due to policies for Red Hat family distributions, the PostgreSQL installation will not be enabled for automatic start or have the database initialized automatically.
@@ -211,7 +224,7 @@ sudo systemctl enable oidentd.service
 sudo systemctl start oidentd.service
 ```
 
-9. Firewall
+10. Firewall
 
 By default, you cannot access your server via public IP. To do so, you must configure firewall:
 
@@ -226,7 +239,7 @@ sudo firewall-cmd --permanent --zone=public --add-service=https
 sudo firewall-cmd --reload
 ```
 
-10. Configure max ports
+11. Configure max ports
 
 This is necessary if you are running dev setup, otherwise you will have errors with `nodemon`
 

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -160,10 +160,10 @@ dnf upgrade
 2. Add a user with sudoers group access:
 
 ```
-useradd my-peertube-user
-passwd my-peertube-user
-usermod my-peertube-user -a -G wheel	# Add my-peertube-user to sudoers
-su my-peertube-user
+useradd peertube
+passwd peertube
+usermod peertube -a -G wheel	# Add peertube to sudoers
+su peertube
 ```
 
 3. (Optional) Install certbot (choose instructions for nginx and your distribution):

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -206,6 +206,9 @@ sudo systemctl start nginx.service
 # Redis
 sudo systemctl enable redis.service
 sudo systemctl start redis.service
+# oidentd
+sudo systemctl enable oidentd.service
+sudo systemctl start oidentd.service
 ```
 
 9. Firewall


### PR DESCRIPTION
I've installed PeerTube on Fedora Workstation 32 and ran in some issues when following the dependencies and production guides. These changes address the missing parts.