### PR TITLE
add `proxy_ignore_client_abort` flag to Nginx conf

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -158,6 +158,7 @@ server {
   keepalive_timeout         10s; # default is 75
   resolver_timeout          10s; # default is 30
   reset_timedout_connection on;
+  proxy_ignore_client_abort on;
 
   tcp_nopush                on; # send headers in one piece
   tcp_nodelay               on; # don't buffer data sent, good for small data bursts in real time


### PR DESCRIPTION
The `proxy_ignore_client_abort` flag specifies whether nginx will
monitor possible connection close while waiting for an upstream
server response. If an error occurs while sending a response, the
connection will be closed regardless of the flag, much like if
there where no nginx at all.

fixes #3484