### PR TITLE
cli `auth add`: do not fail with extraneous characters

### DIFF
--- a/server/tests/cli/peertube.ts
+++ b/server/tests/cli/peertube.ts
@@ -66,6 +66,18 @@ describe('Test CLI wrapper', function () {
       await execCLI(`${env} ${cmd} auth add -u ${server.url} -U user_1 -p super_password`)
     })
 
+    it('Should not fail to add a user if there is a slash at the end of the instance URL', async function () {
+      this.timeout(60000)
+
+      const env = getEnvCli(server)
+      let fullServerURL
+      fullServerURL = server.url + '/'
+      await execCLI(`${env} ${cmd} auth add -u ${fullServerURL} -U user_1 -p super_password`)
+
+      fullServerURL = server.url + '/asdfasdf'
+      await execCLI(`${env} ${cmd} auth add -u ${fullServerURL} -U user_1 -p super_password`)
+    })
+
     it('Should default to this user', async function () {
       this.timeout(60000)
 

--- a/server/tools/peertube-auth.ts
+++ b/server/tools/peertube-auth.ts
@@ -80,8 +80,19 @@ program
         }
       }
     }, async (_, result) => {
+      const stripExtraneousFromPeerTubeUrl = function (url: string) {
+        // Get everything before the 3rd /.
+        const urlLength: number = url.includes('/', 8) ? url.indexOf('/', 8) : url.length
+
+        return url.substr(0, urlLength)
+      }
+
       // Check credentials
       try {
+        // Strip out everything after the domain:port.
+        // @see https://github.com/Chocobozzz/PeerTube/issues/3520
+        result.url = stripExtraneousFromPeerTubeUrl(result.url)
+
         await getAccessToken(result.url, result.username, result.password)
       } catch (err) {
         console.error(err.message)


### PR DESCRIPTION
## Description
**The Solution:**
I have hardened `auth add` by stripping out everything from the third '/' to the end of the instance URL.

**The Problem:**
When adding an authorization for the peertube-cli, before this commit you could not have anything after the domain_name:port.

For instance, if there was a trailing / in your instance URL, before this commit it will always fail with

    expected 200 "OK", got 404 "Not Found".

It took me over 20 minutes to figure out that this was the problem.

## Related issues

* Issue #3091: Peertube CLI auth got forbidden
* Issue #3520: Accept trailing slash with `peertube auth add`

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Please describe the tests that you ran to verify your changes.

I attempted to run the entire test suite, but after many failed starts and one really long one, I cancelled the run after it had been going 37+ minutes. I then attempted to run the CLI tests alone, but that, too, I cancelled after 27 minutes. I then commented out everything inside `server/tests/cli/index.ts` except the `peertube.ts`. I then attempted to run it via the command found in the `CONTRIBUTING.md`:

    TS_NODE_FILES=true npm run mocha -- --exit -r ts-node/register -r tsconfig-paths/register --bail server/tests/cli/index.ts 

but all I ended up with was:

     TypeError: Cannot read property 'app' of undefined

So yeah, I was unable to run the tests, but I did create tests for my own feature.

This is the first time I've ever attempted to run Mocha tests before, and I found it very confusing. I am used to the downright simplicity of `phpunit tests/MyTest.php` or even `phpunit --filter beginningOfMyTestCaseName`. I stumbled around worse than a drunken pirate fresh off a won parlay.
