### PR TITLE
Warn/exit on unavailable port for RTPM/HTTP

### DIFF
--- a/server/helpers/utils.ts
+++ b/server/helpers/utils.ts
@@ -6,6 +6,7 @@ import { Instance as ParseTorrent } from 'parse-torrent'
 import { remove } from 'fs-extra'
 import { CONFIG } from '../initializers/config'
 import { isVideoFileExtnameValid } from './custom-validators/videos'
+import * as net from 'net'
 
 function deleteFileAsync (path: string) {
   remove(path)
@@ -86,6 +87,15 @@ function getUUIDFromFilename (filename: string) {
   return result[0]
 }
 
+function isPortTaken (port: number) {
+  return new Promise<boolean>((resolve, reject) => {
+    const tester = net.createServer()
+                      .once('error', (err: NodeJS.ErrnoException) => (err.code === 'EADDRINUSE' ? resolve(true) : reject(err)))
+                      .once('listening', () => tester.once('close', () => resolve(false)).close())
+                      .listen(port)
+  })
+}
+
 // ---------------------------------------------------------------------------
 
 export {
@@ -95,5 +105,6 @@ export {
   getSecureTorrentName,
   getServerCommit,
   generateVideoImportTmpPath,
-  getUUIDFromFilename
+  getUUIDFromFilename,
+  isPortTaken
 }


### PR DESCRIPTION
## Related issues

closes #3558

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, light tests as follows are enough

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->
I tested port messages via `ffmpeg -listen 1 -i rtmp://localhost:1935`.