### PR TITLE
Memorize scroll position after maximized textarea / disable auto-focus on touchscreens

### DIFF
--- a/client/src/app/shared/shared-forms/markdown-textarea.component.ts
+++ b/client/src/app/shared/shared-forms/markdown-textarea.component.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs'
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
 import { Component, ElementRef, forwardRef, Input, OnInit, ViewChild } from '@angular/core'
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
-import { MarkdownService } from '@app/core'
+import { MarkdownService, ScreenService } from '@app/core'
 
 @Component({
   selector: 'my-markdown-textarea',
@@ -40,6 +40,7 @@ export class MarkdownTextareaComponent implements ControlValueAccessor, OnInit {
 
   constructor (
     private viewportScroller: ViewportScroller,
+    private screenService: ScreenService,
     private markdownService: MarkdownService
   ) { }
 
@@ -80,7 +81,10 @@ export class MarkdownTextareaComponent implements ControlValueAccessor, OnInit {
     this.isMaximized = !this.isMaximized
 
     // Make sure textarea have the focus
-    this.textareaElement.nativeElement.focus()
+    // Except on touchscreens devices, the virtual keyboard may move up and hide the textarea in maximized mode
+    if (!this.screenService.isInTouchScreen()) {
+      this.textareaElement.nativeElement.focus()
+    }
 
     // Make sure the window has no scrollbars
     if (!this.isMaximized) {

--- a/client/src/app/shared/shared-forms/markdown-textarea.component.ts
+++ b/client/src/app/shared/shared-forms/markdown-textarea.component.ts
@@ -1,3 +1,4 @@
+import { ViewportScroller } from '@angular/common'
 import truncate from 'lodash-es/truncate'
 import { Subject } from 'rxjs'
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
@@ -35,8 +36,12 @@ export class MarkdownTextareaComponent implements ControlValueAccessor, OnInit {
   isMaximized = false
 
   private contentChanged = new Subject<string>()
+  private scrollPosition: [number, number]
 
-  constructor (private markdownService: MarkdownService) {}
+  constructor (
+    private viewportScroller: ViewportScroller,
+    private markdownService: MarkdownService
+  ) { }
 
   ngOnInit () {
     this.contentChanged
@@ -86,11 +91,13 @@ export class MarkdownTextareaComponent implements ControlValueAccessor, OnInit {
   }
 
   private lockBodyScroll () {
+    this.scrollPosition = this.viewportScroller.getScrollPosition()
     document.getElementById('content').classList.add('lock-scroll')
   }
 
   private unlockBodyScroll () {
     document.getElementById('content').classList.remove('lock-scroll')
+    this.viewportScroller.scrollToPosition(this.scrollPosition)
   }
 
   private async updatePreviews () {


### PR DESCRIPTION
## Description

- Memorize scroll position after maximized the markdown textarea, caused to the fixed position of the main component ;
- Disable auto-focus of the markdown textarea when maximized on touchscreens that may move up and hide the textarea accidentality.

## Related issues

Fix https://github.com/Chocobozzz/PeerTube/issues/3322

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

Maximize and unmaximize a texteara when body scrolled down in Administration > Configuration > Basic configuration