### PR TITLE
Video embed page: Inject custom CSS and set page title

### DIFF
--- a/client/src/standalone/videos/embed.html
+++ b/client/src/standalone/videos/embed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>PeerTube</title>
+    <!-- title tag -->
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/client/src/standalone/videos/embed.html
+++ b/client/src/standalone/videos/embed.html
@@ -12,7 +12,7 @@
     <link rel="icon" type="image/png" href="/client/assets/images/favicon.png" />
   </head>
 
-  <body id="custom-css">
+  <body id="custom-css" class="standalone-video-embed">
 
     <div id="error-block">
       <h1 id="error-title"></h1>

--- a/client/src/standalone/videos/embed.html
+++ b/client/src/standalone/videos/embed.html
@@ -8,6 +8,7 @@
     <meta name="robots" content="noindex">
     <meta property="og:platform" content="PeerTube" />
 
+    <!-- custom css tag -->
     <link rel="icon" type="image/png" href="/client/assets/images/favicon.png" />
   </head>
 

--- a/client/webpack/webpack.video-embed.js
+++ b/client/webpack/webpack.video-embed.js
@@ -122,7 +122,15 @@ module.exports = function () {
         title: 'PeerTube',
         chunksSortMode: 'auto',
         inject: 'body',
-        chunks: ['video-embed']
+        chunks: ['video-embed'],
+        minify: {
+          collapseWhitespace: true,
+          removeComments: false,
+          removeRedundantAttributes: true,
+          removeScriptTypeAttributes: true,
+          removeStyleLinkTypeAttributes: true,
+          useShortDoctype: true
+        }
       }),
 
       new HtmlWebpackPlugin({

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -184,6 +184,7 @@ export class ClientHtml {
     let html = buffer.toString()
     html = await ClientHtml.addAsyncPluginCSS(html)
     html = ClientHtml.addCustomCSS(html)
+    html = ClientHtml.addTitleTag(html)
 
     ClientHtml.htmlCache[path] = html
 

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -183,6 +183,7 @@ export class ClientHtml {
 
     let html = buffer.toString()
     html = await ClientHtml.addAsyncPluginCSS(html)
+    html = ClientHtml.addCustomCSS(html)
 
     ClientHtml.htmlCache[path] = html
 


### PR DESCRIPTION
## Description
* Add the custom CSS to video embed HTML page.
* Add a CSS class to the body element to make it easier to target.
* Set HTML title at embed page to the instance name.

## Related issues
closes #3420

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, light tests as follows are enough

1) Set `.standalone-video-embed { background: green; } .standalone-video-embed #video-wrapper { display: none; }` as custom CSS.
1) Set a custom name for your PeerTube instance.
1) Copy the iframe target for an embed tag and visit the page.
1) Watch green.

## Screenshots
![image](https://user-images.githubusercontent.com/6680299/101497228-09955e80-396b-11eb-8fa4-a56f42a7fa37.png)
