### PR TITLE
Add input-password type

### DIFF
--- a/client/src/app/shared/shared-forms/dynamic-form-field.component.html
+++ b/client/src/app/shared/shared-forms/dynamic-form-field.component.html
@@ -5,6 +5,8 @@
 
   <input *ngIf="setting.type === 'input'" type="text" [id]="setting.name" [formControlName]="setting.name" />
 
+  <input *ngIf="setting.type === 'input-password'" type="password" [id]="setting.name" [formControlName]="setting.name" />
+
   <textarea *ngIf="setting.type === 'input-textarea'" type="text" [id]="setting.name" [formControlName]="setting.name"></textarea>
 
   <my-help *ngIf="setting.type === 'markdown-text'" helpType="markdownText"></my-help>

--- a/shared/models/plugins/register-client-form-field.model.ts
+++ b/shared/models/plugins/register-client-form-field.model.ts
@@ -1,7 +1,7 @@
 export interface RegisterClientFormFieldOptions {
   name: string
   label: string
-  type: 'input' | 'input-checkbox' | 'input-textarea' | 'markdown-text' | 'markdown-enhanced'
+  type: 'input' | 'input-checkbox' | 'input-password' | 'input-textarea' | 'markdown-text' | 'markdown-enhanced'
 
   descriptionHTML?: string
 

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -165,7 +165,7 @@ registerSetting({
   name: 'admin-name',
   label: 'Admin name',
   type: 'input',
-  // type: input | input-checkbox | input-textarea | markdown-text | markdown-enhanced
+  // type: input | input-checkbox | input-password | input-textarea | markdown-text | markdown-enhanced
   default: 'my super name'
 })
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
:sparkles: Add input-password to edit sensitive information without displaying content.

Funded by @Monogramm.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

* Fix #3375: Add input-password type 

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
