### PR TITLE
Allow administrator to disable logging of ping requests

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -100,6 +100,7 @@ log:
     maxFileSize: 12MB
     maxFiles: 20
   anonymizeIP: false
+  log_ping_requests: true
 
 trending:
   videos:

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -100,6 +100,7 @@ log:
     maxFileSize: 12MB
     maxFiles: 20
   anonymizeIP: false
+  log_ping_requests: true
 
 trending:
   videos:

--- a/server.ts
+++ b/server.ts
@@ -158,7 +158,10 @@ morgan.token('user-agent', (req: express.Request) => {
   return req.get('user-agent')
 })
 app.use(morgan('combined', {
-  stream: { write: logger.info.bind(logger) }
+  stream: { write: logger.info.bind(logger) },
+  skip: function (req, res) {
+    return (req.path === '/api/v1/ping' && CONFIG.LOG.LOG_PING_REQUESTS === false)
+  },
 }))
 
 // For body requests

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -104,7 +104,8 @@ const CONFIG = {
       MAX_FILE_SIZE: bytes.parse(config.get<string>('log.rotation.maxFileSize')),
       MAX_FILES: config.get<number>('log.rotation.maxFiles')
     },
-    ANONYMIZE_IP: config.get<boolean>('log.anonymizeIP')
+    ANONYMIZE_IP: config.get<boolean>('log.anonymizeIP'),
+    LOG_PING_REQUESTS: config.get<boolean>('log.log_ping_requests')
   },
   TRENDING: {
     VIDEOS: {

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -42,6 +42,11 @@ smtp:
     __format: "json"
   from_address: "PEERTUBE_SMTP_FROM"
 
+log:
+  log_ping_requests:
+    __name: "PEERTUBE_LOG_PING_REQUESTS"
+    __format: "json"
+
 user:
   video_quota:
     __name: "PEERTUBE_USER_VIDEO_QUOTA"


### PR DESCRIPTION
## Description

Allow administrator to disable logging of ping requests on `/api/v1/ping`.

This is disabled by default, but can be enabled by setting `log.log_ping_requests` to `true` (or the `PEERTUBE_LOG_PING_REQUESTS` environment variable in Docker).

## Related issues

Implements #3544

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Not sure how I can implement unit test for that.