### PR TITLE
add ability to remove one's avatar for account and channels

### DIFF
--- a/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
+++ b/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
@@ -3,7 +3,7 @@
   <div class="form-group col-12 col-lg-4 col-xl-3"></div>
 
   <div class="form-group col-12 col-lg-8 col-xl-9">
-    <my-actor-avatar-info [actor]="user.account" (avatarChange)="onAvatarChange($event)"></my-actor-avatar-info>
+    <my-actor-avatar-info [actor]="user.account" (avatarChange)="onAvatarChange($event)" (avatarDelete)="onAvatarDelete()"></my-actor-avatar-info>
   </div>
 </div>
 

--- a/client/src/app/+my-account/my-account-settings/my-account-settings.component.ts
+++ b/client/src/app/+my-account/my-account-settings/my-account-settings.component.ts
@@ -53,4 +53,17 @@ export class MyAccountSettingsComponent implements OnInit, AfterViewChecked {
         })
       )
   }
+
+  onAvatarDelete () {
+    this.userService.deleteAvatar()
+      .subscribe(
+        data => {
+          this.notifier.success($localize`Avatar deleted.`)
+
+          this.user.updateAccountAvatar()
+        },
+
+        (err: HttpErrorResponse) => this.notifier.error(err.message)
+      )
+  }
 }

--- a/client/src/app/+my-library/+my-video-channels/my-video-channel-edit.component.html
+++ b/client/src/app/+my-library/+my-video-channels/my-video-channel-edit.component.html
@@ -46,7 +46,7 @@
 
       <my-actor-avatar-info
         *ngIf="!isCreation() && videoChannelToUpdate"
-        [actor]="videoChannelToUpdate" (avatarChange)="onAvatarChange($event)"
+        [actor]="videoChannelToUpdate" (avatarChange)="onAvatarChange($event)" (avatarDelete)="onAvatarDelete()"
       ></my-actor-avatar-info>
 
       <div class="form-group">

--- a/client/src/app/+my-library/+my-video-channels/my-video-channel-edit.ts
+++ b/client/src/app/+my-library/+my-video-channels/my-video-channel-edit.ts
@@ -14,6 +14,7 @@ export abstract class MyVideoChannelEdit extends FormReactive {
 
   // We need this method so angular does not complain in child template that doesn't need this
   onAvatarChange (formData: FormData) { /* empty */ }
+  onAvatarDelete () { /* empty */ }
 
   // Should be implemented by the child
   isBulkUpdateVideosDisplayed () {

--- a/client/src/app/+my-library/+my-video-channels/my-video-channel-update.component.ts
+++ b/client/src/app/+my-library/+my-video-channels/my-video-channel-update.component.ts
@@ -11,6 +11,8 @@ import { FormValidatorService } from '@app/shared/shared-forms'
 import { VideoChannel, VideoChannelService } from '@app/shared/shared-main'
 import { ServerConfig, VideoChannelUpdate } from '@shared/models'
 import { MyVideoChannelEdit } from './my-video-channel-edit'
+import { HttpErrorResponse } from '@angular/common/http'
+import { uploadErrorHandler } from '@app/helpers'
 
 @Component({
   selector: 'my-video-channel-update',
@@ -107,8 +109,25 @@ export class MyVideoChannelUpdateComponent extends MyVideoChannelEdit implements
             this.videoChannelToUpdate.updateAvatar(data.avatar)
           },
 
-          err => this.notifier.error(err.message)
+          (err: HttpErrorResponse) => uploadErrorHandler({
+            err,
+            name: $localize`avatar`,
+            notifier: this.notifier
+          })
         )
+  }
+
+  onAvatarDelete () {
+    this.videoChannelService.deleteVideoChannelAvatar(this.videoChannelToUpdate.name)
+                            .subscribe(
+                              data => {
+                                this.notifier.success($localize`Avatar deleted.`)
+
+                                this.videoChannelToUpdate.resetAvatar()
+                              },
+
+                              err => this.notifier.error(err.message)
+                            )
   }
 
   get maxAvatarSize () {

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -131,8 +131,9 @@ export class User implements UserServerModel {
     }
   }
 
-  updateAccountAvatar (newAccountAvatar: Avatar) {
-    this.account.updateAvatar(newAccountAvatar)
+  updateAccountAvatar (newAccountAvatar?: Avatar) {
+    if (newAccountAvatar) this.account.updateAvatar(newAccountAvatar)
+    else this.account.resetAvatar()
   }
 
   isUploadDisabled () {

--- a/client/src/app/core/users/user.service.ts
+++ b/client/src/app/core/users/user.service.ts
@@ -123,6 +123,16 @@ export class UserService {
                .pipe(catchError(err => this.restExtractor.handleError(err)))
   }
 
+  deleteAvatar () {
+    const url = UserService.BASE_USERS_URL + 'me/avatar'
+
+    return this.authHttp.delete(url)
+               .pipe(
+                 map(this.restExtractor.extractDataBool),
+                 catchError(err => this.restExtractor.handleError(err))
+               )
+  }
+
   signup (userCreate: UserRegister) {
     return this.authHttp.post(UserService.BASE_USERS_URL + 'register', userCreate)
                .pipe(

--- a/client/src/app/shared/shared-main/account/account.model.ts
+++ b/client/src/app/shared/shared-main/account/account.model.ts
@@ -44,6 +44,11 @@ export class Account extends Actor implements ServerAccount {
     this.updateComputedAttributes()
   }
 
+  resetAvatar () {
+    this.avatar = null
+    this.avatarUrl = Account.GET_DEFAULT_AVATAR_URL()
+  }
+
   private updateComputedAttributes () {
     this.avatarUrl = Account.GET_ACTOR_AVATAR_URL(this)
   }

--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.html
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.html
@@ -4,12 +4,18 @@
       <img [src]="actor.avatarUrl" alt="Avatar" />
 
       <div class="actor-img-edit-container">
-        <div class="actor-img-edit-button" [ngbTooltip]="avatarFormat"
-          placement="right" container="body">
-          <my-global-icon iconName="edit"></my-global-icon>
-          <label for="avatarfile" i18n>Change your avatar</label>
-          <input #avatarfileInput type="file" title=" " name="avatarfile" id="avatarfile" [accept]="avatarExtensions" (change)="onAvatarChange()"/>
+
+        <div *ngIf="!hasAvatar" class="actor-img-edit-button" [ngbTooltip]="avatarFormat" placement="right" container="body">
+          <my-global-icon iconName="upload"></my-global-icon>
+          <label class="sr-only" for="avatarfile" i18n>Upload a new avatar</label>
+          <input #avatarfileInput type="file" title=" " name="avatarfile" id="avatarfile" [accept]="avatarExtensions" (change)="onAvatarChange(avatarfileInput)"/>
         </div>
+
+        <div *ngIf="hasAvatar" class="actor-img-edit-button" #avatarPopover="ngbPopover" [ngbPopover]="avatarEditContent" popoverClass="popover-avatar-info" autoClose="outside" placement="right">
+          <my-global-icon iconName="edit"></my-global-icon>
+          <label class="sr-only" for="avatarMenu" i18n>Change your avatar</label>
+        </div>
+
       </div>
     </div>
 
@@ -23,3 +29,15 @@
     </div>
   </div>
 </ng-container>
+
+<ng-template #avatarEditContent>
+  <div class="dropdown-item c-hand" [ngbTooltip]="avatarFormat" placement="right" container="body">
+    <my-global-icon iconName="upload"></my-global-icon>
+    <span for="avatarfile" i18n>Upload a new avatar</span>
+    <input #avatarfileInput type="file" title=" " name="avatarfile" id="avatarfile" [accept]="avatarExtensions" (change)="onAvatarChange(avatarfileInput)"/>
+  </div>
+  <div class="dropdown-item c-hand" (click)="deleteAvatar()" (key.enter)="deleteAvatar()">
+    <my-global-icon iconName="delete"></my-global-icon>
+    <span i18n>Remove avatar</span>
+  </div>
+</ng-template>

--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.scss
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.scss
@@ -71,7 +71,7 @@
   }
 }
 
-::ng-deep .popover-avatar-info .popover-body {
+.actor-img-edit-container ::ng-deep .popover-avatar-info .popover-body {
   padding: 0;
 
   .dropdown-item {

--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.scss
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.scss
@@ -70,3 +70,16 @@
     }
   }
 }
+
+::ng-deep .popover-avatar-info .popover-body {
+  padding: 0;
+
+  .dropdown-item {
+    padding: 6px 10px;
+    border-radius: 4px;
+
+    &:first-child {
+      @include peertube-file;
+    }
+  }
+}

--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.scss
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.scss
@@ -80,6 +80,7 @@
 
     &:first-child {
       @include peertube-file;
+      display: block;
     }
   }
 }

--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.ts
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core'
+import { Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core'
 import { Notifier, ServerService } from '@app/core'
 import { getBytes } from '@root-helpers/bytes'
 import { ServerConfig } from '@shared/models'
@@ -12,7 +12,7 @@ import { Actor } from './actor.model'
   templateUrl: './actor-avatar-info.component.html',
   styleUrls: [ './actor-avatar-info.component.scss' ]
 })
-export class ActorAvatarInfoComponent implements OnInit {
+export class ActorAvatarInfoComponent implements OnInit, OnChanges {
   @ViewChild('avatarfileInput') avatarfileInput: ElementRef<HTMLInputElement>
   @ViewChild('avatarPopover') avatarPopover: NgbPopover
 
@@ -21,6 +21,7 @@ export class ActorAvatarInfoComponent implements OnInit {
   @Output() avatarChange = new EventEmitter<FormData>()
   @Output() avatarDelete = new EventEmitter<void>()
 
+  private avatarUrl: string
   private serverConfig: ServerConfig
 
   constructor (
@@ -34,12 +35,18 @@ export class ActorAvatarInfoComponent implements OnInit {
         .subscribe(config => this.serverConfig = config)
   }
 
+  ngOnChanges (changes: SimpleChanges) {
+    if (changes['actor']) {
+      this.avatarUrl = Actor.GET_ACTOR_AVATAR_URL(this.actor)
+    }
+  }
+
   onAvatarChange (input: HTMLInputElement) {
     this.avatarfileInput = new ElementRef(input)
 
     const avatarfile = this.avatarfileInput.nativeElement.files[ 0 ]
     if (avatarfile.size > this.maxAvatarSize) {
-      this.notifier.error('Error', 'This image is too large.')
+      this.notifier.error('Error', $localize`This image is too large.`)
       return
     }
 
@@ -70,6 +77,6 @@ export class ActorAvatarInfoComponent implements OnInit {
   }
 
   get hasAvatar () {
-    return Actor.GET_ACTOR_AVATAR_URL(this.actor)
+    return !!this.avatarUrl
   }
 }

--- a/client/src/app/shared/shared-main/account/actor-avatar-info.component.ts
+++ b/client/src/app/shared/shared-main/account/actor-avatar-info.component.ts
@@ -4,6 +4,8 @@ import { getBytes } from '@root-helpers/bytes'
 import { ServerConfig } from '@shared/models'
 import { VideoChannel } from '../video-channel/video-channel.model'
 import { Account } from '../account/account.model'
+import { NgbPopover } from '@ng-bootstrap/ng-bootstrap'
+import { Actor } from './actor.model'
 
 @Component({
   selector: 'my-actor-avatar-info',
@@ -12,10 +14,12 @@ import { Account } from '../account/account.model'
 })
 export class ActorAvatarInfoComponent implements OnInit {
   @ViewChild('avatarfileInput') avatarfileInput: ElementRef<HTMLInputElement>
+  @ViewChild('avatarPopover') avatarPopover: NgbPopover
 
   @Input() actor: VideoChannel | Account
 
   @Output() avatarChange = new EventEmitter<FormData>()
+  @Output() avatarDelete = new EventEmitter<void>()
 
   private serverConfig: ServerConfig
 
@@ -30,7 +34,9 @@ export class ActorAvatarInfoComponent implements OnInit {
         .subscribe(config => this.serverConfig = config)
   }
 
-  onAvatarChange () {
+  onAvatarChange (input: HTMLInputElement) {
+    this.avatarfileInput = new ElementRef(input)
+
     const avatarfile = this.avatarfileInput.nativeElement.files[ 0 ]
     if (avatarfile.size > this.maxAvatarSize) {
       this.notifier.error('Error', 'This image is too large.')
@@ -39,8 +45,12 @@ export class ActorAvatarInfoComponent implements OnInit {
 
     const formData = new FormData()
     formData.append('avatarfile', avatarfile)
-
+    this.avatarPopover?.close()
     this.avatarChange.emit(formData)
+  }
+
+  deleteAvatar () {
+    this.avatarDelete.emit()
   }
 
   get maxAvatarSize () {
@@ -57,5 +67,9 @@ export class ActorAvatarInfoComponent implements OnInit {
 
   get avatarFormat () {
     return `${$localize`max size`}: 192*192px, ${this.maxAvatarSizeInBytes} ${$localize`extensions`}: ${this.avatarExtensions}`
+  }
+
+  get hasAvatar () {
+    return Actor.GET_ACTOR_AVATAR_URL(this.actor)
   }
 }

--- a/client/src/app/shared/shared-main/video-channel/video-channel.model.ts
+++ b/client/src/app/shared/shared-main/video-channel/video-channel.model.ts
@@ -56,6 +56,11 @@ export class VideoChannel extends Actor implements ServerVideoChannel {
     this.updateComputedAttributes()
   }
 
+  resetAvatar () {
+    this.avatar = null
+    this.avatarUrl = VideoChannel.GET_DEFAULT_AVATAR_URL()
+  }
+
   private updateComputedAttributes () {
     this.avatarUrl = VideoChannel.GET_ACTOR_AVATAR_URL(this)
   }

--- a/client/src/app/shared/shared-main/video-channel/video-channel.service.ts
+++ b/client/src/app/shared/shared-main/video-channel/video-channel.service.ts
@@ -89,6 +89,16 @@ export class VideoChannelService {
                .pipe(catchError(err => this.restExtractor.handleError(err)))
   }
 
+  deleteVideoChannelAvatar (videoChannelName: string) {
+    const url = VideoChannelService.BASE_VIDEO_CHANNEL_URL + videoChannelName + '/avatar'
+
+    return this.authHttp.delete(url)
+               .pipe(
+                 map(this.restExtractor.extractDataBool),
+                 catchError(err => this.restExtractor.handleError(err))
+               )
+  }
+
   removeVideoChannel (videoChannel: VideoChannel) {
     return this.authHttp.delete(VideoChannelService.BASE_VIDEO_CHANNEL_URL + videoChannel.nameWithHost)
                .pipe(

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -255,14 +255,11 @@
   }
 }
 
-@mixin peertube-button-file ($width) {
+@mixin peertube-file {
   position: relative;
   overflow: hidden;
   display: inline-block;
-  width: $width;
   min-height: 30px;
-
-  @include peertube-button;
 
   input[type=file] {
     position: absolute;
@@ -279,6 +276,13 @@
     cursor: inherit;
     display: block;
   }
+}
+
+@mixin peertube-button-file ($width) {
+  width: $width;
+
+  @include peertube-file;
+  @include peertube-button;
 }
 
 @mixin icon ($size) {

--- a/server/controllers/api/users/me.ts
+++ b/server/controllers/api/users/me.ts
@@ -8,7 +8,7 @@ import { CONFIG } from '../../../initializers/config'
 import { MIMETYPES } from '../../../initializers/constants'
 import { sequelizeTypescript } from '../../../initializers/database'
 import { sendUpdateActor } from '../../../lib/activitypub/send'
-import { updateActorAvatarFile } from '../../../lib/avatar'
+import { deleteActorAvatarFile, updateActorAvatarFile } from '../../../lib/avatar'
 import { getOriginalVideoFileTotalDailyFromUser, getOriginalVideoFileTotalFromUser, sendVerifyUserEmail } from '../../../lib/user'
 import {
   asyncMiddleware,
@@ -84,6 +84,11 @@ meRouter.post('/me/avatar/pick',
   reqAvatarFile,
   updateAvatarValidator,
   asyncRetryTransactionMiddleware(updateMyAvatar)
+)
+
+meRouter.delete('/me/avatar',
+  authenticate,
+  asyncRetryTransactionMiddleware(deleteMyAvatar)
 )
 
 // ---------------------------------------------------------------------------
@@ -220,7 +225,16 @@ async function updateMyAvatar (req: express.Request, res: express.Response) {
 
   const userAccount = await AccountModel.load(user.Account.id)
 
-  const avatar = await updateActorAvatarFile(avatarPhysicalFile, userAccount)
+  const avatar = await updateActorAvatarFile(userAccount, avatarPhysicalFile)
 
   return res.json({ avatar: avatar.toFormattedJSON() })
+}
+
+async function deleteMyAvatar (req: express.Request, res: express.Response) {
+  const user = res.locals.oauth.token.user
+
+  const userAccount = await AccountModel.load(user.Account.id)
+  await deleteActorAvatarFile(userAccount)
+
+  return res.sendStatus(HttpStatusCode.NO_CONTENT_204)
 }

--- a/server/lib/activitypub/actor.ts
+++ b/server/lib/activitypub/actor.ts
@@ -199,6 +199,19 @@ async function updateActorAvatarInstance (actor: MActorDefault, info: AvatarInfo
   return actor
 }
 
+async function deleteActorAvatarInstance (actor: MActorDefault, t: Transaction) {
+  try {
+    await actor.Avatar.destroy({ transaction: t })
+  } catch (err) {
+    logger.error('Cannot remove old avatar of actor %s.', actor.url, { err })
+  }
+
+  actor.avatarId = null
+  actor.Avatar = null
+
+  return actor
+}
+
 async function fetchActorTotalItems (url: string) {
   const options = {
     uri: url,
@@ -337,6 +350,7 @@ export {
   fetchActorTotalItems,
   getAvatarInfoIfExists,
   updateActorInstance,
+  deleteActorAvatarInstance,
   refreshActorIfNeeded,
   updateActorAvatarInstance,
   addFetchOutboxJob

--- a/server/lib/avatar.ts
+++ b/server/lib/avatar.ts
@@ -1,7 +1,7 @@
 import 'multer'
 import { sendUpdateActor } from './activitypub/send'
 import { AVATARS_SIZE, LRU_CACHE, QUEUE_CONCURRENCY } from '../initializers/constants'
-import { updateActorAvatarInstance } from './activitypub/actor'
+import { updateActorAvatarInstance, deleteActorAvatarInstance } from './activitypub/actor'
 import { processImage } from '../helpers/image-utils'
 import { extname, join } from 'path'
 import { retryTransactionWrapper } from '../helpers/database-utils'
@@ -14,8 +14,8 @@ import { downloadImage } from '../helpers/requests'
 import { MAccountDefault, MChannelDefault } from '../types/models'
 
 async function updateActorAvatarFile (
-  avatarPhysicalFile: Express.Multer.File,
-  accountOrChannel: MAccountDefault | MChannelDefault
+  accountOrChannel: MAccountDefault | MChannelDefault,
+  avatarPhysicalFile: Express.Multer.File
 ) {
   const extension = extname(avatarPhysicalFile.filename)
   const avatarName = uuidv4() + extension
@@ -31,6 +31,21 @@ async function updateActorAvatarFile (
       }
 
       const updatedActor = await updateActorAvatarInstance(accountOrChannel.Actor, avatarInfo, t)
+      await updatedActor.save({ transaction: t })
+
+      await sendUpdateActor(accountOrChannel, t)
+
+      return updatedActor.Avatar
+    })
+  })
+}
+
+async function deleteActorAvatarFile (
+  accountOrChannel: MAccountDefault | MChannelDefault
+) {
+  return retryTransactionWrapper(() => {
+    return sequelizeTypescript.transaction(async t => {
+      const updatedActor = await deleteActorAvatarInstance(accountOrChannel.Actor, t)
       await updatedActor.save({ transaction: t })
 
       await sendUpdateActor(accountOrChannel, t)
@@ -64,5 +79,6 @@ const avatarPathUnsafeCache = new LRUCache<string, string>({ max: LRU_CACHE.AVAT
 export {
   avatarPathUnsafeCache,
   updateActorAvatarFile,
+  deleteActorAvatarFile,
   pushAvatarProcessInQueue
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
This PR adds a delete route for account avatars and one for channel avatars.

## Has this been tested?

I should add tests to the test suite.
<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

No avatar:
![Screenshot_2020-12-14 Account settings - PeerTube(1)](https://user-images.githubusercontent.com/6329880/102129532-c7c75500-3e4f-11eb-982a-23b6ac31e5cd.png)
With an avatar:
![Screenshot_2020-12-14 Account settings - PeerTube](https://user-images.githubusercontent.com/6329880/102129541-cc8c0900-3e4f-11eb-8ee2-71734b69745c.png)