### PR TITLE
Dependencies versions

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -15,7 +15,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-Make sure you install the correct versions of the dependencies as mentioned in the [PeerTube README.md](https://github.com/Chocobozzz/PeerTube#dependencies)
+Make sure you install the correct versions of the dependencies as mentioned in the PeerTube [README.md](https://github.com/Chocobozzz/PeerTube#dependencies)
 
 ## Debian / Ubuntu and derivatives
 

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -15,6 +15,15 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+### Dependency versions
+
+- nginx
+- **PostgreSQL >= 9.6**
+- **Redis >= 2.8.18**
+- **NodeJS >= 10.x**
+- **yarn >= 1.x**
+- **FFmpeg >= 4.1**
+
 ## Debian / Ubuntu and derivatives
 
 1. On a fresh Debian/Ubuntu, as root user, install basic utility programs needed for the installation

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -17,7 +17,6 @@
 
 ---
 Make sure you install the correct versions of the dependencies as mentioned in the [PeerTube README.md](https://github.com/Chocobozzz/PeerTube#dependencies)
----
 
 ## Debian / Ubuntu and derivatives
 

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -15,7 +15,9 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-> Make sure you install the correct versions of the dependencies as mentioned in the [PeerTube README.md](https://github.com/Chocobozzz/PeerTube#dependencies)
+---
+Make sure you install the correct versions of the dependencies as mentioned in the [PeerTube README.md](https://github.com/Chocobozzz/PeerTube#dependencies)
+---
 
 ## Debian / Ubuntu and derivatives
 

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -15,14 +15,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-### Dependency versions
-
-- nginx
-- **PostgreSQL >= 9.6**
-- **Redis >= 2.8.18**
-- **NodeJS >= 10.x**
-- **yarn >= 1.x**
-- **FFmpeg >= 4.1**
+> Make sure you install the correct versions of the dependencies as mentioned in the [PeerTube README.md](https://github.com/Chocobozzz/PeerTube#dependencies)
 
 ## Debian / Ubuntu and derivatives
 

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -15,7 +15,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
----
 Make sure you install the correct versions of the dependencies as mentioned in the [PeerTube README.md](https://github.com/Chocobozzz/PeerTube#dependencies)
 
 ## Debian / Ubuntu and derivatives


### PR DESCRIPTION
## Description

The PeerTube dependencies guide doesn't check versions after install and this leads to non-descriptive errors post-install if the dependencies versions were wrong.

There have been countless times has there been frustration and an issue posted in the PeerTube community, because for example a wrong NodeJS version was already installed on the target server.

## Solution

Checking for installed dependencies versions is the responsibility of the one who's installing, but the minimal versions of the dependencies should be referenced in the dependencies guide. These minimal versions are mentioned in the main readme, so the simplest addition to the dependencies guide is a link to that content. 

See also the issue on this project repo: https://github.com/beeldengeluid/extending-peertube/issues/8 