### PR TITLE
add client overrides to nginx configuration

### DIFF
--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -64,6 +64,7 @@ for (const staticClientFile of staticClientFiles) {
 clientsRouter.get('/manifest.webmanifest', asyncMiddleware(generateManifest))
 
 // Static client overrides
+// Must be consistent with static client overrides redirections in /support/nginx/peertube
 const staticClientOverrides = [
   'assets/images/logo.svg',
   'assets/images/favicon.png',

--- a/support/doc/docker-traefik.md
+++ b/support/doc/docker-traefik.md
@@ -24,7 +24,7 @@ touch ./docker-volume/traefik/acme.json
 ```
 Needs to have file mode 600:
 ```shell
-chmod 600 ./docker-volume/traefik/acme.json 
+chmod 600 ./docker-volume/traefik/acme.json
 ```
 
 #### Update the reverse proxy configuration
@@ -40,5 +40,5 @@ More at: https://docs.traefik.io/v1.7
 #### Run with traefik
 
 ```shell
-docker-compose -f docker-compose.yml docker-compose.traefik.yml up -d
+docker-compose -f docker-compose.yml -f docker-compose.traefik.yml up -d
 ```

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -58,18 +58,8 @@ server {
   }
 
   # Bypass PeerTube for performance reasons. Could be removed
-  # Must be consistent with static client-overrides list in /server/controllers/client.ts
-  location ~ ^/client/(assets/images/(logo\.svg|favicon\.png)) {
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    root /var/www/peertube;
-
-    try_files /storage/client-overrides/$1 /peertube-latest/client/dist/$1 $uri;
-  }
-
-  # Bypass PeerTube for performance reasons. Could be removed
-  # Must be consistent with static client-overrides list in /server/controllers/client.ts
-  location ~ ^/client/(assets/images/icons/icon-(36x36|48x48|72x72|96x96|144x144|192x192|512x512)\.png)$ {
+  # Should be consistent with client-overrides assets list in /server/controllers/client.ts
+  location ~ ^/client/(assets/images/(icons/icon-36x36\.png|icons/icon-48x48\.png|icons/icon-72x72\.png|icons/icon-96x96\.png|icons/icon-144x144\.png|icons/icon-192x192\.png|icons/icon-512x512\.png|logo\.svg|favicon\.png))$ {
     add_header Cache-Control "public, max-age=31536000, immutable";
 
     root /var/www/peertube;

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -62,9 +62,9 @@ server {
   location ~ ^/client/(assets/images/(icons/icon-36x36\.png|icons/icon-48x48\.png|icons/icon-72x72\.png|icons/icon-96x96\.png|icons/icon-144x144\.png|icons/icon-192x192\.png|icons/icon-512x512\.png|logo\.svg|favicon\.png))$ {
     add_header Cache-Control "public, max-age=31536000, immutable";
 
-    root /var/www/peertube;
+    root /var/www/peertube/storage/client-overrides;
 
-    try_files /storage/client-overrides/$1 /peertube-latest/client/dist/$1 $uri;
+    try_files /$1 $uri;
   }
 
   # Bypass PeerTube for performance reasons. Could be removed

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -58,6 +58,26 @@ server {
   }
 
   # Bypass PeerTube for performance reasons. Could be removed
+  # Must be consistent with static client-overrides list in /server/controllers/client.ts
+  location ~ ^/client/(assets/images/(logo\.svg|favicon\.png)) {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+
+    root /var/www/peertube;
+
+    try_files /storage/client-overrides/$1 /peertube-latest/client/dist/$1 $uri;
+  }
+
+  # Bypass PeerTube for performance reasons. Could be removed
+  # Must be consistent with static client-overrides list in /server/controllers/client.ts
+  location ~ ^/client/(assets/images/icons/icon-(36x36|48x48|72x72|96x96|144x144|192x192|512x512)\.png)$ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+
+    root /var/www/peertube;
+
+    try_files /storage/client-overrides/$1 /peertube-latest/client/dist/$1 $uri;
+  }
+
+  # Bypass PeerTube for performance reasons. Could be removed
   location ~ ^/client/(.*\.(js|css|png|svg|woff2|otf|ttf|woff|eot))$ {
     add_header Cache-Control "public, max-age=31536000, immutable";
 


### PR DESCRIPTION
## Description
In production client-overrides don't work with nginx because client assets were bypassed without considering client-overrides handled in PeerTube. 

## Related issues
- Fix https://github.com/Chocobozzz/PeerTube/issues/3292
- Also fixes a the doc for a docker-compose command with multiples compose files.

## Has this been tested?
I tested it with production scripts, it may need more tests ? @rigelk ?