### PR TITLE
hls-plugin: destroy hls upon third err

### DIFF
--- a/client/src/assets/player/p2p-media-loader/hls-plugin.ts
+++ b/client/src/assets/player/p2p-media-loader/hls-plugin.ts
@@ -226,6 +226,7 @@ class Html5Hlsjs {
 
     if (this.errorCounts[ Hlsjs.ErrorTypes.MEDIA_ERROR ] > 2) {
       console.info('bubbling media error up to VIDEOJS')
+      this.hls.destroy()
       this.tech.error = () => error
       this.tech.trigger('error')
       return


### PR DESCRIPTION

## Description
According to hls.js docs `hls.destroy()` should be called
https://github.com/video-dev/hls.js/blob/master/docs/API.md#final-step-destroying-switching-between-streams

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

I think it's a bit fussy to create a unit test just to verify this, but if you want to I'll add one.