### PR TITLE
WebTorrent Plugin: Clearify error message

### DIFF
--- a/client/src/assets/player/webtorrent/webtorrent-plugin.ts
+++ b/client/src/assets/player/webtorrent/webtorrent-plugin.ts
@@ -139,6 +139,10 @@ class WebTorrentPlugin extends Plugin {
         : this.pickAverageVideoFile()
     }
 
+    if (videoFile === undefined) {
+      throw Error(`Can't update video file since videoFile is undefined.`)
+    }
+
     // Don't add the same video file once again
     if (this.currentVideoFile !== undefined && this.currentVideoFile.magnetUri === videoFile.magnetUri) {
       return

--- a/client/src/assets/player/webtorrent/webtorrent-plugin.ts
+++ b/client/src/assets/player/webtorrent/webtorrent-plugin.ts
@@ -139,7 +139,7 @@ class WebTorrentPlugin extends Plugin {
         : this.pickAverageVideoFile()
     }
 
-    if (videoFile === undefined) {
+    if (!!videoFile) {
       throw Error(`Can't update video file since videoFile is undefined.`)
     }
 

--- a/client/src/assets/player/webtorrent/webtorrent-plugin.ts
+++ b/client/src/assets/player/webtorrent/webtorrent-plugin.ts
@@ -122,8 +122,15 @@ class WebTorrentPlugin extends Plugin {
     return this.currentVideoFile ? this.currentVideoFile.resolution.id : -1
   }
 
+  private getVideoFile(): VideoFile {
+    const savedAverageBandwidth = getAverageBandwidthInStore()
+    return savedAverageBandwidth
+      ? this.getAppropriateFile(savedAverageBandwidth)
+      : this.pickAverageVideoFile()
+}
+
   updateVideoFile (
-    videoFile?: VideoFile,
+    videoFile: VideoFile,
     options: {
       forcePlay?: boolean,
       seek?: number,
@@ -131,14 +138,6 @@ class WebTorrentPlugin extends Plugin {
     } = {},
     done: () => void = () => { /* empty */ }
   ) {
-    // Automatically choose the adapted video file
-    if (videoFile === undefined) {
-      const savedAverageBandwidth = getAverageBandwidthInStore()
-      videoFile = savedAverageBandwidth
-        ? this.getAppropriateFile(savedAverageBandwidth)
-        : this.pickAverageVideoFile()
-    }
-
     if (videoFile === undefined) {
       throw Error(`Can't update video file since videoFile is undefined.`)
     }
@@ -427,7 +426,7 @@ class WebTorrentPlugin extends Plugin {
     if (this.autoplay) {
       this.player.posterImage.hide()
 
-      return this.updateVideoFile(undefined, { forcePlay: true, seek: this.startTime })
+      return this.updateVideoFile(this.getVideoFile(), { forcePlay: true, seek: this.startTime })
     }
 
     // Proxy first play
@@ -436,7 +435,7 @@ class WebTorrentPlugin extends Plugin {
       this.player.addClass('vjs-has-big-play-button-clicked')
       this.player.play = oldPlay
 
-      this.updateVideoFile(undefined, { forcePlay: true, seek: this.startTime })
+      this.updateVideoFile(this.getVideoFile(), { forcePlay: true, seek: this.startTime })
     }
   }
 

--- a/client/src/assets/player/webtorrent/webtorrent-plugin.ts
+++ b/client/src/assets/player/webtorrent/webtorrent-plugin.ts
@@ -68,7 +68,7 @@ class WebTorrentPlugin extends Plugin {
 
   private downloadSpeeds: number[] = []
 
-  constructor (player: videojs.Player, options: WebtorrentPluginOptions) {
+  constructor (player: videojs.Player, options?: WebtorrentPluginOptions) {
     super(player)
 
     this.startTime = timeToInt(options.startTime)
@@ -129,7 +129,7 @@ class WebTorrentPlugin extends Plugin {
       : this.pickAverageVideoFile()
 }
 
-  private updateVideoFile (
+  updateVideoFile (
     videoFile: VideoFile,
     options: {
       forcePlay?: boolean,

--- a/client/src/assets/player/webtorrent/webtorrent-plugin.ts
+++ b/client/src/assets/player/webtorrent/webtorrent-plugin.ts
@@ -68,7 +68,7 @@ class WebTorrentPlugin extends Plugin {
 
   private downloadSpeeds: number[] = []
 
-  constructor (player: videojs.Player, options?: WebtorrentPluginOptions) {
+  constructor (player: videojs.Player, options: WebtorrentPluginOptions) {
     super(player)
 
     this.startTime = timeToInt(options.startTime)
@@ -129,7 +129,7 @@ class WebTorrentPlugin extends Plugin {
       : this.pickAverageVideoFile()
 }
 
-  updateVideoFile (
+  private updateVideoFile (
     videoFile: VideoFile,
     options: {
       forcePlay?: boolean,

--- a/client/src/assets/player/webtorrent/webtorrent-plugin.ts
+++ b/client/src/assets/player/webtorrent/webtorrent-plugin.ts
@@ -122,15 +122,8 @@ class WebTorrentPlugin extends Plugin {
     return this.currentVideoFile ? this.currentVideoFile.resolution.id : -1
   }
 
-  private getVideoFile(): VideoFile {
-    const savedAverageBandwidth = getAverageBandwidthInStore()
-    return savedAverageBandwidth
-      ? this.getAppropriateFile(savedAverageBandwidth)
-      : this.pickAverageVideoFile()
-}
-
   updateVideoFile (
-    videoFile: VideoFile,
+    videoFile?: VideoFile,
     options: {
       forcePlay?: boolean,
       seek?: number,
@@ -138,6 +131,14 @@ class WebTorrentPlugin extends Plugin {
     } = {},
     done: () => void = () => { /* empty */ }
   ) {
+    // Automatically choose the adapted video file
+    if (videoFile === undefined) {
+      const savedAverageBandwidth = getAverageBandwidthInStore()
+      videoFile = savedAverageBandwidth
+        ? this.getAppropriateFile(savedAverageBandwidth)
+        : this.pickAverageVideoFile()
+    }
+
     if (videoFile === undefined) {
       throw Error(`Can't update video file since videoFile is undefined.`)
     }
@@ -426,7 +427,7 @@ class WebTorrentPlugin extends Plugin {
     if (this.autoplay) {
       this.player.posterImage.hide()
 
-      return this.updateVideoFile(this.getVideoFile(), { forcePlay: true, seek: this.startTime })
+      return this.updateVideoFile(undefined, { forcePlay: true, seek: this.startTime })
     }
 
     // Proxy first play
@@ -435,7 +436,7 @@ class WebTorrentPlugin extends Plugin {
       this.player.addClass('vjs-has-big-play-button-clicked')
       this.player.play = oldPlay
 
-      this.updateVideoFile(this.getVideoFile(), { forcePlay: true, seek: this.startTime })
+      this.updateVideoFile(undefined, { forcePlay: true, seek: this.startTime })
     }
   }
 


### PR DESCRIPTION
## Description
This PR shouldn't change any functionality, but just give a more clear error message when `videoFiles`

## Related issues
#3412 

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Start the dev server
1) Start a video
1) Verify nothing is broken