### PR TITLE
Fix transcoding errors in readonly docker containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@types/config": "^0.0.36",
     "@types/express": "^4.0.35",
     "@types/express-rate-limit": "^5.0.0",
-    "@types/fluent-ffmpeg": "^2.1.8",
+    "@types/fluent-ffmpeg": "^2.1.16",
     "@types/fs-extra": "^9.0.1",
     "@types/libxmljs": "^0.18.0",
     "@types/lodash": "^4.14.64",

--- a/server/helpers/ffmpeg-utils.ts
+++ b/server/helpers/ffmpeg-utils.ts
@@ -270,7 +270,8 @@ type TranscodeOptions =
 function transcode (options: TranscodeOptions) {
   return new Promise<void>(async (res, rej) => {
     try {
-      let command = ffmpeg(options.inputPath, { niceness: FFMPEG_NICE.TRANSCODING })
+      // we set cwd explicitly because ffmpeg appears to create temporary files when trancoding which fails in read-only file systems
+      let command = ffmpeg(options.inputPath, { niceness: FFMPEG_NICE.TRANSCODING, cwd: CONFIG.STORAGE.TMP_DIR })
         .output(options.outputPath)
 
       if (options.type === 'quick-transcode') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,10 +591,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/fluent-ffmpeg@^2.1.8":
-  version "2.1.14"
-  resolved "https://registry.yarnpkg.com/@types/fluent-ffmpeg/-/fluent-ffmpeg-2.1.14.tgz#b21d60267fe269c2ea81fa3238a36a8349f8f2f3"
-  integrity sha512-nJrAX9ODNI7mUB0b7Y0Stx1a6dOpV3zXsOnWoBuEd9/woQhepBNCMeCyOL6SLJD3jn5sLw5ciDGH0RwJenCoag==
+"@types/fluent-ffmpeg@^2.1.16":
+  version "2.1.16"
+  resolved "https://registry.yarnpkg.com/@types/fluent-ffmpeg/-/fluent-ffmpeg-2.1.16.tgz#63949b0cb6bc88c9157a579cdd80858a269f3a3a"
+  integrity sha512-1FTstm6xY/2WsJVt6ARV7CiJjNCQDlR/nfw6xuYk5ITbVjk7sw89Biyqm2DGW4c3aZ3vBx+5irZvsql4eybpoQ==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
ffmpeg seems to create some temporary files in the cwd. When PeerTube
is run in a read-only docker container, this causes all transcoding
to fail. As a workaround, we set the cwd to the configured tmp dir.