### PR TITLE
Make emails more user friendly

### DIFF
--- a/server/lib/emailer.ts
+++ b/server/lib/emailer.ts
@@ -472,7 +472,7 @@ class Emailer {
     const emailPayload: EmailPayload = {
       template: 'user-registered',
       to,
-      subject: `a new user registered on ${WEBSERVER.HOST}: ${user.username}`,
+      subject: `a new user registered on ${CONFIG.INSTANCE.NAME}: ${user.username}`,
       locals: {
         user
       }
@@ -486,7 +486,7 @@ class Emailer {
     const videoUrl = WEBSERVER.URL + videoBlacklist.Video.getWatchStaticPath()
 
     const reasonString = videoBlacklist.reason ? ` for the following reason: ${videoBlacklist.reason}` : ''
-    const blockedString = `Your video ${videoName} (${videoUrl} on ${WEBSERVER.HOST} has been blacklisted${reasonString}.`
+    const blockedString = `Your video ${videoName} (${videoUrl} on ${CONFIG.INSTANCE.NAME} has been blacklisted${reasonString}.`
 
     const emailPayload: EmailPayload = {
       to,
@@ -506,7 +506,7 @@ class Emailer {
     const emailPayload: EmailPayload = {
       to,
       subject: `Video ${video.name} unblacklisted`,
-      text: `Your video "${video.name}" (${videoUrl}) on ${WEBSERVER.HOST} has been unblacklisted.`,
+      text: `Your video "${video.name}" (${videoUrl}) on ${CONFIG.INSTANCE.NAME} has been unblacklisted.`,
       locals: {
         title: 'Your video was unblacklisted'
       }
@@ -547,7 +547,7 @@ class Emailer {
     const emailPayload: EmailPayload = {
       template: 'verify-email',
       to: [ to ],
-      subject: `Verify your email on ${WEBSERVER.HOST}`,
+      subject: `Verify your email on ${CONFIG.INSTANCE.NAME}`,
       locals: {
         username,
         verifyEmailUrl
@@ -565,7 +565,7 @@ class Emailer {
     const emailPayload: EmailPayload = {
       to: [ to ],
       subject: 'Account ' + blockedWord,
-      text: `Your account ${user.username} on ${WEBSERVER.HOST} has been ${blockedWord}${reasonString}.`
+      text: `Your account ${user.username} on ${CONFIG.INSTANCE.NAME} has been ${blockedWord}${reasonString}.`
     }
 
     return JobQueue.Instance.createJob({ type: 'email', payload: emailPayload })
@@ -597,7 +597,7 @@ class Emailer {
 
     const fromDisplayName = options.from
       ? options.from
-      : WEBSERVER.HOST
+      : CONFIG.INSTANCE.NAME
 
     const email = new Email({
       send: true,
@@ -625,6 +625,7 @@ class Emailer {
             locals: { // default variables available in all templates
               WEBSERVER,
               EMAIL: CONFIG.EMAIL,
+              instanceName: CONFIG.INSTANCE.NAME,
               text: options.text,
               subject: options.subject
             }

--- a/server/lib/emails/abuse-new-message/html.pug
+++ b/server/lib/emails/abuse-new-message/html.pug
@@ -6,6 +6,6 @@ block title
 
 block content
   p
-    | A new message by #{messageAccountName} was posted on #[a(href=abuseUrl) abuse report ##{abuseId}] on #{WEBSERVER.HOST}
+    | A new message by #{messageAccountName} was posted on #[a(href=abuseUrl) abuse report ##{abuseId}] on #{instanceName}
   blockquote #{messageText}
   br(style="display: none;")

--- a/server/lib/emails/abuse-state-change/html.pug
+++ b/server/lib/emails/abuse-state-change/html.pug
@@ -6,4 +6,4 @@ block title
 
 block content
   p
-    | #[a(href=abuseUrl) Your abuse report ##{abuseId}] on #{WEBSERVER.HOST} has been #{isAccepted ? 'accepted' : 'rejected'}
+    | #[a(href=abuseUrl) Your abuse report ##{abuseId}] on #{instanceName} has been #{isAccepted ? 'accepted' : 'rejected'}

--- a/server/lib/emails/account-abuse-new/html.pug
+++ b/server/lib/emails/account-abuse-new/html.pug
@@ -6,7 +6,7 @@ block title
 
 block content
   p
-    | #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}] received an abuse report for the #{isLocal ? '' : 'remote '}account
+    | #[a(href=WEBSERVER.URL) #{instanceName}] received an abuse report for the #{isLocal ? '' : 'remote '}account
     a(href=accountUrl)  #{accountDisplayName}
 
   p The reporter, #{reporter}, cited the following reason(s):

--- a/server/lib/emails/common/base.pug
+++ b/server/lib/emails/common/base.pug
@@ -230,7 +230,7 @@ body(width="100%" style="margin: 0; padding: 0 !important; mso-line-height-rule:
                 tr
                   td(style='padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;')
                     p(style='margin: 0;')
-                      | You are receiving this email as part of your notification settings on #{WEBSERVER.HOST} for your account #{username}.
+                      | You are receiving this email as part of your notification settings on #{instanceName} for your account #{username}.
         //- 1 Column Text : END
       //- Email Body : END
       //- Email Footer : BEGIN

--- a/server/lib/emails/contact-form/html.pug
+++ b/server/lib/emails/contact-form/html.pug
@@ -4,6 +4,6 @@ block title
   | Someone just used the contact form
 
 block content
-  p #{fromName} sent you a message via the contact form on #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}]:
+  p #{fromName} sent you a message via the contact form on #[a(href=WEBSERVER.URL) #{instanceName}]:
   blockquote(style='white-space: pre-wrap') #{body}
   p You can contact them at #[a(href=`mailto:${fromEmail}`) #{fromEmail}], or simply reply to this email to get in touch.

--- a/server/lib/emails/password-create/html.pug
+++ b/server/lib/emails/password-create/html.pug
@@ -5,6 +5,6 @@ block title
 
 block content
   p.
-    Welcome to #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}], your PeerTube instance. Your username is: #{username}.
+    Welcome to #[a(href=WEBSERVER.URL) #{instanceName}], your PeerTube instance. Your username is: #{username}.
     Please set your password by following #[a(href=createPasswordUrl) this link]: #[a(href=createPasswordUrl) #{createPasswordUrl}] 
     (this link will expire within seven days).

--- a/server/lib/emails/password-create/html.pug
+++ b/server/lib/emails/password-create/html.pug
@@ -5,6 +5,6 @@ block title
 
 block content
   p.
-    Welcome to #[a(href=WEBSERVER.URL) #{instanceName}], your PeerTube instance. Your username is: #{username}.
+    Welcome to #[a(href=WEBSERVER.URL) #{instanceName}]. Your username is: #{username}.
     Please set your password by following #[a(href=createPasswordUrl) this link]: #[a(href=createPasswordUrl) #{createPasswordUrl}] 
     (this link will expire within seven days).

--- a/server/lib/emails/password-reset/html.pug
+++ b/server/lib/emails/password-reset/html.pug
@@ -7,6 +7,6 @@ block content
   p.
     A reset password procedure for your account #{username} has been requested on #[a(href=WEBSERVER.URL) #{instanceName}].
     Please follow #[a(href=resetPasswordUrl) this link] to reset it: #[a(href=resetPasswordUrl) #{resetPasswordUrl}]
-    (the link will expire within 1 hour)
+    (the link will expire within 1 hour).
   p.
     If you are not the person who initiated this request, please ignore this email.

--- a/server/lib/emails/password-reset/html.pug
+++ b/server/lib/emails/password-reset/html.pug
@@ -5,7 +5,7 @@ block title
 
 block content
   p.
-    A reset password procedure for your account #{username} has been requested on #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}].
+    A reset password procedure for your account #{username} has been requested on #[a(href=WEBSERVER.URL) #{instanceName}].
     Please follow #[a(href=resetPasswordUrl) this link] to reset it: #[a(href=resetPasswordUrl) #{resetPasswordUrl}]
     (the link will expire within 1 hour)
   p.

--- a/server/lib/emails/verify-email/html.pug
+++ b/server/lib/emails/verify-email/html.pug
@@ -4,11 +4,14 @@ block title
   | Account verification
 
 block content
-  p Welcome to PeerTube!
+  p Welcome to #{instanceName}!
   p.
-    You just created an account #[a(href=WEBSERVER.URL) #{instanceName}], your new PeerTube instance. 
+    You just created an account at #[a(href=WEBSERVER.URL) #{instanceName}].
     Your username there is: #{username}.
   p.
-    To start using PeerTube on #[a(href=WEBSERVER.URL) #{instanceName}] you must verify your email first! 
-    Please follow #[a(href=verifyEmailUrl) this link] to verify this email belongs to you: #[a(href=verifyEmailUrl) #{verifyEmailUrl}] 
+    To start using your account you must verify your email first!
+    Please follow #[a(href=verifyEmailUrl) this link] to verify this email belongs to you.
+  p.
+    If you can't see the verification link above you can use the following link #[a(href=verifyEmailUrl) #{verifyEmailUrl}]
+  p.
     If you are not the person who initiated this request, please ignore this email.

--- a/server/lib/emails/verify-email/html.pug
+++ b/server/lib/emails/verify-email/html.pug
@@ -6,9 +6,9 @@ block title
 block content
   p Welcome to PeerTube!
   p.
-    You just created an account #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}], your new PeerTube instance. 
+    You just created an account #[a(href=WEBSERVER.URL) #{instanceName}], your new PeerTube instance. 
     Your username there is: #{username}.
   p.
-    To start using PeerTube on #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}] you must verify your email first! 
+    To start using PeerTube on #[a(href=WEBSERVER.URL) #{instanceName}] you must verify your email first! 
     Please follow #[a(href=verifyEmailUrl) this link] to verify this email belongs to you: #[a(href=verifyEmailUrl) #{verifyEmailUrl}] 
     If you are not the person who initiated this request, please ignore this email.

--- a/server/lib/emails/video-abuse-new/html.pug
+++ b/server/lib/emails/video-abuse-new/html.pug
@@ -6,7 +6,7 @@ block title
 
 block content
   p
-    | #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}] received an abuse report for the #{isLocal ? '' : 'remote '}video "
+    | #[a(href=WEBSERVER.URL) #{instanceName}] received an abuse report for the #{isLocal ? '' : 'remote '}video "
     a(href=videoUrl) #{videoName}
     | " by #[+channel(videoChannel)]
     if videoPublishedAt

--- a/server/lib/emails/video-comment-abuse-new/html.pug
+++ b/server/lib/emails/video-comment-abuse-new/html.pug
@@ -6,7 +6,7 @@ block title
 
 block content
   p
-    | #[a(href=WEBSERVER.URL) #{WEBSERVER.HOST}] received an abuse report for the #{isLocal ? '' : 'remote '}
+    | #[a(href=WEBSERVER.URL) #{instanceName}] received an abuse report for the #{isLocal ? '' : 'remote '}
     a(href=commentUrl) comment on video "#{videoName}"
     |  of #{flaggedAccount}
     |  created on #{commentCreatedAt}


### PR DESCRIPTION
## Description
* Instead of communicating the hostname to the user in emails, show the instance name.
* It's not always that the end user knows that he's using a PeerTube platform, therefore it can be confusing when receiving an email stating "Welcome to PeerTube", etc.

## Notes during work
* Sometimes the instance name is linked to the instance and sometimes not.
* It can be hard to read the email when the full link text is shown in the middle of the email. Putting it on bottom should make the email more readable.
* The video blacklisted/unblacklisted contains a link that's not clickable (it just prints the link code).
* Printing the video name in the subject can result in very long subjects.

## Related issues
Partially solves #3392

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough


### Test scenario
1) Login as root.
1) Configure email verification upon user registration.
1) Configure that you'll get an email when a user is registered.
1) Configure that contact form is enabled and goes do a valid email address.
1) Configure instance name to Nobel.
1) Logout
-----

1) Send a message in the contact form.
* - [x] Check that contact form receiver receives an email where sender name is Nobel. (contact-form)
-----

1) Register user1.
* - [x] Check that user1 receives an email where sender name is Nobel. (from display name)
* - [x] Check that user1 receives an email not containing the hostname, but instead instance name Nobel. (verify-email)
* - [x] Check that root receives an email not containing the hostname, but instead instance name Nobel. (user-registered)
1) Verify user1s email address.
-----

1) Login as user1
1) Upload a video called Abusive video.
1) Comment on the video.
1) Logout
-----

1) As a guest, ask a password reset for user1.
* - [x] Check that user1 receives an email not containing the hostname, but instead instance name Nobel. (password-reset)
-----

1) As root user, create user2 with password field set empty.
* - [x] Check that user2 receives an email not containing the hostname, but instead instance name Nobel. (password-create)
-----

1) As user2, report the uploaded video as abusive.
* - [x] Check that root receives an email not containing the hostname, but instead instance name Nobel. (video-abuse-new)
1) As user2, report the comment as abusive.
* - [x] Check that root receives an email not containing the hostname, but instead instance name Nobel. (video-comment-abuse-new)
1) As user2, report user1 as abusive.
* - [x] Check that root receives an email not containing the hostname, but instead instance name Nobel. (account-abuse-new)
-----

1) As root, block the video.
* - [x] Check that user1 receives an email not containing the hostname, but instead instance name Nobel. (video blacklisted)
1) As root, unblock the video.
* - [x] Check that user1 receives an email not containing the hostname, but instead instance name Nobel. (video unblacklisted)
1) As root, block user1.
* - [x] Check that user1 receives an email not containing the hostname, but instead instance name Nobel. (account blocked)
1) As root, unblock user1.
* - [x] Check that user1 receives an email not containing the hostname, but instead instance name Nobel. (account unblocked)
1) As root, send a message in the abuse report.
* - [x] Check that user2 receives an email not containing the hostname, but instead instance name Nobel. (abuse-new-message)
1) As root, accept the report.
* - [x] Check that user2 receives an email not containing the hostname, but instead instance name Nobel. (abuse-state-change)
