### PR TITLE
Improve markdown-it emoji list column display

### DIFF
--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.html
@@ -85,15 +85,10 @@
     <my-global-icon iconName="cross" aria-label="Close" role="button" (click)="hideModals()"></my-global-icon>
   </div>
   <div class="modal-body">
-    <table class="table-emoji" *ngFor="let emojiMarkup of emojiMarkupList | keyvalue">
-      <tr>
-        <td>
-          <span>{{ emojiMarkup.value }}</span>
-        </td>
-        <td>
-          <code>:{{ emojiMarkup.key }}:</code>
-        </td>
-      </tr>
-    </table>
+    <div class="emoji-flex">
+      <div class="emoji-flex-item" *ngFor="let emojiMarkup of emojiMarkupList">
+        {{ emojiMarkup[0] }} <code>:{{ emojiMarkup[1] }}:</code>
+      </div>
+    </div>
   </div>
 </ng-template>

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
@@ -107,7 +107,8 @@ form {
   .emoji-flex-item {
     text-align: left;
     margin: auto;
-    width: 227px;
+    min-width: 227px;
+    flex: 1;
 
     code {
       display: inline-block;

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.scss
@@ -99,13 +99,21 @@ form {
   }
 }
 
-.table-emoji {
-  td {
-    &:first-child {
-      width: 20px;
-    }
+.emoji-flex {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
 
-    vertical-align: top;
+  .emoji-flex-item {
+    text-align: left;
+    margin: auto;
+    width: 227px;
+
+    code {
+      display: inline-block;
+      vertical-align: middle;
+      margin-left: 5px;
+    }
   }
 }
 

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
@@ -43,9 +43,18 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
   }
 
   get emojiMarkupList () {
-    const emojiMarkup = require('markdown-it-emoji/lib/data/light.json')
+    const emojiMarkupObjectList = require('markdown-it-emoji/lib/data/light.json')
 
-    return emojiMarkup
+    // Populate emoji-markup-list from object to array to avoid keys alphabetical order
+    const emojiMarkupArrayList = []
+    for (const emojiMarkupName in emojiMarkupObjectList) {
+      if (emojiMarkupName) {
+        const emoji = emojiMarkupObjectList[emojiMarkupName]
+        emojiMarkupArrayList.push([emoji, emojiMarkupName])
+      }
+    }
+
+    return emojiMarkupArrayList
   }
 
   ngOnInit () {

--- a/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment-add.component.ts
@@ -98,7 +98,7 @@ export class VideoCommentAddComponent extends FormReactive implements OnChanges,
 
   openEmojiModal (event: any) {
     event.preventDefault()
-    this.modalService.open(this.emojiModal, { backdrop: true })
+    this.modalService.open(this.emojiModal, { backdrop: true, size: 'lg' })
   }
 
   hideModals () {


### PR DESCRIPTION
Fix https://github.com/Chocobozzz/PeerTube/issues/3245

- Use CSS flex instead of a classic table to extend the columns on the full modal width and make it responsive ;
- Center the columns ;
- Populate the the markdown-it emoji list from object to array to avoid an alphabetical order of the keys.

![emoji-list](https://user-images.githubusercontent.com/1877318/98293237-40640780-1fae-11eb-96ec-d70a4b0a1f2d.png)
![image](https://user-images.githubusercontent.com/1877318/98293263-4fe35080-1fae-11eb-89f6-8ea9c3f1487f.png)
