### PR TITLE
Added Markdown formatting in all the fields of the "About" page

### DIFF
--- a/client/src/app/+about/about-instance/about-instance.component.html
+++ b/client/src/app/+about/about-instance/about-instance.component.html
@@ -21,7 +21,7 @@
 
     <div class="anchor" id="administrators-and-sustainability"></div>
     <a
-      *ngIf="html.administrator || maintenanceLifetime || businessModel"
+      *ngIf="html.administrator || html.maintenanceLifetime || html.businessModel"
       class="anchor-link"
       routerLink="/about/instance"
       fragment="administrators-and-sustainability"
@@ -47,7 +47,7 @@
       <div [innerHTML]="html.administrator"></div>
     </div>
 
-    <div class="block creation-reason" *ngIf="creationReason">
+    <div class="block creation-reason" *ngIf="html.creationReason">
       <div class="anchor" id="creation-reason"></div>
       <a
         class="anchor-link"
@@ -61,7 +61,7 @@
       <div [innerHTML]="html.creationReason"></div>
     </div>
 
-    <div class="block maintenance-lifetime" *ngIf="maintenanceLifetime">
+    <div class="block maintenance-lifetime" *ngIf="html.maintenanceLifetime">
       <div class="anchor" id="maintenance-lifetime"></div>
       <a
         class="anchor-link"
@@ -75,7 +75,7 @@
       <div [innerHTML]="html.maintenanceLifetime"></div>
     </div>
 
-    <div class="block business-model" *ngIf="businessModel">
+    <div class="block business-model" *ngIf="html.businessModel">
         <div class="anchor" id="business-model"></div>
         <a
           class="anchor-link"

--- a/client/src/app/+about/about-instance/about-instance.component.html
+++ b/client/src/app/+about/about-instance/about-instance.component.html
@@ -58,7 +58,7 @@
         <h3 i18n class="section-title">Why we created this instance</h3>
       </a>
 
-      <p>{{ creationReason }}</p>
+      <div [innerHTML]="html.creationReason"></div>
     </div>
 
     <div class="block maintenance-lifetime" *ngIf="maintenanceLifetime">
@@ -72,7 +72,7 @@
         <h3 i18n class="section-title">How long we plan to maintain this instance</h3>
       </a>
 
-      <p>{{ maintenanceLifetime }}</p>
+      <div [innerHTML]="html.maintenanceLifetime"></div>
     </div>
 
     <div class="block business-model" *ngIf="businessModel">
@@ -86,7 +86,7 @@
           <h3 i18n class="section-title">How we will pay for this instance</h3>
         </a>
 
-      <p>{{ businessModel }}</p>
+      <div [innerHTML]="html.businessModel"></div>
     </div>
 
     <div class="anchor" id="information"></div>

--- a/client/src/app/+about/about-instance/about-instance.component.ts
+++ b/client/src/app/+about/about-instance/about-instance.component.ts
@@ -24,12 +24,11 @@ export class AboutInstanceComponent implements OnInit, AfterViewChecked {
     codeOfConduct: '',
     moderationInformation: '',
     administrator: '',
+    creationReason: '',
+    maintenanceLifetime: '',
+    businessModel: '',
     hardwareInformation: ''
   }
-
-  creationReason = ''
-  maintenanceLifetime = ''
-  businessModel = ''
 
   languages: string[] = []
   categories: string[] = []
@@ -68,10 +67,6 @@ export class AboutInstanceComponent implements OnInit, AfterViewChecked {
     this.categories = categories
 
     this.shortDescription = about.instance.shortDescription
-
-    this.creationReason = about.instance.creationReason
-    this.maintenanceLifetime = about.instance.maintenanceLifetime
-    this.businessModel = about.instance.businessModel
 
     this.html = await this.instanceService.buildHtml(about)
 

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -221,7 +221,7 @@
                 <div i18n class="label-small-info">i.e. 2vCore 2GB RAM, a direct the link to the server you rent, etc.</div>
 
                 <my-markdown-textarea
-                  name="instanceHardwareInformation" formControlName="hardwareInformation" textareaMaxWidth="500px" textareaHeight="75px"
+                  name="instanceHardwareInformation" formControlName="hardwareInformation" textareaMaxWidth="500px"
                   [classes]="{ 'input-error': formErrors['instance.hardwareInformation'] }"
                 ></my-markdown-textarea>
 

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -162,11 +162,11 @@
             <div class="form-group form-group-right col-12 col-lg-8 col-xl-9">
 
               <div class="form-group">
-                <label i18n for="instanceAdministrator">Who is behind the instance?</label>
+                <label i18n for="instanceAdministrator">Who is behind the instance?</label><my-help helpType="markdownText"></my-help>
                 <div i18n class="label-small-info">A single person? A non-profit? A company?</div>
 
                 <my-markdown-textarea
-                  name="instanceAdministrator" formControlName="administrator" textareaMaxWidth="500px" textareaHeight="75px"
+                  name="instanceAdministrator" formControlName="administrator" textareaMaxWidth="500px"
                   [classes]="{ 'input-error': formErrors['instance.administrator'] }"
                 ></my-markdown-textarea>
 
@@ -174,35 +174,35 @@
               </div>
 
               <div class="form-group">
-                <label i18n for="instanceCreationReason">Why did you create this instance?</label>
+                <label i18n for="instanceCreationReason">Why did you create this instance?</label><my-help helpType="markdownText"></my-help>
                 <div i18n class="label-small-info">To share your personal videos? To open registrations and allow people to upload what they want?</div>
 
-                <textarea
-                  id="instanceCreationReason" formControlName="creationReason" class="small" class="form-control"
+                <my-markdown-textarea
+                  id="instanceCreationReason" formControlName="creationReason" textareaMaxWidth="500px"
                   [ngClass]="{ 'input-error': formErrors['instance.creationReason'] }"
-                ></textarea>
+                ></my-markdown-textarea>
                 <div *ngIf="formErrors.instance.creationReason" class="form-error">{{ formErrors.instance.creationReason }}</div>
               </div>
 
               <div class="form-group">
-                <label i18n for="instanceMaintenanceLifetime">How long do you plan to maintain this instance?</label>
+                <label i18n for="instanceMaintenanceLifetime">How long do you plan to maintain this instance?</label><my-help helpType="markdownText"></my-help>
                 <div i18n class="label-small-info">It's important to know for users who want to register on your instance</div>
 
-                <textarea
-                  id="instanceMaintenanceLifetime" formControlName="maintenanceLifetime" class="form-control small"
+                <my-markdown-textarea
+                  id="instanceMaintenanceLifetime" formControlName="maintenanceLifetime" textareaMaxWidth="500px"
                   [ngClass]="{ 'input-error': formErrors['instance.maintenanceLifetime'] }"
-                ></textarea>
+                ></my-markdown-textarea>
                 <div *ngIf="formErrors.instance.maintenanceLifetime" class="form-error">{{ formErrors.instance.maintenanceLifetime }}</div>
               </div>
 
               <div class="form-group">
-                <label i18n for="instanceBusinessModel">How will you finance the PeerTube server?</label>
+                <label i18n for="instanceBusinessModel">How will you finance the PeerTube server?</label><my-help helpType="markdownText"></my-help>
                 <div i18n class="label-small-info">With your own funds? With user donations? Advertising?</div>
 
-                <textarea
-                  id="instanceBusinessModel" formControlName="businessModel" class="form-control small"
+                <my-markdown-textarea
+                  id="instanceBusinessModel" formControlName="businessModel" textareaMaxWidth="500px"
                   [ngClass]="{ 'input-error': formErrors['instance.businessModel'] }"
-                ></textarea>
+                ></my-markdown-textarea>
                 <div *ngIf="formErrors.instance.businessModel" class="form-error">{{ formErrors.instance.businessModel }}</div>
               </div>
 

--- a/client/src/app/shared/shared-instance/instance.service.ts
+++ b/client/src/app/shared/shared-instance/instance.service.ts
@@ -45,6 +45,9 @@ export class InstanceService {
       codeOfConduct: '',
       moderationInformation: '',
       administrator: '',
+      creationReason: '',
+      maintenanceLifetime: '',
+      businessModel: '',
       hardwareInformation: ''
     }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

This PR introduces Markdown formatting in additional fields of the instance's "About" page.
It replaces plain-text textareas in the admin configuration by `my-markdown-textarea` as well as adds the `<my-help helpType="markdownText"></my-help>` to all of them.
It also registers the missing fields into `instance.service.ts` so that their content gets rendered as Markdown.
 
## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/3368.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

Since my computer is a bit of a potato, I can't efficiently run Docker on it. Therefore, I developed all of that on Gitpod.

The "new" code reuses the same "code" that previously existed. It was just a matter of tweaking some HTML tags and adding a few fields in `instance.service.ts`. I tested the code by running a dev PeerTube instance and modifying the "config" of the About page a few times (this included: not-formatted text, Markdown-formatted text, blank text fields...).

## Screenshots

Proof that the Markdown formatting now works in fields it previously didn't:

![image](https://user-images.githubusercontent.com/20014332/100452793-22278e00-30ba-11eb-9bb7-1e0fdc62795e.png)

