### PR TITLE
server accounts/videos: trigger filter hook

### DIFF
--- a/server/controllers/api/accounts.ts
+++ b/server/controllers/api/accounts.ts
@@ -176,12 +176,12 @@ async function listAccountVideos (req: express.Request, res: express.Response) {
     accountId: account.id,
     user: res.locals.oauth ? res.locals.oauth.token.User : undefined,
     countVideos
-  }, 'filter:api.videos.list.params')
+  }, 'filter:api.accounts.videos.list.params')
 
   const resultList = await Hooks.wrapPromiseFun(
     VideoModel.listForApi,
     apiOptions,
-    'filter:api.videos.list.result'
+    'filter:api.accounts.videos.list.result'
   )
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))

--- a/server/controllers/api/accounts.ts
+++ b/server/controllers/api/accounts.ts
@@ -2,6 +2,7 @@ import * as express from 'express'
 import { getServerActor } from '@server/models/application/application'
 import { buildNSFWFilter, getCountVideos, isUserAbleToSearchRemoteURI } from '../../helpers/express-utils'
 import { getFormattedObjects } from '../../helpers/utils'
+import { Hooks } from '../../lib/plugins/hooks'
 import { JobQueue } from '../../lib/job-queue'
 import {
   asyncMiddleware,
@@ -158,7 +159,7 @@ async function listAccountVideos (req: express.Request, res: express.Response) {
   const followerActorId = isUserAbleToSearchRemoteURI(res) ? null : undefined
   const countVideos = getCountVideos(req)
 
-  const resultList = await VideoModel.listForApi({
+  const apiOptions = await Hooks.wrapObject({
     followerActorId,
     start: req.query.start,
     count: req.query.count,
@@ -175,7 +176,13 @@ async function listAccountVideos (req: express.Request, res: express.Response) {
     accountId: account.id,
     user: res.locals.oauth ? res.locals.oauth.token.User : undefined,
     countVideos
-  })
+  }, 'filter:api.videos.list.params')
+
+  const resultList = await Hooks.wrapPromiseFun(
+    VideoModel.listForApi,
+    apiOptions,
+    'filter:api.videos.list.result'
+  )
 
   return res.json(getFormattedObjects(resultList.data, resultList.total))
 }

--- a/server/tests/fixtures/peertube-plugin-test/main.js
+++ b/server/tests/fixtures/peertube-plugin-test/main.js
@@ -40,6 +40,26 @@ async function register ({ registerHook, registerSetting, settingsManager, stora
   })
 
   registerHook({
+    target: 'filter:api.accounts.videos.list.params',
+    handler: obj => addToCount(obj)
+  })
+
+  registerHook({
+    target: 'filter:api.accounts.videos.list.result',
+    handler: obj => addToTotal(obj, 2)
+  })
+
+  registerHook({
+    target: 'filter:api.video-channels.videos.list.params',
+    handler: obj => addToCount(obj, 3)
+  })
+
+  registerHook({
+    target: 'filter:api.video-channels.videos.list.result',
+    handler: obj => addToTotal(obj, 3)
+  })
+
+  registerHook({
     target: 'filter:api.video.get.result',
     handler: video => {
       video.name += ' <3'
@@ -167,14 +187,14 @@ module.exports = {
 
 // ############################################################################
 
-function addToCount (obj) {
-  return Object.assign({}, obj, { count: obj.count + 1 })
+function addToCount (obj, amount = 1) {
+  return Object.assign({}, obj, { count: obj.count + amount })
 }
 
-function addToTotal (result) {
+function addToTotal (result, amount = 1) {
   return {
     data: result.data,
-    total: result.total + 1
+    total: result.total + amount
   }
 }
 

--- a/server/tests/plugins/filter-hooks.ts
+++ b/server/tests/plugins/filter-hooks.ts
@@ -8,9 +8,11 @@ import {
   addVideoCommentThread,
   createLive,
   doubleFollow,
+  getAccountVideos,
   getConfig,
   getPluginTestPath,
   getVideo,
+  getVideoChannelVideos,
   getVideoCommentThreads,
   getVideosList,
   getVideosListPagination,
@@ -88,6 +90,34 @@ describe('Test plugin filter hooks', function () {
 
     // Plugin do +1 to the total result
     expect(res.body.total).to.equal(11)
+  })
+
+  it('Should run filter:api.accounts.videos.list.params', async function () {
+    const res = await getAccountVideos(servers[0].url, servers[0].accessToken, 'root', 0, 2)
+
+    // 1 plugin do +1 to the count parameter
+    expect(res.body.data).to.have.lengthOf(3)
+  })
+
+  it('Should run filter:api.accounts.videos.list.result', async function () {
+    const res = await getAccountVideos(servers[0].url, servers[0].accessToken, 'root', 0, 2)
+
+    // Plugin do +2 to the total result
+    expect(res.body.total).to.equal(12)
+  })
+
+  it('Should run filter:api.video-channels.videos.list.params', async function () {
+    const res = await getVideoChannelVideos(servers[0].url, servers[0].accessToken, 'root_channel', 0, 2)
+
+    // 1 plugin do +3 to the count parameter
+    expect(res.body.data).to.have.lengthOf(5)
+  })
+
+  it('Should run filter:api.video-channels.videos.list.result', async function () {
+    const res = await getAccountVideos(servers[0].url, servers[0].accessToken, 'root_channel', 0, 2)
+
+    // Plugin do +3 to the total result
+    expect(res.body.total).to.equal(13)
   })
 
   it('Should run filter:api.video.get.result', async function () {

--- a/shared/models/plugins/server-hook.model.ts
+++ b/shared/models/plugins/server-hook.model.ts
@@ -5,6 +5,15 @@ export const serverFilterHookObject = {
   // (used by the trending page, recently-added page, local page etc)
   'filter:api.videos.list.params': true,
   'filter:api.videos.list.result': true,
+
+  // Filter params/result used to list account videos for the REST API
+  'filter:api.accounts.videos.list.params': true,
+  'filter:api.accounts.videos.list.result': true,
+
+  // Filter params/result used to list account videos for the REST API
+  'filter:api.video-channels.videos.list.params': true,
+  'filter:api.video-channels.videos.list.result': true,
+
   // Filter the result of the get function
   // Used to get detailed video information (video watch page for example)
   'filter:api.video.get.result': true,


### PR DESCRIPTION
## Description
`filter:api.videos.list.*` hooks weren't triggered when listing an accounts videos. It's still not working for `/me/videos` since I don't know how to solve it there. I
<!-- Please include a summary of the change, with motivation and context -->

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

1) Visit an accounts videos page (ie /accounts/root/videos) and verify it's not broken
1) Install a plugin that hooks `filter:api.videos.list.result` and verify it works (for example https://www.npmjs.com/package/peertube-plugin-sort-originally-published-at)