### PR TITLE
Register service worker

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,20 +11,9 @@ if (environment.production) {
 const bootstrap = () => platformBrowserDynamic()
   .bootstrapModule(AppModule)
   .then(bootstrapModule => {
-    // TODO: Uncomment and remove unregistration when https://github.com/angular/angular/issues/21191 is fixed
-    // TODO: Remove when https://github.com/angular/angular-cli/issues/8779 is fixed?
-    // if ('serviceWorker' in navigator && environment.production) {
-    //   navigator.serviceWorker.register('/ngsw-worker.js')
-    //     .catch(err => console.error('Cannot register service worker.', err))
-    // }
-
-    if (navigator.serviceWorker && typeof navigator.serviceWorker.getRegistrations === 'function') {
-      navigator.serviceWorker.getRegistrations()
-               .then(registrations => {
-                 for (const registration of registrations) {
-                   registration.unregister()
-                 }
-               })
+    if ('serviceWorker' in navigator && environment.production) {
+      navigator.serviceWorker.register('/ngsw-worker.js')
+        .catch(err => console.error('Cannot register service worker.', err))
     }
 
     if (!environment.production) {

--- a/client/src/ngsw-config.json
+++ b/client/src/ngsw-config.json
@@ -7,10 +7,9 @@
       "resources": {
         "files": [
           "/index.html",
-          "/client/assets/images/favicon.png",
-          "/client/*.bundle.css",
-          "/client/*.bundle.js",
-          "/client/*.chunk.js",
+          "/client/assets/images/icons/favicon.png",
+          "/client/*.css",
+          "/client/*.js",
           "/manifest.webmanifest"
         ]
       }

--- a/scripts/build/client.sh
+++ b/scripts/build/client.sh
@@ -56,7 +56,6 @@ if [ -z ${1+x} ] || ([ "$1" != "--light" ] && [ "$1" != "--analyze-bundle" ]); t
     done
 
     mv "./dist/$defaultLanguage/assets" "./dist"
-    mv "./dist/$defaultLanguage/manifest.webmanifest" "./dist/manifest.webmanifest"
 
     rmdir "dist/build"
 else
@@ -69,6 +68,7 @@ else
     npm run ng build -- --localize=false --output-path "dist/$defaultLanguage/" --deploy-url "/client/$defaultLanguage/" --prod --stats-json $additionalParams
 fi
 
+mv "./dist/$defaultLanguage/manifest.webmanifest" "./dist/manifest.webmanifest"
 mv "./dist/$defaultLanguage/ngsw-worker.js" "./dist/"
 
 cd ../ && npm run build:embed && cd client/

--- a/scripts/build/client.sh
+++ b/scripts/build/client.sh
@@ -69,6 +69,8 @@ else
     npm run ng build -- --localize=false --output-path "dist/$defaultLanguage/" --deploy-url "/client/$defaultLanguage/" --prod --stats-json $additionalParams
 fi
 
+mv "./dist/$defaultLanguage/ngsw-worker.js" "./dist/"
+
 cd ../ && npm run build:embed && cd client/
 
 # Copy runtime locales


### PR DESCRIPTION
## Description
Registers the ng service worker. I guess the asset names has changed since `ngsw-config.json` was written, therefore I just switched just to wildcard. 

## Related issues
Closes #296

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

Open up DevTools in Brave and check in Network tab to see that JS and CSS assets are fetched via service worker.

## Screenshots
![image](https://user-images.githubusercontent.com/6680299/102002314-a05f7380-3cfb-11eb-96b9-79cbb32c7b0e.png)

