### PR TITLE
Mention additional nginx modules required since #3313

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -1,7 +1,7 @@
 # Minimum Nginx version required:  1.13.0 (released Apr 25, 2017)
 # Please check your Nginx installation features the following modules via 'nginx -V':
-# STANDARD HTTP MODULES: Core, Proxy, Rewrite.
-# OPTIONAL HTTP MODULES: Gzip, Headers, HTTP/2, Log, Real IP, SSL, Thread Pool, Upstream.
+# STANDARD HTTP MODULES: AIO Multithreading, Core, Proxy, Rewrite.
+# OPTIONAL HTTP MODULES: Access, Gzip, Headers, HTTP/2, Log, Real IP, SSL, Thread Pool, Upstream.
 # THIRD PARTY MODULES:   None.
 
 server {

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -1,7 +1,6 @@
 # Minimum Nginx version required:  1.13.0 (released Apr 25, 2017)
 # Please check your Nginx installation features the following modules via 'nginx -V':
-# STANDARD HTTP MODULES: AIO Multithreading, Core, Proxy, Rewrite.
-# OPTIONAL HTTP MODULES: Access, Gzip, Headers, HTTP/2, Log, Real IP, SSL, Thread Pool, Upstream.
+# STANDARD HTTP MODULES: Core, Proxy, Rewrite, Access, Gzip, Headers, HTTP/2, Log, Real IP, SSL, Thread Pool, Upstream, AIO Multithreading.
 # THIRD PARTY MODULES:   None.
 
 server {


### PR DESCRIPTION
5f59cf077fd9f9c0c91c7bb56efbfd5db103bff2 introduced requirements on additional nginx modules:

nginx: [emerg] "aio threads" is unsupported on this platform in /etc/nginx/sites-enabled/peertube:247
https://nginx.org/en/docs/http/ngx_http_core_module.html#aio

nginx: [emerg] unknown directive "deny" in /etc/nginx/sites-enabled/peertube:83
https://nginx.org/en/docs/http/ngx_http_access_module.html

Note: Not sure how you differentiate between what is a `STANDARD` and an `OPTIONAL` HTTP MODULE in your documentation, so I put `AIO Multithreading` to `STANDARD` as it's a core module and `access` to `OPTIONAL` however when judging on what is required for the PeerTube included nginx config to actuall work there are no real `OPTIONAL` modules as every mising one will throw an error(?).