### PR TITLE
add My History API to openapi

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -70,6 +70,9 @@ tags:
     description: >
       Operations related to your subscriptions to video channels, their
       new videos, and how to keep up to date with their latest publications!
+  - name: My History
+    description: >
+      Operations related to your watch history. 
   - name: My Notifications
     description: >
       Notifications following new videos, follows or reports. They allow you
@@ -914,6 +917,43 @@ paths:
                   $ref: '#/components/schemas/NotificationSettingValue'
                 autoInstanceFollowing:
                   $ref: '#/components/schemas/NotificationSettingValue'
+      responses:
+        '204':
+          description: successful operation
+  /users/me/history/videos:
+    get:
+      summary: List watched videos history
+      security:
+        - OAuth2: []
+      tags:
+        - My History
+      parameters:
+        - $ref: '#/components/parameters/start'
+        - $ref: '#/components/parameters/count'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VideoListResponse'
+  /users/me/history/videos/remove:
+    post:
+      summary: Clear video history
+      security:
+        - OAuth2: []
+      tags:
+        - My History
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                beforeDate:
+                  description: If passed, history before this date will be deleted
+                  type: string
+                  format: date-time
       responses:
         '204':
           description: successful operation

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -153,6 +153,7 @@ x-tagGroups:
       - My User
       - My Subscriptions
       - My Notifications
+      - My History
   - name: Videos
     tags:
       - Video

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -952,7 +952,7 @@ paths:
               type: object
               properties:
                 beforeDate:
-                  description: If passed, history before this date will be deleted
+                  description: history before this date will be deleted
                   type: string
                   format: date-time
       responses:


### PR DESCRIPTION

## Description

`/users/me/history/videos` and `/users/me/history/videos/remove` were missing in openapi docs, I added them!

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
No related issue. just found these API endpoints were missing.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
