### PR TITLE
Added 'total downloaded' from server and peers in the player

### DIFF
--- a/client/src/assets/player/p2p-media-loader/p2p-media-loader-plugin.ts
+++ b/client/src/assets/player/p2p-media-loader/p2p-media-loader-plugin.ts
@@ -153,6 +153,7 @@ class P2pMediaLoaderPlugin extends Plugin {
       this.statsHTTPBytes.pendingUpload = []
 
       return this.player.trigger('p2pInfo', {
+        source: 'p2p-media-loader',
         http: {
           downloadSpeed: httpDownloadSpeed,
           uploadSpeed: httpUploadSpeed,

--- a/client/src/assets/player/peertube-videojs-typings.ts
+++ b/client/src/assets/player/peertube-videojs-typings.ts
@@ -175,6 +175,8 @@ type AutoResolutionUpdateData = {
 }
 
 type PlayerNetworkInfo = {
+  source: 'webtorrent' | 'p2p-media-loader'
+
   http: {
     downloadSpeed: number
     uploadSpeed: number

--- a/client/src/assets/player/videojs-components/p2p-info-button.ts
+++ b/client/src/assets/player/videojs-components/p2p-info-button.ts
@@ -85,14 +85,16 @@ class P2pInfoButton extends Button {
       const numPeers = p2pStats.numPeers
 
       subDivWebtorrent.title = this.player().localize('Total downloaded: ') + totalDownloaded.join(' ') + '\n'
-      if (data.source == 'p2p-media-loader') {
+
+      if (data.source === 'p2p-media-loader') {
         const downloadedFromServer = bytes(httpStats.downloaded).join(' ')
         const downloadedFromPeers = bytes(p2pStats.downloaded).join(' ')
 
-        subDivWebtorrent.title += '* ' + this.player().localize('From the server: ') + downloadedFromServer + '\n' +
+        subDivWebtorrent.title +=
+          '* ' + this.player().localize('From the server: ') + downloadedFromServer + '\n' +
           '* ' + this.player().localize('From peers: ') + downloadedFromPeers + '\n'
       }
-      subDivWebtorrent.title += this.player().localize('Total uploaded: ' + totalUploaded.join(' '))
+      subDivWebtorrent.title += this.player().localize('Total uploaded: ') + totalUploaded.join(' ')
 
       downloadSpeedNumber.textContent = downloadSpeed[ 0 ]
       downloadSpeedUnit.textContent = ' ' + downloadSpeed[ 1 ]

--- a/client/src/assets/player/videojs-components/p2p-info-button.ts
+++ b/client/src/assets/player/videojs-components/p2p-info-button.ts
@@ -84,8 +84,15 @@ class P2pInfoButton extends Button {
       const totalUploaded = bytes(p2pStats.uploaded + httpStats.uploaded)
       const numPeers = p2pStats.numPeers
 
-      subDivWebtorrent.title = this.player().localize('Total downloaded: ') + totalDownloaded.join(' ') + '\n' +
-        this.player().localize('Total uploaded: ' + totalUploaded.join(' '))
+      subDivWebtorrent.title = this.player().localize('Total downloaded: ') + totalDownloaded.join(' ') + '\n'
+      if (data.source == 'p2p-media-loader') {
+        const downloadedFromServer = bytes(httpStats.downloaded).join(' ')
+        const downloadedFromPeers = bytes(p2pStats.downloaded).join(' ')
+
+        subDivWebtorrent.title += '* ' + this.player().localize('From the server: ') + downloadedFromServer + '\n' +
+          '* ' + this.player().localize('From peers: ') + downloadedFromPeers + '\n'
+      }
+      subDivWebtorrent.title += this.player().localize('Total uploaded: ' + totalUploaded.join(' '))
 
       downloadSpeedNumber.textContent = downloadSpeed[ 0 ]
       downloadSpeedUnit.textContent = ' ' + downloadSpeed[ 1 ]

--- a/client/src/assets/player/webtorrent/webtorrent-plugin.ts
+++ b/client/src/assets/player/webtorrent/webtorrent-plugin.ts
@@ -487,6 +487,7 @@ class WebTorrentPlugin extends Plugin {
       if (this.webtorrent.downloadSpeed !== 0) this.downloadSpeeds.push(this.webtorrent.downloadSpeed)
 
       return this.player.trigger('p2pInfo', {
+        source: 'webtorrent',
         http: {
           downloadSpeed: 0,
           uploadSpeed: 0,


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

This PR implements #3384 with the changes @Chocobozzz suggested in https://github.com/Chocobozzz/PeerTube/issues/3384#issuecomment-737112057. Namely:
* adding a `source` field in `PlayerNetworkInfo`
* adding the requested information in `subDivWebtorrent.title` (from `p2p-info-button.ts`) **if** the server uses HLS.

WebTorrent is seemingly not able to tell the difference between the server and other peers, hence why it's left out of that PR.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/3384

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->

![image](https://user-images.githubusercontent.com/20014332/101043050-2520f380-357e-11eb-9abf-05a49c69545e.png)

