### PR TITLE
Add about link icon in header right on bigger screens width than mobile

### DIFF
--- a/client/src/app/header/header.component.html
+++ b/client/src/app/header/header.component.html
@@ -4,3 +4,7 @@
   <my-global-icon iconName="upload" aria-hidden="true"></my-global-icon>
   <span i18n class="publish-button-label">Publish</span>
 </a>
+
+<a *ngIf="!isInMobileView" class="about-button" routerLink="/about" routerLinkActive="active" [ngbTooltip]="aboutText">
+  <my-global-icon iconName="help" aria-hidden="true"></my-global-icon>
+</a>

--- a/client/src/app/header/header.component.scss
+++ b/client/src/app/header/header.component.scss
@@ -1,6 +1,10 @@
 @import '_variables';
 @import '_mixins';
 
+:host {
+  align-items: center;
+}
+
 my-search-typeahead {
   margin-right: 15px;
 }
@@ -10,10 +14,9 @@ my-search-typeahead {
   @include orange-button;
   @include button-with-icon(22px, 3px, -1px);
 
-  margin-right: 25px;
+  margin-right: 10px;
 
-  @media screen and (max-width: 600px) {
-    margin-right: 10px;
+  @media screen and (max-width: $small-view) {
     padding: 0 10px;
 
     .icon.icon-upload {
@@ -24,4 +27,24 @@ my-search-typeahead {
       display: none;
     }
   }
+}
+
+.about-button {
+  @include apply-svg-color(rgba(0, 0, 0, 0.75));
+
+  &:hover, &:active {
+    @include apply-svg-color(pvar(--mainColorLighter));
+  }
+
+  &.active {
+    @include apply-svg-color(pvar(--mainColor));
+  }
+
+  ::ng-deep {
+    svg {
+      transition: color 0.15s;
+    }
+  }
+
+  margin-right: 25px;
 }

--- a/client/src/app/header/header.component.ts
+++ b/client/src/app/header/header.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core'
+import { ScreenService } from '@app/core'
 
 @Component({
   selector: 'my-header',
@@ -6,4 +7,14 @@ import { Component } from '@angular/core'
   styleUrls: [ './header.component.scss' ]
 })
 
-export class HeaderComponent {}
+export class HeaderComponent {
+  aboutText = $localize`About`
+
+  constructor (
+    private screenService: ScreenService
+  ) { }
+
+  get isInMobileView () {
+    return this.screenService.isInMobileView()
+  }
+}

--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -158,7 +158,7 @@
           <ng-container i18n>Settings</ng-container>
         </a>
 
-        <a routerLink="/about" routerLinkActive="active">
+        <a *ngIf="isInMobileView" routerLink="/about" routerLinkActive="active">
           <my-global-icon iconName="help" aria-hidden="true"></my-global-icon>
           <ng-container i18n>About</ng-container>
         </a>


### PR DESCRIPTION
## Description

Add about link icon in header right to the publish button for screens width bigger than 500px (mobile).
This way, the about pages are well promoted. **On mobile screens the about link stays in the menu**.

## Screenshots
![Capture d’écran du 2020-11-23 15-38-52](https://user-images.githubusercontent.com/1877318/99975968-27779680-2da3-11eb-808e-191119879132.png)


![Peek 23-11-2020 15-37](https://user-images.githubusercontent.com/1877318/99975947-22b2e280-2da3-11eb-9fcc-cc407f1f5127.gif)

