### PR TITLE
register: hide channel step if upload quota is 0

### DIFF
--- a/client/src/app/+signup/+register/custom-stepper.component.html
+++ b/client/src/app/+signup/+register/custom-stepper.component.html
@@ -1,5 +1,5 @@
 <section class="container">
-  <header>
+  <header *ngIf="steps.length > 2">
     <ng-container *ngFor="let step of steps; let i = index; let isLast = last;">
       <div
         class="step-info" [ngClass]="{ active: selectedIndex === i, completed: isCompleted(step) }" [attr.aria-current]="selectedIndex === i"

--- a/client/src/app/+signup/+register/register-step-user.component.html
+++ b/client/src/app/+signup/+register/register-step-user.component.html
@@ -1,5 +1,9 @@
 <form role="form" [formGroup]="form">
 
+  <div class="capability-information alert alert-info" i18n *ngIf="videoUploadDisabled">
+    Video uploads are disabled on this instance, hence your account won't be able to upload videos.
+  </div>
+
   <div class="form-group">
     <label for="displayName" i18n>Display name</label>
 

--- a/client/src/app/+signup/+register/register-step-user.component.ts
+++ b/client/src/app/+signup/+register/register-step-user.component.ts
@@ -19,6 +19,7 @@ import { FormReactive, FormValidatorService } from '@app/shared/shared-forms'
 })
 export class RegisterStepUserComponent extends FormReactive implements OnInit {
   @Input() hasCodeOfConduct = false
+  @Input() videoUploadDisabled = false
 
   @Output() formBuilt = new EventEmitter<FormGroup>()
   @Output() termsClick = new EventEmitter<void>()

--- a/client/src/app/+signup/+register/register.component.html
+++ b/client/src/app/+signup/+register/register.component.html
@@ -13,14 +13,16 @@
         <cdk-step [stepControl]="formStepUser" i18n-label label="User">
           <my-register-step-user
             [hasCodeOfConduct]="!!aboutHtml.codeOfConduct"
+            [videoUploadDisabled]="videoUploadDisabled"
             (formBuilt)="onUserFormBuilt($event)" (termsClick)="onTermsClick()" (codeOfConductClick)="onCodeOfConductClick()"
           >
           </my-register-step-user>
 
-          <button i18n cdkStepperNext [disabled]="!formStepUser || !formStepUser.valid">Next</button>
+          <button i18n cdkStepperNext [disabled]="!formStepUser || !formStepUser.valid"
+            (click)="signup()">{{ videoUploadDisabled ? 'Signup' : 'Next' }}</button>
         </cdk-step>
 
-        <cdk-step [stepControl]="formStepChannel" i18n-label label="Channel">
+        <cdk-step [stepControl]="formStepChannel" i18n-label label="Channel" *ngIf="!videoUploadDisabled">
           <my-register-step-channel (formBuilt)="onChannelFormBuilt($event)" [username]="getUsername()"></my-register-step-channel>
 
           <button i18n cdkStepperNext (click)="signup()"

--- a/client/src/app/+signup/+register/register.component.ts
+++ b/client/src/app/+signup/+register/register.component.ts
@@ -30,6 +30,8 @@ export class RegisterComponent implements OnInit {
     administrator: ''
   }
 
+  videoUploadDisabled: boolean
+
   formStepUser: FormGroup
   formStepChannel: FormGroup
 
@@ -51,6 +53,8 @@ export class RegisterComponent implements OnInit {
 
   ngOnInit (): void {
     this.serverConfig = this.route.snapshot.data.serverConfig
+
+    this.videoUploadDisabled = this.serverConfig.user.videoQuota === 0
 
     this.instanceService.getAbout()
       .subscribe(
@@ -102,7 +106,7 @@ export class RegisterComponent implements OnInit {
     this.error = null
 
     const body: UserRegister = await this.hooks.wrapObject(
-      Object.assign(this.formStepUser.value, { channel: this.formStepChannel.value }),
+      Object.assign(this.formStepUser.value, { channel: this.videoUploadDisabled ? undefined : this.formStepChannel.value }),
       'signup',
       'filter:api.signup.registration.create.params'
     )


### PR DESCRIPTION
## Description

When default upload quota is set to 0, the channel step in the registration will be hidden, as proposed in #782 

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

closing #782 
relates #2805 
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->
I couldn't find any appropriate way to add tests since there's no unit tests for the client and the tests in `server/tests/client.ts` seems to be on a higher lever than this feature.

## Screenshots

![videodisabled](https://user-images.githubusercontent.com/6680299/100975795-da33bb80-353e-11eb-9364-31e8972bc44b.gif)
