### PR TITLE
add title attribute for exact view counters

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -55,10 +55,7 @@
               <ng-container i18n>Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle></ng-container>
 
               <span i18n i18n-title
-                    title="{{
-                      (video.views >= 1000)
-                      ? (video.views + ' ' + (video.isLive ? 'views' : 'viewers'))
-                      : ''}}"
+                    title="{{getExactNumberOfViews()}}"
                     class="views">
                 • {{ video.views | myNumberFormatter }}
                 <ng-container *ngIf="!video.isLive">views</ng-container>
@@ -77,10 +74,7 @@
                 <ng-container i18n>Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle></ng-container>
 
                 <span i18n i18n-title
-                      title="{{
-                      (video.views >= 1000)
-                      ? (video.views + ' ' + (video.isLive ? 'views' : 'viewers'))
-                      : ''}}"
+                      title="{{getExactNumberOfViews()}}"
                       class="views">
                   • {{ video.views | myNumberFormatter }}
                   <ng-container *ngIf="!video.isLive">views</ng-container>

--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -54,7 +54,12 @@
             <div class="video-info-date-views">
               <ng-container i18n>Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle></ng-container>
 
-              <span i18n class="views">
+              <span i18n i18n-title
+                    title="{{
+                      (video.views >= 1000)
+                      ? (video.views + ' ' + (video.isLive ? 'views' : 'viewers'))
+                      : ''}}"
+                    class="views">
                 • {{ video.views | myNumberFormatter }}
                 <ng-container *ngIf="!video.isLive">views</ng-container>
                 <ng-container *ngIf="video.isLive">viewers</ng-container>
@@ -71,7 +76,12 @@
               <div class="d-none d-md-block video-info-date-views">
                 <ng-container i18n>Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle></ng-container>
 
-                <span i18n class="views">
+                <span i18n i18n-title
+                      title="{{
+                      (video.views >= 1000)
+                      ? (video.views + ' ' + (video.isLive ? 'views' : 'viewers'))
+                      : ''}}"
+                      class="views">
                   • {{ video.views | myNumberFormatter }}
                   <ng-container *ngIf="!video.isLive">views</ng-container>
                   <ng-container *ngIf="video.isLive">viewers</ng-container>

--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -54,8 +54,8 @@
             <div class="video-info-date-views">
               <ng-container i18n>Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle></ng-container>
 
-              <span i18n i18n-title
-                    title="{{getExactNumberOfViews()}}"
+              <span i18n
+                    title="{{ getExactNumberOfViews() }}"
                     class="views">
                 • {{ video.views | myNumberFormatter }}
                 <ng-container *ngIf="!video.isLive">views</ng-container>
@@ -73,8 +73,8 @@
               <div class="d-none d-md-block video-info-date-views">
                 <ng-container i18n>Published <my-date-toggle [date]="video.publishedAt"></my-date-toggle></ng-container>
 
-                <span i18n i18n-title
-                      title="{{getExactNumberOfViews()}}"
+                <span i18n
+                      title="{{ getExactNumberOfViews() }}"
                       class="views">
                   • {{ video.views | myNumberFormatter }}
                   <ng-container *ngIf="!video.isLive">views</ng-container>

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -219,6 +219,12 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     return $localize`You need to be <a href="/login">logged in</a> to rate this video.`
   }
 
+  getExactNumberOfViews () {
+    return (this.video.views >= 1000)
+      ? (this.video.views + ' ' + (this.video.isLive ? 'viewers' : 'views'))
+      : ''
+  }
+
   showMoreDescription () {
     if (this.completeVideoDescription === undefined) {
       return this.loadCompleteDescription()

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -221,7 +221,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
   getExactNumberOfViews () {
     return (this.video.views >= 1000)
-      ? (this.video.views + ' ' + (this.video.isLive ? $localize`viewers` : $localize`views`))
+      ? `${this.video.views} ${this.video.isLive ? $localize`viewers` : $localize`views`}`
       : ''
   }
 

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -221,7 +221,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
   getExactNumberOfViews () {
     return (this.video.views >= 1000)
-      ? (this.video.views + ' ' + (this.video.isLive ? 'viewers' : 'views'))
+      ? (this.video.views + ' ' + (this.video.isLive ? $localize`viewers` : $localize`views`))
       : ''
   }
 

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.html
@@ -26,9 +26,7 @@
           <span class="video-miniature-created-at-views">
             <my-date-toggle *ngIf="displayOptions.date" [date]="video.publishedAt"></my-date-toggle>
 
-            <span class="views" title="{{ (video.views >= 1000 && displayOptions.views)
-                              ? (video.views + ' ' + (video.isLive ? 'views' : 'viewers'))
-                              : ''}}">
+            <span class="views" title="{{getExactNumberOfViews()}}">
               <ng-container *ngIf="displayOptions.date && displayOptions.views"> • </ng-container>
               <ng-container i18n *ngIf="displayOptions.views">
                 {video.views, plural, =1 {1 view} other {{{ video.views | myNumberFormatter }} views}}

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.html
@@ -26,13 +26,11 @@
           <span class="video-miniature-created-at-views">
             <my-date-toggle *ngIf="displayOptions.date" [date]="video.publishedAt"></my-date-toggle>
 
-            <span class="views">
-              <ng-container *ngIf="displayOptions.date && displayOptions.views"> • </ng-container>
-              <ng-container i18n *ngIf="displayOptions.views"
-                            title="{{ (video.views >= 1000 && displayOptions.views)
+            <span class="views" title="{{ (video.views >= 1000 && displayOptions.views)
                               ? (video.views + ' ' + (video.isLive ? 'views' : 'viewers'))
-                              : ''}}"
-              >
+                              : ''}}">
+              <ng-container *ngIf="displayOptions.date && displayOptions.views"> • </ng-container>
+              <ng-container i18n *ngIf="displayOptions.views">
                 {video.views, plural, =1 {1 view} other {{{ video.views | myNumberFormatter }} views}}
               </ng-container>
             </span>

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.html
@@ -26,7 +26,7 @@
           <span class="video-miniature-created-at-views">
             <my-date-toggle *ngIf="displayOptions.date" [date]="video.publishedAt"></my-date-toggle>
 
-            <span class="views" title="{{getExactNumberOfViews()}}">
+            <span class="views" title="{{ getExactNumberOfViews() }}">
               <ng-container *ngIf="displayOptions.date && displayOptions.views"> • </ng-container>
               <ng-container i18n *ngIf="displayOptions.views">
                 {video.views, plural, =1 {1 view} other {{{ video.views | myNumberFormatter }} views}}

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.html
@@ -28,7 +28,13 @@
 
             <span class="views">
               <ng-container *ngIf="displayOptions.date && displayOptions.views"> • </ng-container>
-              <ng-container i18n *ngIf="displayOptions.views">{video.views, plural, =1 {1 view} other {{{ video.views | myNumberFormatter }} views}}</ng-container>
+              <ng-container i18n *ngIf="displayOptions.views"
+                            title="{{ (video.views >= 1000 && displayOptions.views)
+                              ? (video.views + ' ' + (video.isLive ? 'views' : 'viewers'))
+                              : ''}}"
+              >
+                {video.views, plural, =1 {1 view} other {{{ video.views | myNumberFormatter }} views}}
+              </ng-container>
             </span>
           </span>
 

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
@@ -192,7 +192,7 @@ export class VideoMiniatureComponent implements OnInit {
 
   getExactNumberOfViews () {
     return (this.video.views >= 1000 && this.displayOptions.views)
-        ? (this.video.views + ' ' + (this.video.isLive ? 'viewers' : 'views'))
+        ? (this.video.views + ' ' + (this.video.isLive ? $localize`viewers` : $localize`views`))
         : ''
   }
 

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
@@ -192,7 +192,7 @@ export class VideoMiniatureComponent implements OnInit {
 
   getExactNumberOfViews () {
     return (this.video.views >= 1000 && this.displayOptions.views)
-        ? (this.video.views + ' ' + (this.video.isLive ? $localize`viewers` : $localize`views`))
+        ? `${this.video.views} ${this.video.isLive ? $localize`viewers` : $localize`views`}`
         : ''
   }
 

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
@@ -190,6 +190,12 @@ export class VideoMiniatureComponent implements OnInit {
     return this.video.videoChannelAvatarUrl
   }
 
+  getExactNumberOfViews () {
+    return (this.video.views >= 1000 && this.displayOptions.views)
+        ? (this.video.views + ' ' + (this.video.isLive ? 'viewers' : 'views'))
+        : ''
+  }
+
   loadActions () {
     if (this.displayVideoActions) this.showActions = true
 


### PR DESCRIPTION
add title for video-watch and video-miniature to see the details of numbers of views

## Description

Add information about the exact view of a video or live

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
fixes #3173

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

I asked a question on the issue about the translation, if you can help me :) 

https://github.com/Chocobozzz/PeerTube/issues/3173#issuecomment-732396928