### PR TITLE
Add short url option to share menu, enhances #534

### DIFF
--- a/client/src/app/shared/shared-share-modal/video-share.component.html
+++ b/client/src/app/shared/shared-share-modal/video-share.component.html
@@ -77,6 +77,16 @@
           </ng-template>
         </ng-container>
 
+        <ng-container ngbNavItem="shortUrl">
+          <a ngbNavLink i18n>Short URL</a>
+
+          <ng-template ngbNavContent>
+            <div class="nav-content">
+              <my-input-toggle-hidden [value]="getVideoShortUrl()" [withToggle]="false" [withCopy]="true" [show]="true" [readonly]="true"></my-input-toggle-hidden>
+            </div>
+          </ng-template>
+        </ng-container>
+
         <ng-container ngbNavItem="qrcode">
           <a ngbNavLink i18n>QR-Code</a>
 

--- a/client/src/app/shared/shared-share-modal/video-share.component.ts
+++ b/client/src/app/shared/shared-share-modal/video-share.component.ts
@@ -96,8 +96,8 @@ export class VideoShareComponent {
     return buildVideoOrPlaylistEmbed(embedUrl)
   }
 
-  getBaseUrl(id: string) {
-    let baseUrl = this.customizations.originUrl ? this.video.originInstanceUrl : window.location.origin
+  getBaseUrl (id: string) {
+    const baseUrl = this.customizations.originUrl ? this.video.originInstanceUrl : window.location.origin
     return baseUrl + '/videos/watch/' + id
   }
 

--- a/client/src/app/shared/shared-share-modal/video-share.component.ts
+++ b/client/src/app/shared/shared-share-modal/video-share.component.ts
@@ -25,7 +25,7 @@ type Customizations = {
   peertubeLink: boolean
 }
 
-type TabId = 'url' | 'qrcode' | 'embed'
+type TabId = 'url' | 'shortUrl' | 'qrcode' | 'embed'
 
 @Component({
   selector: 'my-video-share',
@@ -96,10 +96,19 @@ export class VideoShareComponent {
     return buildVideoOrPlaylistEmbed(embedUrl)
   }
 
-  getVideoUrl () {
+  getBaseUrl(id: string) {
     let baseUrl = this.customizations.originUrl ? this.video.originInstanceUrl : window.location.origin
-    baseUrl += '/videos/watch/' + this.video.uuid
-    const options = this.getVideoOptions(baseUrl)
+    return baseUrl + '/videos/watch/' + id
+  }
+
+  getVideoUrl () {
+    const options = this.getVideoOptions(this.getBaseUrl(this.video.uuid))
+
+    return buildVideoLink(options)
+  }
+
+  getVideoShortUrl () {
+    const options = this.getVideoOptions(this.getBaseUrl(this.video.id.toString()))
 
     return buildVideoLink(options)
   }


### PR DESCRIPTION
## Description

Creates a new tab in the share menu that displays a link using the instance's interal video ID instead of the UUID.
It's useful if you need shorter links.

## Related issues

#534 Add ability to create friendly url for video links

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Link creation works and creates valid urls. I can't test it for federated videos, but that should work, because I saw (using an API call like /videos/uuid-of-remote-video), that even a remote video has an id on the viewer's server.