### PR TITLE
fix user preferences column width for notifications table

### DIFF
--- a/client/src/app/+my-account/my-account-settings/my-account-notification-preferences/my-account-notification-preferences.component.scss
+++ b/client/src/app/+my-account/my-account-settings/my-account-notification-preferences/my-account-notification-preferences.component.scss
@@ -12,16 +12,14 @@
 
   & > div {
     padding: 10px;
-    width: 350px;
 
-    &:nth-child(2) {
-      max-width: 60px !important;
+    &:first-child {
+      width: 350px;
     }
 
-    @media screen and (max-width: $small-view) {
-      width: auto;
-
+    @media screen and (max-width: #{breakpoint(sm)}) {
       &:first-child {
+        width: auto;
         flex-grow: 1;
       }
     }


### PR DESCRIPTION
# Description
Fix notifications preferences column width in `/my-account/settings#notifications`

# Screenshots
![Screenshot_2020-11-24 Account settings - QueerMotion](https://user-images.githubusercontent.com/1877318/100096239-0a52ce80-2e5c-11eb-8a08-7dc419291c66.png)
