### PR TITLE
add optional authentication for plugin routes

### DIFF
--- a/server/controllers/plugins.ts
+++ b/server/controllers/plugins.ts
@@ -8,6 +8,7 @@ import { PluginType } from '../../shared/models/plugins/plugin.type'
 import { isTestInstance } from '../helpers/core-utils'
 import { getCompleteLocale, is18nLocale } from '../../shared/core-utils/i18n'
 import { logger } from '@server/helpers/logger'
+import { optionalAuthenticate } from '@server/middlewares/oauth'
 
 const sendFileOptions = {
   maxAge: '30 days',
@@ -44,11 +45,13 @@ pluginsRouter.get('/plugins/:pluginName/:pluginVersion/client-scripts/:staticEnd
 
 pluginsRouter.use('/plugins/:pluginName/router',
   getPluginValidator(PluginType.PLUGIN, false),
+  optionalAuthenticate,
   servePluginCustomRoutes
 )
 
 pluginsRouter.use('/plugins/:pluginName/:pluginVersion/router',
   getPluginValidator(PluginType.PLUGIN),
+  optionalAuthenticate,
   servePluginCustomRoutes
 )
 

--- a/server/middlewares/oauth.ts
+++ b/server/middlewares/oauth.ts
@@ -19,6 +19,8 @@ function authenticate (req: express.Request, res: express.Response, next: expres
         .end()
     }
 
+    res.locals.authenticated = true
+
     return next()
   })
 }

--- a/server/tests/fixtures/peertube-plugin-test-five/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-five/main.js
@@ -4,6 +4,8 @@ async function register ({
   const router = getRouter()
   router.get('/ping', (req, res) => res.json({ message: 'pong' }))
 
+  router.get('/is-authenticated', (req, res) => res.json({ isAuthenticated: res.locals.authenticated }))
+
   router.post('/form/post/mirror', (req, res) => {
     res.json(req.body)
   })

--- a/server/tests/plugins/plugin-router.ts
+++ b/server/tests/plugins/plugin-router.ts
@@ -52,7 +52,7 @@ describe('Test plugin helpers', function () {
         statusCodeExpected: 200
       })
 
-      expect(res.body.isAuthenticated).to.equal(undefined)
+      expect(res.body.isAuthenticated).to.equal(true)
 
       const secRes = await makeGetRequest({
         url: server.url,

--- a/server/tests/plugins/plugin-router.ts
+++ b/server/tests/plugins/plugin-router.ts
@@ -43,6 +43,27 @@ describe('Test plugin helpers', function () {
     }
   })
 
+  it('Should check if authenticated', async function () {
+    for (const path of basePaths) {
+      const res = await makeGetRequest({
+        url: server.url,
+        path: path + 'is-authenticated',
+        token: server.accessToken,
+        statusCodeExpected: 200
+      })
+
+      expect(res.body.isAuthenticated).to.equal(undefined)
+
+      const secRes = await makeGetRequest({
+        url: server.url,
+        path: path + 'is-authenticated',
+        statusCodeExpected: 200
+      })
+
+      expect(secRes.body.isAuthenticated).to.equal(false)
+    }
+  })
+
   it('Should mirror post body', async function () {
     const body = {
       hello: 'world',


### PR DESCRIPTION
## Description
* When creating custom routes with plugins, let the plugin author check if the user is authenticated or not.
* `authenticate` middleware now sets `res.locals.authenticated` to `true` upon successful authentication.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help