### PR TITLE
remove hungry pervasive headers (etag, x-powered-b)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -21,6 +21,8 @@ process.title = 'peertube'
 
 // Create our main app
 const app = express()
+app.disable('etag')
+   .disable('x-powered-by')
 
 // ----------- Core checker -----------
 import { checkMissedConfig, checkFFmpeg, checkNodeVersion } from './server/initializers/checker-before-init'


### PR DESCRIPTION
## Description

Very simple PR following recommendations and metrics by https://www.youtube.com/watch?v=gltzZjKYK1I&t=4m11s

## Has this been tested?

We don’t make use of both tags, nor do we in our CI. Impact on client caching should be evaluated. Maybe enabling Etags on static assets only could be enough.