### PR TITLE
default youtube-dl to use ipv4

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -285,7 +285,9 @@ import:
   videos:
     http: # Classic HTTP or all sites supported by youtube-dl https://rg3.github.io/youtube-dl/supportedsites.html
       enabled: false
-      forceIPV4: true
+      # IPv6 sometimes bumps into impossible to debug problems on the YouTube side.
+      forceipV4:
+        enabled: true
       # You can use an HTTP/HTTPS/SOCKS proxy with youtube-dl
       proxy:
         enabled: false

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -285,8 +285,8 @@ import:
   videos:
     http: # Classic HTTP or all sites supported by youtube-dl https://rg3.github.io/youtube-dl/supportedsites.html
       enabled: false
-      # IPv6 sometimes bumps into impossible to debug problems on the YouTube side.
-      forceipV4:
+      # IPv6 is very strongly rate-limited on most sites supported by youtube-dl
+      forceipv4:
         enabled: true
       # You can use an HTTP/HTTPS/SOCKS proxy with youtube-dl
       proxy:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -285,6 +285,7 @@ import:
   videos:
     http: # Classic HTTP or all sites supported by youtube-dl https://rg3.github.io/youtube-dl/supportedsites.html
       enabled: false
+      forceIPV4: true
       # You can use an HTTP/HTTPS/SOCKS proxy with youtube-dl
       proxy:
         enabled: false

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -299,6 +299,9 @@ import:
   videos:
     http: # Classic HTTP or all sites supported by youtube-dl https://rg3.github.io/youtube-dl/supportedsites.html
       enabled: false
+      # IPv6 is very strongly rate-limited on most sites supported by youtube-dl
+      forceipv4:
+        enabled: true
       # You can use an HTTP/HTTPS/SOCKS proxy with youtube-dl
       proxy:
         enabled: false

--- a/server/helpers/youtube-dl.ts
+++ b/server/helpers/youtube-dl.ts
@@ -33,7 +33,7 @@ const processOptions = {
 
 function getYoutubeDLInfo (url: string, opts?: string[]): Promise<YoutubeDLInfo> {
   return new Promise<YoutubeDLInfo>((res, rej) => {
-    let args = opts || [ '-j', '--flat-playlist' ]
+    let args = opts || [ '-j', '--flat-playlist', '--force-ipv4' ]
     args = wrapWithProxyOptions(args)
 
     safeGetYoutubeDL()

--- a/server/helpers/youtube-dl.ts
+++ b/server/helpers/youtube-dl.ts
@@ -33,8 +33,9 @@ const processOptions = {
 
 function getYoutubeDLInfo (url: string, opts?: string[]): Promise<YoutubeDLInfo> {
   return new Promise<YoutubeDLInfo>((res, rej) => {
-    let args = opts || [ '-j', '--flat-playlist', '--force-ipv4' ]
+    let args = opts || [ '-j', '--flat-playlist' ]
     args = wrapWithProxyOptions(args)
+    if (CONFIG.IMPORT.VIDEOS.HTTP.FORCEIPV4) args = [ '--force-ipv4' ].concat(args)
 
     safeGetYoutubeDL()
       .then(youtubeDL => {

--- a/server/helpers/youtube-dl.ts
+++ b/server/helpers/youtube-dl.ts
@@ -34,8 +34,8 @@ const processOptions = {
 function getYoutubeDLInfo (url: string, opts?: string[]): Promise<YoutubeDLInfo> {
   return new Promise<YoutubeDLInfo>((res, rej) => {
     let args = opts || [ '-j', '--flat-playlist' ]
+    if (CONFIG.IMPORT.VIDEOS.HTTP.FORCEIPV4) args.push('--force-ipv4')
     args = wrapWithProxyOptions(args)
-    if (CONFIG.IMPORT.VIDEOS.HTTP.FORCEIPV4) args = [ '--force-ipv4' ].concat(args)
 
     safeGetYoutubeDL()
       .then(youtubeDL => {

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -229,6 +229,9 @@ const CONFIG = {
     VIDEOS: {
       HTTP: {
         get ENABLED () { return config.get<boolean>('import.videos.http.enabled') },
+        FORCEIPV4: {
+          get ENABLED () { return config.get<boolean>('import.videos.http.forceipv4.enabled') }
+        },
         PROXY: {
           get ENABLED () { return config.get<boolean>('import.videos.http.proxy.enabled') },
           get URL () { return config.get<string>('import.videos.http.proxy.url') }


### PR DESCRIPTION
## Description

It seems YouTube does not like ipv6 clients (HTTP Error 429). This extra option works around that.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->