### PR TITLE
Resume video playback on close share modal

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -280,6 +280,9 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
   }
 
   showShareModal () {
+    // Check video was playing before opening support modal
+    const isVideoPlaying = this.isPlaying()
+
     this.pausePlayer()
 
     this.videoShareModal.show(this.currentTime, this.videoWatchPlaylist.currentPlaylistPosition)

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -285,7 +285,13 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
     this.pausePlayer()
 
-    this.videoShareModal.show(this.currentTime, this.videoWatchPlaylist.currentPlaylistPosition)
+    const modalRef = this.videoShareModal.show(this.currentTime, this.videoWatchPlaylist.currentPlaylistPosition)
+
+    modalRef.result.then(() => {
+      if (isVideoPlaying) {
+        this.resumePlayer()
+      }
+    })
   }
 
   isUserLoggedIn () {

--- a/client/src/app/shared/shared-share-modal/video-share.component.ts
+++ b/client/src/app/shared/shared-share-modal/video-share.component.ts
@@ -79,7 +79,7 @@ export class VideoShareComponent {
 
     this.playlistPosition = currentPlaylistPosition
 
-    this.modalService.open(this.modal, { centered: true })
+    return this.modalService.open(this.modal, { centered: true })
   }
 
   getVideoIframeCode () {


### PR DESCRIPTION
## Description

This fix is merely a copy/paste of https://github.com/Chocobozzz/PeerTube/pull/3052.
The playback state of the video prior to the opening of the share modal is stored, and if the video was playing, it gets resumed when the share modal is closed.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Fixes https://github.com/Chocobozzz/PeerTube/issues/3478

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

Tests do not appear mandatory there. And I've got an issue with GitPod and CORS: I can't test the fix because not a single video would play...

(namely:)
> Blocage d’une requête multiorigines (Cross-Origin Request) : la politique « Same Origin » ne permet pas de consulter la ressource distante située sur http://localhost:9000/static/streaming-playlists/hls/0c995f93-1564-4045-a805-707dd2b62474/master.m3u8. Raison : échec de la requête CORS.