### PR TITLE
Add possibility to share origin URL to video if it's not local

### DIFF
--- a/client/src/app/shared/shared-share-modal/video-share.component.html
+++ b/client/src/app/shared/shared-share-modal/video-share.component.html
@@ -173,6 +173,13 @@
                 i18n-labelText labelText="Loop"
               ></my-peertube-checkbox>
             </div>
+
+            <div *ngIf="!isLocalVideo() && !isVideoInEmbedTab()" class="form-group">
+              <my-peertube-checkbox
+                inputName="originUrl" [(ngModel)]="customizations.originUrl"
+                i18n-labelText labelText="Use origin instance URL"
+              ></my-peertube-checkbox>
+            </div>
           </div>
 
           <ng-container *ngIf="isVideoInEmbedTab()">

--- a/client/src/app/shared/shared-share-modal/video-share.component.ts
+++ b/client/src/app/shared/shared-share-modal/video-share.component.ts
@@ -16,6 +16,7 @@ type Customizations = {
   subtitle: string
 
   loop: boolean
+  originUrl: boolean
   autoplay: boolean
   muted: boolean
   title: boolean
@@ -65,6 +66,7 @@ export class VideoShareComponent {
       subtitle,
 
       loop: false,
+      originUrl: false,
       autoplay: false,
       muted: false,
 
@@ -95,7 +97,8 @@ export class VideoShareComponent {
   }
 
   getVideoUrl () {
-    const baseUrl = window.location.origin + '/videos/watch/' + this.video.uuid
+    let baseUrl = this.customizations.originUrl ? this.video.originInstanceUrl : window.location.origin
+    baseUrl += '/videos/watch/' + this.video.uuid
     const options = this.getVideoOptions(baseUrl)
 
     return buildVideoLink(options)
@@ -115,6 +118,10 @@ export class VideoShareComponent {
 
   isVideoInEmbedTab () {
     return this.activeVideoId === 'embed'
+  }
+
+  isLocalVideo () {
+    return this.video.isLocal
   }
 
   private getPlaylistOptions (baseUrl?: string) {


### PR DESCRIPTION
It's very difficult to share the original URL for a video when you watch it on your
own instance while it's not from it but from a different instance. Right now when
you use the share UI you only can share a link so a person can watch it on your
own instance, this patch adds a checkbox to the share UI to share the origin URL
instead if needed.

![origin-url](https://user-images.githubusercontent.com/151764/96361863-940ad000-1129-11eb-966b-71c52e22f76e.png)