### PR TITLE
Add pixel size to tooltip and gif support with FFmpeg for avatar upload

### DIFF
--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.html
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.html
@@ -4,7 +4,8 @@
       <img [src]="actor.avatarUrl" alt="Avatar" />
 
       <div class="actor-img-edit-container">
-        <div class="actor-img-edit-button" [ngbTooltip]="'(extensions: '+ avatarExtensions +', '+ maxSizeText +': '+ maxAvatarSizeInBytes +')'" placement="right" container="body">
+        <div class="actor-img-edit-button" [ngbTooltip]="avatarFormat"
+          placement="right" container="body">
           <my-global-icon iconName="edit"></my-global-icon>
           <label for="avatarfile" i18n>Change your avatar</label>
           <input #avatarfileInput type="file" title=" " name="avatarfile" id="avatarfile" [accept]="avatarExtensions" (change)="onAvatarChange()"/>

--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.ts
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.ts
@@ -17,16 +17,12 @@ export class ActorAvatarInfoComponent implements OnInit {
 
   @Output() avatarChange = new EventEmitter<FormData>()
 
-  maxSizeText: string
-
   private serverConfig: ServerConfig
 
   constructor (
     private serverService: ServerService,
     private notifier: Notifier
-  ) {
-    this.maxSizeText = $localize`max size`
-  }
+  ) { }
 
   ngOnInit (): void {
     this.serverConfig = this.serverService.getTmpConfig()
@@ -57,5 +53,9 @@ export class ActorAvatarInfoComponent implements OnInit {
 
   get avatarExtensions () {
     return this.serverConfig.avatar.file.extensions.join(', ')
+  }
+
+  get avatarFormat () {
+    return `${$localize`max size`}: 192*192px, ${this.maxAvatarSizeInBytes} ${$localize`extensions`}: ${this.avatarExtensions}`
   }
 }

--- a/server/helpers/image-utils.ts
+++ b/server/helpers/image-utils.ts
@@ -1,5 +1,6 @@
+import { extname } from 'path'
 import { remove, rename } from 'fs-extra'
-import { convertWebPToJPG } from './ffmpeg-utils'
+import { convertWebPToJPG, processGIF } from './ffmpeg-utils'
 import { logger } from './logger'
 
 const Jimp = require('jimp')
@@ -10,6 +11,13 @@ async function processImage (
   newSize: { width: number, height: number },
   keepOriginal = false
 ) {
+  const extension = extname(path)
+
+  // Use FFmpeg to process GIF
+  if (extension === '.gif') {
+    return processGIF(path, destination, newSize, keepOriginal)
+  }
+
   if (path === destination) {
     throw new Error('Jimp needs an input path different that the output path.')
   }

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -291,7 +291,7 @@ const CONSTRAINTS_FIELDS = {
     PRIVATE_KEY: { min: 10, max: 5000 }, // Length
     URL: { min: 3, max: 2000 }, // Length
     AVATAR: {
-      EXTNAME: [ '.png', '.jpeg', '.jpg' ],
+      EXTNAME: [ '.png', '.jpeg', '.jpg', '.gif' ],
       FILE_SIZE: {
         max: 2 * 1024 * 1024 // 2MB
       }

--- a/server/lib/avatar.ts
+++ b/server/lib/avatar.ts
@@ -1,5 +1,4 @@
 import 'multer'
-import { move } from 'fs-extra'
 import { sendUpdateActor } from './activitypub/send'
 import { AVATARS_SIZE, LRU_CACHE, QUEUE_CONCURRENCY } from '../initializers/constants'
 import { updateActorAvatarInstance } from './activitypub/actor'
@@ -21,13 +20,7 @@ async function updateActorAvatarFile (
   const extension = extname(avatarPhysicalFile.filename)
   const avatarName = uuidv4() + extension
   const destination = join(CONFIG.STORAGE.AVATARS_DIR, avatarName)
-
-  // For gif do not resize, just move
-  if (extension === '.gif') {
-    await move(avatarPhysicalFile.path, destination)
-  } else {
-    await processImage(avatarPhysicalFile.path, destination, AVATARS_SIZE)
-  }
+  await processImage(avatarPhysicalFile.path, destination, AVATARS_SIZE)
 
   return retryTransactionWrapper(() => {
     return sequelizeTypescript.transaction(async t => {


### PR DESCRIPTION
## Description

- Add max resolution 192x192 (after resize) in tooltip avatar upload
- Add gif support for avatar with **FFmpeg process**

## Related issues

Gif support only : https://github.com/Chocobozzz/PeerTube/issues/3299

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
~~- [ ] 👍 yes, I added tests to the test suite~~ Didn't found any unit test for Image processing
- [x] 👍 yes, light tests as follows are enough

I just live tested, does it need unit test @Chocobozzz  ?

## Screenshots

![Peek 19-11-2020 02-13](https://user-images.githubusercontent.com/1877318/99608137-96ed2f00-2a0d-11eb-91da-5924a7d9d075.gif)


