### PR TITLE
authenticate upload requests before they transmit video

### DIFF
--- a/server/controllers/api/users/token.ts
+++ b/server/controllers/api/users/token.ts
@@ -35,6 +35,10 @@ tokensRouter.post('/scoped-tokens',
   asyncMiddleware(renewScopedTokens)
 )
 
+tokensRouter.get('/check-auth',
+  authenticate
+)
+
 // ---------------------------------------------------------------------------
 
 export {

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -1,7 +1,7 @@
 # Minimum Nginx version required:  1.13.0 (released Apr 25, 2017)
 # Please check your Nginx installation features the following modules via 'nginx -V':
 # STANDARD HTTP MODULES: Core, Proxy, Rewrite.
-# OPTIONAL HTTP MODULES: Gzip, Headers, HTTP/2, Log, Real IP, SSL, Thread Pool, Upstream.
+# OPTIONAL HTTP MODULES: Auth Request, Gzip, Headers, HTTP/2, Log, Real IP, SSL, Thread Pool, Upstream.
 # THIRD PARTY MODULES:   None.
 
 # Uncomment in production to redirect HTTP to HTTPS. Leave commented for docker-compose.
@@ -80,8 +80,17 @@ server {
     try_files /dev/null @api;
   }
 
+  location = /check-auth {
+    internal;
+    proxy_set_header Content-Length "";
+    proxy_pass_request_body off;
+
+    try_files /dev/null @api;
+  }
+
   location = /api/v1/users/me/avatar/pick {
     limit_except POST HEAD { deny all; }
+    auth_request /check-auth;
 
     client_max_body_size                      2M; # default is 1M
     add_header            X-File-Maximum-Size 2M always; # inform backend of the set value in bytes
@@ -91,6 +100,7 @@ server {
 
   location = /api/v1/videos/upload {
     limit_except POST HEAD { deny all; }
+    auth_request /check-auth;
 
     # This is the maximum upload size, which roughly matches the maximum size of a video file.
     # Note that temporary space is needed equal to the total size of all concurrent uploads.


### PR DESCRIPTION
## Description

Adds a simple route to check for proper authentification before any traffic reaches the backend. The route is used internally and prevents requests to DDoS a PeerTube server with a large client body size.

## Has this been tested?

- [x] 💭 no, because this PR is a draft and still needs work

Ideally the app should be tested on a live instance running with the new route.
