### PR TITLE
higher priority for live transcoding compared to vod transcoding

### DIFF
--- a/server/helpers/ffmpeg-utils.ts
+++ b/server/helpers/ffmpeg-utils.ts
@@ -610,7 +610,10 @@ function presetOnlyAudio (command: ffmpeg.FfmpegCommand): ffmpeg.FfmpegCommand {
 
 function getFFmpeg (input: string, type: 'live' | 'vod') {
   // We set cwd explicitly because ffmpeg appears to create temporary files when trancoding which fails in read-only file systems
-  const command = ffmpeg(input, { niceness: FFMPEG_NICE.TRANSCODING, cwd: CONFIG.STORAGE.TMP_DIR })
+  const command = ffmpeg(input, {
+    niceness: type === 'live' ? FFMPEG_NICE.LIVE : FFMPEG_NICE.VOD,
+    cwd: CONFIG.STORAGE.TMP_DIR
+  })
 
   const threads = type === 'live'
     ? CONFIG.LIVE.TRANSCODING.THREADS

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -356,8 +356,11 @@ const VIDEO_RATE_TYPES: { [ id: string ]: VideoRateType } = {
 }
 
 const FFMPEG_NICE: { [ id: string ]: number } = {
-  THUMBNAIL: 2, // 2 just for don't blocking servers
-  TRANSCODING: 15
+  // parent process defaults to niceness = 0
+  // reminder: lower = higher priority, max value is 19, lowest is -20
+  THUMBNAIL: 2, // low value in order to avoid blocking server
+  LIVE: 9, // prioritize over VOD
+  VOD: 15
 }
 
 const VIDEO_CATEGORIES = {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Split live and vod transcoding niceness values to reflect their priorities.

Closes https://github.com/Chocobozzz/PeerTube/issues/3583

## Has this been tested?

- [x] 🙅 no, because changes are not significant enough.