### PR TITLE
Trigger a Gitpod dev image rebuild (in order to get upstream's Node.js 12 upgrade)

### DIFF
--- a/support/docker/gitpod/Dockerfile
+++ b/support/docker/gitpod/Dockerfile
@@ -1,6 +1,6 @@
 FROM gitpod/workspace-postgres
 
-# Gitpod does not rebuild dev images unless *some* change is made to the Dockerfile.
+# Gitpod will not rebuild PeerTube's dev image unless *some* change is made to this Dockerfile.
 # To trigger a rebuild, simply increase this counter:
 ENV TRIGGER_REBUILD 1
 

--- a/support/docker/gitpod/Dockerfile
+++ b/support/docker/gitpod/Dockerfile
@@ -1,5 +1,9 @@
 FROM gitpod/workspace-postgres
 
+# Gitpod does not rebuild dev images unless *some* change is made to the Dockerfile.
+# To trigger a rebuild, simply increase this counter:
+ENV TRIGGER_REBUILD 1
+
 # Install PeerTube's dependencies.
 RUN sudo apt-get update -q && sudo apt-get install -qy \
  ffmpeg \


### PR DESCRIPTION

## Description

PeerTube's Gitpod dev image still uses Node.js 10, while [upstream]() was updated to Node.js 12.

The reason is that no change has been made to the Dockerfile in a while.

Adding a trivial change invalidates & rebuilds the dev image, and I've also added a comment to explain why.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
