### PR TITLE
Restore line feed before HTML rendering for markdown lists support in comments

### DIFF
--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.ts
@@ -153,7 +153,9 @@ export class VideoCommentComponent implements OnInit, OnChanges {
   }
 
   private async init () {
-    const html = await this.markdownService.textMarkdownToHTML(this.comment.text, true, true)
+    // Before HTML rendering restore line feed for markdown list compatibility
+    const commentText = this.comment.text.replace(/<br.?\/?>/g, '\r\n')
+    const html = await this.markdownService.textMarkdownToHTML(commentText, true, true)
     this.sanitizedCommentHTML = await this.markdownService.processVideoTimestamps(html)
     this.newParentComments = this.parentComments.concat([ this.comment ])
 

--- a/client/src/app/+videos/+video-watch/comment/video-comments.component.ts
+++ b/client/src/app/+videos/+video-watch/comment/video-comments.component.ts
@@ -199,7 +199,7 @@ export class VideoCommentsComponent implements OnInit, OnChanges, OnDestroy {
     if (confirm) {
       this.inReplyToCommentId = commentToRedraft.inReplyToCommentId
 
-      // Display <br /> tag as a break line for editing
+      // Restore line feed for editing
       const commentToRedraftText = commentToRedraft.text.replace(/<br.?\/?>/g, '\r\n')
 
       if (commentToRedraft.threadId === commentToRedraft.id) {


### PR DESCRIPTION
Fix https://github.com/Chocobozzz/PeerTube/pull/3261#issuecomment-723294546 
Fix #3260