### PR TITLE
add support for 1440p (Quad HD/QHD/WQHD) videos

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
@@ -82,6 +82,10 @@ export class EditCustomConfigComponent extends FormReactive implements OnInit, A
         label: $localize`1080p`
       },
       {
+        id: '1440p',
+        label: $localize`1440p`
+      },
+      {
         id: '2160p',
         label: $localize`2160p`
       }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -226,6 +226,7 @@ transcoding:
     480p: false
     720p: false
     1080p: false
+    1440p: false
     2160p: false
 
   # Generate videos in a WebTorrent format (what we do since the first PeerTube release)
@@ -278,6 +279,7 @@ live:
       480p: false
       720p: false
       1080p: false
+      1440p: false
       2160p: false
 
 import:

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -240,6 +240,7 @@ transcoding:
     480p: false
     720p: false
     1080p: false
+    1440p: false
     2160p: false
 
   # Generate videos in a WebTorrent format (what we do since the first PeerTube release)
@@ -292,6 +293,7 @@ live:
       480p: false
       720p: false
       1080p: false
+      1440p: false
       2160p: false
 
 import:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -78,6 +78,7 @@ transcoding:
     480p: true
     720p: true
     1080p: true
+    1440p: true
     2160p: true
   hls:
     enabled: true
@@ -98,6 +99,7 @@ live:
       480p: false
       720p: false
       1080p: false
+      1440p: false
       2160p: false
 
 import:

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -419,6 +419,7 @@ function customConfig (): CustomConfig {
         '480p': CONFIG.TRANSCODING.RESOLUTIONS['480p'],
         '720p': CONFIG.TRANSCODING.RESOLUTIONS['720p'],
         '1080p': CONFIG.TRANSCODING.RESOLUTIONS['1080p'],
+        '1440p': CONFIG.TRANSCODING.RESOLUTIONS['1440p'],
         '2160p': CONFIG.TRANSCODING.RESOLUTIONS['2160p']
       },
       webtorrent: {
@@ -443,6 +444,7 @@ function customConfig (): CustomConfig {
           '480p': CONFIG.LIVE.TRANSCODING.RESOLUTIONS['480p'],
           '720p': CONFIG.LIVE.TRANSCODING.RESOLUTIONS['720p'],
           '1080p': CONFIG.LIVE.TRANSCODING.RESOLUTIONS['1080p'],
+          '1440p': CONFIG.LIVE.TRANSCODING.RESOLUTIONS['1440p'],
           '2160p': CONFIG.LIVE.TRANSCODING.RESOLUTIONS['2160p']
         }
       }

--- a/server/helpers/ffprobe-utils.ts
+++ b/server/helpers/ffprobe-utils.ts
@@ -188,6 +188,7 @@ function computeResolutionsToTranscode (videoFileResolution: number, type: 'vod'
     VideoResolution.H_720P,
     VideoResolution.H_240P,
     VideoResolution.H_1080P,
+    VideoResolution.H_1440P,
     VideoResolution.H_4K
   ]
 

--- a/server/initializers/checker-before-init.ts
+++ b/server/initializers/checker-before-init.ts
@@ -23,7 +23,7 @@ function checkMissedConfig () {
     'redundancy.videos.strategies', 'redundancy.videos.check_interval',
     'transcoding.enabled', 'transcoding.threads', 'transcoding.allow_additional_extensions', 'transcoding.hls.enabled',
     'transcoding.resolutions.0p', 'transcoding.resolutions.240p', 'transcoding.resolutions.360p', 'transcoding.resolutions.480p',
-    'transcoding.resolutions.720p', 'transcoding.resolutions.1080p', 'transcoding.resolutions.2160p',
+    'transcoding.resolutions.720p', 'transcoding.resolutions.1080p', 'transcoding.resolutions.1440p', 'transcoding.resolutions.2160p',
     'import.videos.http.enabled', 'import.videos.torrent.enabled', 'auto_blacklist.videos.of_users.enabled',
     'trending.videos.interval_days',
     'instance.name', 'instance.short_description', 'instance.description', 'instance.terms', 'instance.default_client_route',
@@ -41,7 +41,8 @@ function checkMissedConfig () {
     'live.enabled', 'live.allow_replay', 'live.max_duration', 'live.max_user_lives', 'live.max_instance_lives',
     'live.transcoding.enabled', 'live.transcoding.threads',
     'live.transcoding.resolutions.240p', 'live.transcoding.resolutions.360p', 'live.transcoding.resolutions.480p',
-    'live.transcoding.resolutions.720p', 'live.transcoding.resolutions.1080p', 'live.transcoding.resolutions.2160p'
+    'live.transcoding.resolutions.720p', 'live.transcoding.resolutions.1080p', 'live.transcoding.resolutions.1440p',
+    'live.transcoding.resolutions.2160p'
   ]
 
   const requiredAlternatives = [

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -189,6 +189,7 @@ const CONFIG = {
       get '480p' () { return config.get<boolean>('transcoding.resolutions.480p') },
       get '720p' () { return config.get<boolean>('transcoding.resolutions.720p') },
       get '1080p' () { return config.get<boolean>('transcoding.resolutions.1080p') },
+      get '1440p' () { return config.get<boolean>('transcoding.resolutions.1440p') },
       get '2160p' () { return config.get<boolean>('transcoding.resolutions.2160p') }
     },
     HLS: {
@@ -221,6 +222,7 @@ const CONFIG = {
         get '480p' () { return config.get<boolean>('live.transcoding.resolutions.480p') },
         get '720p' () { return config.get<boolean>('live.transcoding.resolutions.720p') },
         get '1080p' () { return config.get<boolean>('live.transcoding.resolutions.1080p') },
+        get '1440p' () { return config.get<boolean>('live.transcoding.resolutions.1440p') },
         get '2160p' () { return config.get<boolean>('live.transcoding.resolutions.2160p') }
       }
     }

--- a/server/middlewares/validators/config.ts
+++ b/server/middlewares/validators/config.ts
@@ -45,6 +45,7 @@ const customConfigUpdateValidator = [
   body('transcoding.resolutions.480p').isBoolean().withMessage('Should have a valid transcoding 480p resolution enabled boolean'),
   body('transcoding.resolutions.720p').isBoolean().withMessage('Should have a valid transcoding 720p resolution enabled boolean'),
   body('transcoding.resolutions.1080p').isBoolean().withMessage('Should have a valid transcoding 1080p resolution enabled boolean'),
+  body('transcoding.resolutions.1440p').isBoolean().withMessage('Should have a valid transcoding 1440p resolution enabled boolean'),
   body('transcoding.resolutions.2160p').isBoolean().withMessage('Should have a valid transcoding 2160p resolution enabled boolean'),
 
   body('transcoding.webtorrent.enabled').isBoolean().withMessage('Should have a valid webtorrent transcoding enabled boolean'),
@@ -75,6 +76,7 @@ const customConfigUpdateValidator = [
   body('live.transcoding.resolutions.480p').isBoolean().withMessage('Should have a valid transcoding 480p resolution enabled boolean'),
   body('live.transcoding.resolutions.720p').isBoolean().withMessage('Should have a valid transcoding 720p resolution enabled boolean'),
   body('live.transcoding.resolutions.1080p').isBoolean().withMessage('Should have a valid transcoding 1080p resolution enabled boolean'),
+  body('live.transcoding.resolutions.1440p').isBoolean().withMessage('Should have a valid transcoding 1440p resolution enabled boolean'),
   body('live.transcoding.resolutions.2160p').isBoolean().withMessage('Should have a valid transcoding 2160p resolution enabled boolean'),
 
   body('search.remoteUri.users').isBoolean().withMessage('Should have a remote URI search for users boolean'),

--- a/server/tests/api/check-params/config.ts
+++ b/server/tests/api/check-params/config.ts
@@ -92,6 +92,7 @@ describe('Test config API validators', function () {
         '480p': true,
         '720p': false,
         '1080p': false,
+        '1440p': false,
         '2160p': false
       },
       webtorrent: {
@@ -118,6 +119,7 @@ describe('Test config API validators', function () {
           '480p': true,
           '720p': true,
           '1080p': true,
+          '1440p': true,
           '2160p': true
         }
       }

--- a/server/tests/api/live/live-constraints.ts
+++ b/server/tests/api/live/live-constraints.ts
@@ -179,6 +179,7 @@ describe('Test live constraints', function () {
             '480p': true,
             '720p': true,
             '1080p': true,
+            '1440p': true,
             '2160p': true
           }
         }

--- a/server/tests/api/live/live-permanent.ts
+++ b/server/tests/api/live/live-permanent.ts
@@ -75,6 +75,7 @@ describe('Permenant live', function () {
             '480p': true,
             '720p': true,
             '1080p': true,
+            '1440p': true,
             '2160p': true
           }
         }
@@ -164,6 +165,7 @@ describe('Permenant live', function () {
             '480p': false,
             '720p': false,
             '1080p': false,
+            '1440p': false,
             '2160p': false
           }
         }

--- a/server/tests/api/live/live-save-replay.ts
+++ b/server/tests/api/live/live-save-replay.ts
@@ -99,6 +99,7 @@ describe('Save replay setting', function () {
             '480p': true,
             '720p': true,
             '1080p': true,
+            '1440p': true,
             '2160p': true
           }
         }

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -75,6 +75,7 @@ function checkInitialConfig (server: ServerInfo, data: CustomConfig) {
   expect(data.transcoding.resolutions['480p']).to.be.true
   expect(data.transcoding.resolutions['720p']).to.be.true
   expect(data.transcoding.resolutions['1080p']).to.be.true
+  expect(data.transcoding.resolutions['1440p']).to.be.true
   expect(data.transcoding.resolutions['2160p']).to.be.true
   expect(data.transcoding.webtorrent.enabled).to.be.true
   expect(data.transcoding.hls.enabled).to.be.true
@@ -91,6 +92,7 @@ function checkInitialConfig (server: ServerInfo, data: CustomConfig) {
   expect(data.live.transcoding.resolutions['480p']).to.be.false
   expect(data.live.transcoding.resolutions['720p']).to.be.false
   expect(data.live.transcoding.resolutions['1080p']).to.be.false
+  expect(data.live.transcoding.resolutions['1440p']).to.be.false
   expect(data.live.transcoding.resolutions['2160p']).to.be.false
 
   expect(data.import.videos.http.enabled).to.be.true
@@ -322,6 +324,7 @@ describe('Test config', function () {
           '480p': true,
           '720p': false,
           '1080p': false,
+          '1440p': false,
           '2160p': false
         },
         webtorrent: {
@@ -346,6 +349,7 @@ describe('Test config', function () {
             '480p': true,
             '720p': true,
             '1080p': true,
+            '1440p': true,
             '2160p': true
           }
         }

--- a/server/tests/api/server/stats.ts
+++ b/server/tests/api/server/stats.ts
@@ -153,6 +153,7 @@ describe('Test stats (excluding redundancy)', function () {
           '480p': false,
           '720p': false,
           '1080p': false,
+          '1440p': false,
           '2160p': false
         }
       }

--- a/server/tests/api/videos/audio-only.ts
+++ b/server/tests/api/videos/audio-only.ts
@@ -36,6 +36,7 @@ describe('Test audio only video transcoding', function () {
           '480p': false,
           '720p': false,
           '1080p': false,
+          '1440p': false,
           '2160p': false
         },
         hls: {

--- a/server/tests/api/videos/video-hls.ts
+++ b/server/tests/api/videos/video-hls.ts
@@ -202,6 +202,7 @@ describe('Test HLS videos', function () {
             '480p': true,
             '720p': true,
             '1080p': true,
+            '1440p': true,
             '2160p': true
           },
           hls: {

--- a/server/tests/cli/create-transcoding-job.ts
+++ b/server/tests/cli/create-transcoding-job.ts
@@ -33,6 +33,7 @@ describe('Test create transcoding jobs', function () {
         '480p': true,
         '720p': true,
         '1080p': true,
+        '1440p': true,
         '2160p': true
       },
       hls: {

--- a/shared/extra-utils/server/config.ts
+++ b/shared/extra-utils/server/config.ts
@@ -117,6 +117,7 @@ function updateCustomSubConfig (url: string, token: string, newConfig: DeepParti
         '480p': true,
         '720p': false,
         '1080p': false,
+        '1440p': false,
         '2160p': false
       },
       webtorrent: {
@@ -141,6 +142,7 @@ function updateCustomSubConfig (url: string, token: string, newConfig: DeepParti
           '480p': true,
           '720p': true,
           '1080p': true,
+          '1440p': true,
           '2160p': true
         }
       }

--- a/shared/models/server/custom-config.model.ts
+++ b/shared/models/server/custom-config.model.ts
@@ -7,6 +7,7 @@ export type ConfigResolutions = {
   '480p': boolean
   '720p': boolean
   '1080p': boolean
+  '1440p': boolean
   '2160p': boolean
 }
 

--- a/shared/models/videos/video-resolution.enum.ts
+++ b/shared/models/videos/video-resolution.enum.ts
@@ -7,6 +7,7 @@ export const enum VideoResolution {
   H_480P = 480,
   H_720P = 720,
   H_1080P = 1080,
+  H_1440P = 1440,
   H_4K = 2160
 }
 
@@ -53,9 +54,15 @@ function getBaseBitrate (resolution: number) {
     return 5200 * 1000
   }
 
+  if (resolution <= VideoResolution.H_1440P) {
+    // quality according to Google Live Encoder: 6000 - 13000 Kbps
+    // Quality according to YouTube Video Info: 8600 (av01) - 17000 (vp9.2) Kbps
+    return 10_000 * 1000
+  }
+
   // 4K
   // quality according to Google Live Encoder: 13000 - 34000 Kbps
-  return 22000 * 1000
+  return 22_000 * 1000
 }
 
 /**

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -3941,7 +3941,7 @@ components:
       properties:
         id:
           type: integer
-          description: 'Video resolution (240, 360, 720 ...)'
+          description: 'Video resolution (240, 360, 720, 1080, 1440 or 2160)'
           example: 240
         label:
           type: string
@@ -4828,6 +4828,8 @@ components:
                 720p:
                   type: boolean
                 1080p:
+                  type: boolean
+                1440p:
                   type: boolean
                 2160p:
                   type: boolean

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -106,6 +106,9 @@ transcoding:
     1080p:
       __name: "PEERTUBE_TRANSCODING_1080P"
       __format: "json"
+    1440p:
+      __name: "PEERTUBE_TRANSCODING_1440P"
+      __format: "json"
     2160p:
       __name: "PEERTUBE_TRANSCODING_2160P"
       __format: "json"


### PR DESCRIPTION
resolves #3500. The CI harness is supposedly enough to catch mistakes but I might need to add 1440p videos to it.