### PR TITLE
Fix themes colors by using SCSS variables

### DIFF
--- a/client/src/app/menu/menu.component.scss
+++ b/client/src/app/menu/menu.component.scss
@@ -164,7 +164,7 @@ menu {
       &:hover,
       &:focus-visible {
         my-global-icon {
-          @include apply-svg-color(var(--mainForegroundColor));
+          @include apply-svg-color(var(--menuForegroundColor));
         }
       }
 
@@ -269,7 +269,7 @@ menu {
     a, span[role=button] {
       display: inline-block;
       text-decoration: none;
-      color: pvar(--mainForegroundColor);
+      color: pvar(--menuForegroundColor);
       opacity: $footer-links-base-opacity;
       white-space: nowrap;
       font-size: 90%;
@@ -284,7 +284,7 @@ menu {
         height: 1.4rem;
 
         my-global-icon {
-          @include apply-svg-color(pvar(--mainForegroundColor));
+          @include apply-svg-color(pvar(--menuForegroundColor));
 
           display: flex;
           width: auto;
@@ -298,7 +298,7 @@ menu {
   .footer-copyleft small a {
     @include disable-default-a-behaviour;
 
-    color: pvar(--mainForegroundColor);
+    color: pvar(--menuForegroundColor);
     opacity: $footer-links-base-opacity - .2;
   }
 }

--- a/client/src/app/menu/menu.component.scss
+++ b/client/src/app/menu/menu.component.scss
@@ -164,7 +164,7 @@ menu {
       &:hover,
       &:focus-visible {
         my-global-icon {
-          @include apply-svg-color(var(--mainBackgroundColor));
+          @include apply-svg-color(var(--mainForegroundColor));
         }
       }
 
@@ -269,7 +269,7 @@ menu {
     a, span[role=button] {
       display: inline-block;
       text-decoration: none;
-      color: pvar(--mainBackgroundColor);
+      color: pvar(--mainForegroundColor);
       opacity: $footer-links-base-opacity;
       white-space: nowrap;
       font-size: 90%;
@@ -284,7 +284,7 @@ menu {
         height: 1.4rem;
 
         my-global-icon {
-          @include apply-svg-color(pvar(--mainBackgroundColor));
+          @include apply-svg-color(pvar(--mainForegroundColor));
 
           display: flex;
           width: auto;
@@ -298,7 +298,7 @@ menu {
   .footer-copyleft small a {
     @include disable-default-a-behaviour;
 
-    color: pvar(--mainBackgroundColor);
+    color: pvar(--mainForegroundColor);
     opacity: $footer-links-base-opacity - .2;
   }
 }

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -262,7 +262,7 @@ code {
     opacity: 0.6;
 
     &.active {
-      background-color: #f0f0f0;
+      background-color: pvar(--submenuColor);
     }
 
     &.active, &:hover, &:active, &:focus {

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -105,6 +105,7 @@ label {
 
 code {
   background-color: pvar(--greyBackgroundColor);
+  color: pvar(--greyForegroundColor);
   border-radius: 3px;
   padding: .2em .4em;
   margin: auto .4em;


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Fix hardcoded colors preventing correct theming.

Funded by @Monogramm.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

This PR will fix themes displays, like listed in https://framagit.org/framasoft/peertube/official-plugins/-/issues/21 of [peertube-theme-dark](https://framagit.org/framasoft/peertube/official-plugins/-/tree/master/peertube-theme-dark).

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
WIth dark theme:
* ![image](https://user-images.githubusercontent.com/6967675/100478741-6f245800-30ec-11eb-8b75-b80df71cc2cd.png)
* 
![image](https://user-images.githubusercontent.com/6967675/100478767-7d727400-30ec-11eb-9382-3f4d62fc0371.png)

With default theme:
* 
![image](https://user-images.githubusercontent.com/6967675/100478796-9d099c80-30ec-11eb-947a-abba505848b2.png)
* 
![image](https://user-images.githubusercontent.com/6967675/100478812-a85cc800-30ec-11eb-8d1b-92baea06ce18.png)
