### PR TITLE
Fix sending notification upon abuse report message

### DIFF
--- a/server/lib/notifier.ts
+++ b/server/lib/notifier.ts
@@ -463,11 +463,11 @@ class Notifier {
 
     async function buildReporterOptions () {
       // Only notify our users
-      if (abuse.ReporterAccount.isOwned() !== true) return
+      if (abuse.ReporterAccount.isOwned() !== true) return undefined
 
       const reporter = await UserModel.loadByAccountActorId(abuse.ReporterAccount.actorId)
       // Don't notify my own message
-      if (reporter.Account.id === message.accountId) return
+      if (reporter.Account.id === message.accountId) return undefined
 
       return { users: [ reporter ], settingGetter, notificationCreator, emailSender: emailSenderReporter }
     }
@@ -477,7 +477,7 @@ class Notifier {
       // Don't notify my own message
       moderators = moderators.filter(m => m.Account.id !== message.accountId)
 
-      if (moderators.length === 0) return
+      if (moderators.length === 0) return undefined
 
       return { users: moderators, settingGetter, notificationCreator, emailSender: emailSenderModerators }
     }
@@ -489,8 +489,8 @@ class Notifier {
 
     return Promise.all(
       options
-        .filter(opt => opt)
-        .map(this.notify)
+        .filter(opt => !!opt)
+        .map(opt => this.notify(opt))
     )
   }
 

--- a/server/lib/notifier.ts
+++ b/server/lib/notifier.ts
@@ -482,15 +482,16 @@ class Notifier {
       return { users: moderators, settingGetter, notificationCreator, emailSender: emailSenderModerators }
     }
 
-    const [ reporterOptions, moderatorsOptions ] = await Promise.all([
+    const options = await Promise.all([
       buildReporterOptions(),
       buildModeratorsOptions()
     ])
 
-    return Promise.all([
-      this.notify(reporterOptions),
-      this.notify(moderatorsOptions)
-    ])
+    return Promise.all(
+      options
+        .filter(opt => opt)
+        .map(this.notify)
+    )
   }
 
   private async notifyModeratorsOfVideoAutoBlacklist (videoBlacklist: MVideoBlacklistLightVideo) {


### PR DESCRIPTION
## Description
When sending an abuse message and the sender is the only moderator or is the reporter, the notification sending fails.

Before calling `notify` a check is done to verify that we really have someone to notify.

## Related issues
Closes #3445

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Create a video with user1
1) Report the video with admin1
1) Send a abuse report message from admin1 to user1