### PR TITLE
Select first available channel when accepting ownership change

### DIFF
--- a/client/src/app/+my-library/my-ownership/my-accept-ownership/my-accept-ownership.component.html
+++ b/client/src/app/+my-library/my-ownership/my-accept-ownership/my-accept-ownership.component.html
@@ -11,7 +11,7 @@
       <div class="peertube-select-container">
         <select formControlName="channel" id="channel" class="form-control">
           <option i18n value="undefined" disabled>Channel that will receive the video</option>
-          <option *ngFor="let channel of videoChannels" [value]="channel.id">{{ channel.displayName }}
+          <option *ngFor="let channel of videoChannels; let i = index;" [value]="channel.id" [selected]="i == 0">{{ channel.displayName }}
           </option>
         </select>
       </div>
@@ -28,7 +28,7 @@
 
       <input
           type="submit" i18n-value value="Accept" class="action-button-submit"
-          [disabled]="!form.valid"
+          [disabled]="!form.valid && videoChannels.length != 1"
           (click)="close()"
       >
     </div>

--- a/client/src/app/+my-library/my-ownership/my-accept-ownership/my-accept-ownership.component.html
+++ b/client/src/app/+my-library/my-ownership/my-accept-ownership/my-accept-ownership.component.html
@@ -11,7 +11,7 @@
       <div class="peertube-select-container">
         <select formControlName="channel" id="channel" class="form-control">
           <option i18n value="undefined" disabled>Channel that will receive the video</option>
-          <option *ngFor="let channel of videoChannels; let i = index;" [value]="channel.id" [selected]="i == 0">{{ channel.displayName }}
+          <option *ngFor="let channel of videoChannels" [value]="channel.id">{{ channel.displayName }}
           </option>
         </select>
       </div>
@@ -28,7 +28,6 @@
 
       <input
           type="submit" i18n-value value="Accept" class="action-button-submit"
-          [disabled]="!form.valid && videoChannels.length != 1"
           (click)="close()"
       >
     </div>

--- a/client/src/app/+my-library/my-ownership/my-accept-ownership/my-accept-ownership.component.ts
+++ b/client/src/app/+my-library/my-ownership/my-accept-ownership/my-accept-ownership.component.ts
@@ -47,6 +47,11 @@ export class MyAcceptOwnershipComponent extends FormReactive implements OnInit {
   }
 
   show (videoChangeOwnership: VideoChangeOwnership) {
+    // Select the first available channel by default
+    this.form.patchValue({
+      channel: this.videoChannels[0].id
+    })
+
     this.videoChangeOwnership = videoChangeOwnership
     this.modalService
       .open(this.modal, { centered: true })


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, with motivation and context -->

**This is a draft as the implementation it introduces must be discussed.**

Per request in #2240, I've slightly changed the select form in `my-accept-ownership.component.html` so that the first element of `videoChannels` is automatically selected. This, however, **occurs regardless of the amount of channels an account has**. This is the behavior I want to discuss with you. Should it remain as is, or should I refactor this PR to follow more closely the request of #2240?

Secondly, I had to change the `disable` condition of the "Accept" button. While the aforementioned change somehow worked fine if an account had multiple channels, the "Accept" button would remain greyed out if the account only had one channel.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/2240

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

I don't know if tests should be added to the tests suite and/or modified.

Manual testing showed that the changes introduced by this PR are working as expected on my end.

## Screenshots

These screenshots are taken just right after clicking on the "checkmark" button to open the popup.

**When the account only has one channel**
![image](https://user-images.githubusercontent.com/20014332/100547204-bb46d800-3265-11eb-98c6-362b58212c32.png)

**When the account has 2 or more channels**
![image](https://user-images.githubusercontent.com/20014332/100547186-9c484600-3265-11eb-823e-2d5eb735a2f9.png)