### PR TITLE
Fix PostreSQL initialization for Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,11 @@ ports:
 - port: 9000
   onOpen: ignore
 tasks:
-- command: redis-server
-- before: export NODE_CONFIG="{\"import\":{\"videos\":{\"torrent\":{\"enabled\":false}}},\"webserver\":{\"hostname\":\"$(gp url 3000 | cut -d/ -f3)\",\"port\":\"443\",\"https\":true}}"
-  init: yarn install --pure-lockfile
+- name: Redis
+  command: redis-server
+- name: PeerTube
+  before: export NODE_CONFIG="{\"import\":{\"videos\":{\"torrent\":{\"enabled\":false}}},\"webserver\":{\"hostname\":\"$(gp url 3000 | cut -d/ -f3)\",\"port\":\"443\",\"https\":true}}"
+  init: >
+    psql -h localhost -d postgres --file=support/docker/gitpod/setup_postgres.sql &&
+    yarn install --pure-lockfile
   command: npm run dev

--- a/support/docker/gitpod/Dockerfile
+++ b/support/docker/gitpod/Dockerfile
@@ -9,7 +9,3 @@ RUN sudo apt-get update -q && sudo apt-get install -qy \
  ffmpeg \
  openssl \
  redis-server
-
-# Set up PostgreSQL.
-COPY --chown=gitpod:gitpod support/docker/gitpod/setup_postgres.sql /tmp/
-RUN pg_start && psql -h localhost -d postgres --file=/tmp/setup_postgres.sql && pg_stop


### PR DESCRIPTION
## Description

Fixes https://github.com/gitpod-io/gitpod/issues/2429

> Unable to boot a Workspace : fails at "Building Workspace Image"

---

Solution: https://github.com/gitpod-io/gitpod/issues/2429#issuecomment-739238805

> I think I know what the problem is. PeerTube's Gitpod Dockerfile attempts to initialize a PostgreSQL database:
> 
> https://github.com/Chocobozzz/PeerTube/blob/95bd9515b86e577033d9929c829c77c0df761acf/support/docker/gitpod/Dockerfile#L15
> 
> For some reason, this now fails with "Permission denied", when `pg_start` tries to create `/workspace/.pgsql/data` with `mkdir -p`:
> 
> https://github.com/gitpod-io/workspace-images/blob/c9896cde76e0698b1ed1b93ad464d77f87dd96e6/postgres/Dockerfile#L13
> 
> Probably user `gitpod` is not authorized to create directories under `/`.
> 
> However, probably setting up the PostgreSQL database doesn't even make sense in the Dockerfile, because everything under `/workspace` will get replaced anyway when you start a Gitpod workspace (because `/workspace` is replaced by a mounted partition where the repository then gets cloned into -- i.e. everything you put in `/workspace` in the Dockerfile will be gone at runtime).
> 
> So, instead, I think the proper fix is to set up the PostgreSQL database not in the Dockerfile but in the `.gitpod.yml` tasks once the workspace is running.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Can be tested by opening my fork in Gitpod: https://gitpod.io/#https://github.com/jankeromnes/PeerTube

## Screenshots
<img width="1440" alt="Screenshot 2020-12-05 at 12 37 01" src="https://user-images.githubusercontent.com/599268/101241469-9daac000-36f6-11eb-9430-8b39ecb322dd.png">

