### PR TITLE
fix CONTRIBUTING.md command order

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,8 +83,8 @@ and then clone the sources and install node modules:
 
 ```
 $ git clone https://github.com/Chocobozzz/PeerTube
-$ git remote add me git@github.com:YOUR_GITHUB_USERNAME/PeerTube.git
 $ cd PeerTube
+$ git remote add me git@github.com:YOUR_GITHUB_USERNAME/PeerTube.git
 $ yarn install --pure-lockfile
 ```
 


### PR DESCRIPTION
After cloning the PeerTube repo you should first `cd` into the PeerTube local repo before adding a remote, otherwise this will happen: 'fatal: not a git repository (or any of the parent directories): .git'

