### PR TITLE
Allow users/visitors to search through an account's videos

### DIFF
--- a/client/src/app/+accounts/account-search/account-search.component.ts
+++ b/client/src/app/+accounts/account-search/account-search.component.ts
@@ -1,0 +1,91 @@
+import { Subscription } from 'rxjs'
+import { first, tap } from 'rxjs/operators'
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { ActivatedRoute, Router } from '@angular/router'
+import { AuthService, ConfirmService, LocalStorageService, Notifier, ScreenService, ServerService, UserService } from '@app/core'
+import { immutableAssign } from '@app/helpers'
+import { Account, AccountService, VideoService } from '@app/shared/shared-main'
+import { AbstractVideoList } from '@app/shared/shared-video-miniature'
+import { VideoFilter } from '@shared/models'
+
+@Component({
+  selector: 'my-account-search',
+  templateUrl: '../../shared/shared-video-miniature/abstract-video-list.html',
+  styleUrls: [
+    '../../shared/shared-video-miniature/abstract-video-list.scss'
+  ]
+})
+export class AccountSearchComponent extends AbstractVideoList implements OnInit, OnDestroy {
+  titlePage: string
+  loadOnInit = false
+
+  filter: VideoFilter = null
+
+  private account: Account
+  private accountSub: Subscription
+
+  constructor (
+    protected router: Router,
+    protected serverService: ServerService,
+    protected route: ActivatedRoute,
+    protected authService: AuthService,
+    protected userService: UserService,
+    protected notifier: Notifier,
+    protected confirmService: ConfirmService,
+    protected screenService: ScreenService,
+    protected storageService: LocalStorageService,
+    private accountService: AccountService,
+    private videoService: VideoService
+  ) {
+    super()
+  }
+
+  ngOnInit () {
+    super.ngOnInit()
+
+    this.enableAllFilterIfPossible()
+
+    // Parent get the account for us
+    this.accountSub = this.accountService.accountLoaded
+                          .pipe(first())
+                          .subscribe(account => {
+                            this.account = account
+
+                            this.reloadVideos()
+                            this.generateSyndicationList()
+                          })
+  }
+
+  ngOnDestroy () {
+    if (this.accountSub) this.accountSub.unsubscribe()
+
+    super.ngOnDestroy()
+  }
+
+  getVideosObservable (page: number) {
+    const newPagination = immutableAssign(this.pagination, { currentPage: page })
+    const options = {
+      account: this.account,
+      videoPagination: newPagination,
+      sort: this.sort,
+      nsfwPolicy: this.nsfwPolicy,
+      videoFilter: this.filter
+    }
+
+    return this.videoService
+               .getAccountVideos(options)
+               .pipe(
+                 tap(({ total }) => {
+                   this.titlePage = $localize`${total} results on this account for TODO`
+                 })
+               )
+  }
+
+  toggleModerationDisplay () {
+    this.filter = this.buildLocalFilter(this.filter, null)
+
+    this.reloadVideos()
+  }
+
+  generateSyndicationList () {}
+}

--- a/client/src/app/+accounts/account-search/account-search.component.ts
+++ b/client/src/app/+accounts/account-search/account-search.component.ts
@@ -19,6 +19,7 @@ export class AccountSearchComponent extends AbstractVideoList implements OnInit,
   titlePage: string
   loadOnInit = false
 
+  search = ''
   filter: VideoFilter = null
 
   private account: Account
@@ -62,6 +63,13 @@ export class AccountSearchComponent extends AbstractVideoList implements OnInit,
     super.ngOnDestroy()
   }
 
+  updateSearch (value: string) {
+    if (value === '') this.router.navigate(['../videos'], { relativeTo: this.route })
+    this.search = value
+
+    this.reloadVideos()
+  }
+
   getVideosObservable (page: number) {
     const newPagination = immutableAssign(this.pagination, { currentPage: page })
     const options = {
@@ -69,14 +77,17 @@ export class AccountSearchComponent extends AbstractVideoList implements OnInit,
       videoPagination: newPagination,
       sort: this.sort,
       nsfwPolicy: this.nsfwPolicy,
-      videoFilter: this.filter
+      videoFilter: this.filter,
+      search: this.search
     }
 
     return this.videoService
                .getAccountVideos(options)
                .pipe(
                  tap(({ total }) => {
-                   this.titlePage = $localize`${total} results on this account for TODO`
+                   this.titlePage = this.search
+                     ? $localize`Published ${total} videos matching "${this.search}"`
+                     : $localize`Published ${total} videos`
                  })
                )
   }
@@ -87,5 +98,7 @@ export class AccountSearchComponent extends AbstractVideoList implements OnInit,
     this.reloadVideos()
   }
 
-  generateSyndicationList () {}
+  generateSyndicationList () {
+    /* disable syndication */
+  }
 }

--- a/client/src/app/+accounts/accounts-routing.module.ts
+++ b/client/src/app/+accounts/accounts-routing.module.ts
@@ -5,6 +5,7 @@ import { AccountsComponent } from './accounts.component'
 import { AccountVideosComponent } from './account-videos/account-videos.component'
 import { AccountAboutComponent } from './account-about/account-about.component'
 import { AccountVideoChannelsComponent } from './account-video-channels/account-video-channels.component'
+import { AccountSearchComponent } from './account-search/account-search.component'
 
 const accountsRoutes: Routes = [
   {
@@ -22,19 +23,6 @@ const accountsRoutes: Routes = [
         pathMatch: 'full'
       },
       {
-        path: 'videos',
-        component: AccountVideosComponent,
-        data: {
-          meta: {
-            title: $localize`Account videos`
-          },
-          reuse: {
-            enabled: true,
-            key: 'account-videos-list'
-          }
-        }
-      },
-      {
         path: 'video-channels',
         component: AccountVideoChannelsComponent,
         data: {
@@ -49,6 +37,28 @@ const accountsRoutes: Routes = [
         data: {
           meta: {
             title: $localize`About account`
+          }
+        }
+      },
+      {
+        path: 'videos',
+        component: AccountVideosComponent,
+        data: {
+          meta: {
+            title: $localize`Account videos`
+          },
+          reuse: {
+            enabled: true,
+            key: 'account-videos-list'
+          }
+        }
+      },
+      {
+        path: 'search',
+        component: AccountSearchComponent,
+        data: {
+          meta: {
+            title: $localize`Search videos within account`
           }
         }
       }

--- a/client/src/app/+accounts/accounts.component.html
+++ b/client/src/app/+accounts/accounts.component.html
@@ -45,7 +45,7 @@
 
       <list-overflow [items]="links" [itemTemplate]="linkTemplate"></list-overflow>
 
-      <simple-search-input (searchChanged)="searchChanged($event)" (enter)="'search'"></simple-search-input>
+      <simple-search-input (searchChanged)="searchChanged($event)" name="search-videos" i18n-placeholder placeholder="Search videos"></simple-search-input>
     </div>
   </div>
 

--- a/client/src/app/+accounts/accounts.component.html
+++ b/client/src/app/+accounts/accounts.component.html
@@ -44,11 +44,13 @@
       </ng-template>
 
       <list-overflow [items]="links" [itemTemplate]="linkTemplate"></list-overflow>
+
+      <simple-search-input (searchChanged)="searchChanged($event)" (enter)="'search'"></simple-search-input>
     </div>
   </div>
 
   <div class="margin-content">
-    <router-outlet></router-outlet>
+    <router-outlet (activate)="onOutletLoaded($event)"></router-outlet>
   </div>
 </div>
 

--- a/client/src/app/+accounts/accounts.component.ts
+++ b/client/src/app/+accounts/accounts.component.ts
@@ -15,6 +15,7 @@ import { AccountSearchComponent } from './account-search/account-search.componen
 })
 export class AccountsComponent implements OnInit, OnDestroy {
   @ViewChild('accountReportModal') accountReportModal: AccountReportComponent
+  accountSearch: AccountSearchComponent
 
   account: Account
   accountUser: User
@@ -102,13 +103,14 @@ export class AccountsComponent implements OnInit, OnDestroy {
 
   onOutletLoaded (component: Component) {
     if (component instanceof AccountSearchComponent) {
-      console.log('AccounSearchComponent')
+      this.accountSearch = component
+    } else {
+      this.accountSearch = undefined
     }
-    console.log('not AccountSearchComponent')
   }
 
   searchChanged (search: string) {
-    console.log('search: ' + search)
+    if (this.accountSearch) this.accountSearch.updateSearch(search)
   }
 
   private onAccount (account: Account) {

--- a/client/src/app/+accounts/accounts.component.ts
+++ b/client/src/app/+accounts/accounts.component.ts
@@ -7,6 +7,7 @@ import { Account, AccountService, DropdownAction, ListOverflowItem, VideoChannel
 import { AccountReportComponent } from '@app/shared/shared-moderation'
 import { User, UserRight } from '@shared/models'
 import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
+import { AccountSearchComponent } from './account-search/account-search.component'
 
 @Component({
   templateUrl: './accounts.component.html',
@@ -97,6 +98,17 @@ export class AccountsComponent implements OnInit, OnDestroy {
     if (count === 1) return $localize`1 subscriber`
 
     return $localize`${count} subscribers`
+  }
+
+  onOutletLoaded (component: Component) {
+    if (component instanceof AccountSearchComponent) {
+      console.log('AccounSearchComponent')
+    }
+    console.log('not AccountSearchComponent')
+  }
+
+  searchChanged (search: string) {
+    console.log('search: ' + search)
   }
 
   private onAccount (account: Account) {

--- a/client/src/app/+accounts/accounts.module.ts
+++ b/client/src/app/+accounts/accounts.module.ts
@@ -8,6 +8,7 @@ import { SharedVideoMiniatureModule } from '@app/shared/shared-video-miniature'
 import { AccountAboutComponent } from './account-about/account-about.component'
 import { AccountVideoChannelsComponent } from './account-video-channels/account-video-channels.component'
 import { AccountVideosComponent } from './account-videos/account-videos.component'
+import { AccountSearchComponent } from './account-search/account-search.component'
 import { AccountsRoutingModule } from './accounts-routing.module'
 import { AccountsComponent } from './accounts.component'
 
@@ -27,7 +28,8 @@ import { AccountsComponent } from './accounts.component'
     AccountsComponent,
     AccountVideosComponent,
     AccountVideoChannelsComponent,
-    AccountAboutComponent
+    AccountAboutComponent,
+    AccountSearchComponent
   ],
 
   exports: [

--- a/client/src/app/shared/shared-main/misc/index.ts
+++ b/client/src/app/shared/shared-main/misc/index.ts
@@ -1,3 +1,4 @@
 export * from './help.component'
 export * from './list-overflow.component'
 export * from './top-menu-dropdown.component'
+export * from './simple-search-input.component'

--- a/client/src/app/shared/shared-main/misc/simple-search-input.component.html
+++ b/client/src/app/shared/shared-main/misc/simple-search-input.component.html
@@ -1,0 +1,13 @@
+<my-global-icon iconName="search" aria-label="Search" role="button" (click)="showInput()"></my-global-icon>
+
+<input
+  #searchVideos
+  name="search-videos"
+  type="text"
+  [(ngModel)]="search"
+  (ngModelChange)="searchChange"
+  i18n-placeholder placeholder="Search videos"
+  (focusout)="focusLost()"
+  (keyup.enter)="navigate()"
+  [hidden]="!shown"
+>

--- a/client/src/app/shared/shared-main/misc/simple-search-input.component.html
+++ b/client/src/app/shared/shared-main/misc/simple-search-input.component.html
@@ -1,13 +1,14 @@
-<my-global-icon iconName="search" aria-label="Search" role="button" (click)="showInput()"></my-global-icon>
+<span>
+  <my-global-icon iconName="search" aria-label="Search" role="button" (click)="showInput()"></my-global-icon>
 
-<input
-  #searchVideos
-  name="search-videos"
-  type="text"
-  [(ngModel)]="search"
-  (ngModelChange)="searchChange"
-  i18n-placeholder placeholder="Search videos"
-  (focusout)="focusLost()"
-  (keyup.enter)="navigate()"
-  [hidden]="!shown"
->
+  <input
+    #ref
+    type="text"
+    [(ngModel)]="value"
+    (focusout)="focusLost()"
+    (keyup.enter)="searchChange()"
+    [hidden]="!shown"
+    [name]="name"
+    [placeholder]="placeholder"
+  >
+</span>

--- a/client/src/app/shared/shared-main/misc/simple-search-input.component.scss
+++ b/client/src/app/shared/shared-main/misc/simple-search-input.component.scss
@@ -1,19 +1,24 @@
 @import '_variables';
 @import '_mixins';
 
+span {
+  opacity: .6;
+  
+  &:focus-within {
+    opacity: 1;
+  }
+}
+
 my-global-icon {
   height: 18px;
   position: relative;
   top: -2px;
-
-  opacity: .6;
-  color: pvar(--mainForegroundColor);
 }
 
 input {
   @include peertube-input-text(150px);
 
-  height: 24px; // maximum height for the account/video-channels links
+  height: 22px; // maximum height for the account/video-channels links
   padding-left: 10px;
   background-color: transparent;
   border: none;

--- a/client/src/app/shared/shared-main/misc/simple-search-input.component.scss
+++ b/client/src/app/shared/shared-main/misc/simple-search-input.component.scss
@@ -1,0 +1,24 @@
+@import '_variables';
+@import '_mixins';
+
+my-global-icon {
+  height: 18px;
+  position: relative;
+  top: -2px;
+
+  opacity: .6;
+  color: pvar(--mainForegroundColor);
+}
+
+input {
+  @include peertube-input-text(150px);
+
+  height: 24px; // maximum height for the account/video-channels links
+  padding-left: 10px;
+  background-color: transparent;
+  border: none;
+
+  &::placeholder {
+    font-size: 15px;
+  }
+}

--- a/client/src/app/shared/shared-main/misc/simple-search-input.component.ts
+++ b/client/src/app/shared/shared-main/misc/simple-search-input.component.ts
@@ -9,16 +9,17 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
   styleUrls: [ './simple-search-input.component.scss' ]
 })
 export class SimpleSearchInputComponent implements OnInit {
-  @ViewChild("searchVideos") input: ElementRef
+  @ViewChild('ref') input: ElementRef
 
-  @Input() enter: string
+  @Input() name = 'search'
+  @Input() placeholder = $localize`Search`
 
   @Output() searchChanged = new EventEmitter<string>()
 
-  search = ''
+  value = ''
   shown: boolean
 
-  private searchSubject= new Subject<string>()
+  private searchSubject = new Subject<string>()
 
   constructor (
     private router: Router,
@@ -33,26 +34,21 @@ export class SimpleSearchInputComponent implements OnInit {
         )
         .subscribe(value => this.searchChanged.emit(value))
 
-    this.searchSubject.next(this.search)
+    this.searchSubject.next(this.value)
   }
 
   showInput () {
     this.shown = true
-    setTimeout(()=> {
-      this.input.nativeElement.focus()
-    })
+    setTimeout(() => this.input.nativeElement.focus())
   }
 
   focusLost () {
-    if (this.search !== '') return
+    if (this.value !== '') return
     this.shown = false
   }
 
   searchChange () {
-    this.searchChanged.emit(this.search)
-  }
-
-  navigate () {
     this.router.navigate(['./search'], { relativeTo: this.route })
+    this.searchSubject.next(this.value)
   }
 }

--- a/client/src/app/shared/shared-main/misc/simple-search-input.component.ts
+++ b/client/src/app/shared/shared-main/misc/simple-search-input.component.ts
@@ -1,0 +1,58 @@
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core'
+import { ActivatedRoute, Router } from '@angular/router'
+import { Subject } from 'rxjs'
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
+
+@Component({
+  selector: 'simple-search-input',
+  templateUrl: './simple-search-input.component.html',
+  styleUrls: [ './simple-search-input.component.scss' ]
+})
+export class SimpleSearchInputComponent implements OnInit {
+  @ViewChild("searchVideos") input: ElementRef
+
+  @Input() enter: string
+
+  @Output() searchChanged = new EventEmitter<string>()
+
+  search = ''
+  shown: boolean
+
+  private searchSubject= new Subject<string>()
+
+  constructor (
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit () {
+    this.searchSubject
+        .pipe(
+          debounceTime(400),
+          distinctUntilChanged()
+        )
+        .subscribe(value => this.searchChanged.emit(value))
+
+    this.searchSubject.next(this.search)
+  }
+
+  showInput () {
+    this.shown = true
+    setTimeout(()=> {
+      this.input.nativeElement.focus()
+    })
+  }
+
+  focusLost () {
+    if (this.search !== '') return
+    this.shown = false
+  }
+
+  searchChange () {
+    this.searchChanged.emit(this.search)
+  }
+
+  navigate () {
+    this.router.navigate(['./search'], { relativeTo: this.route })
+  }
+}

--- a/client/src/app/shared/shared-main/shared-main.module.ts
+++ b/client/src/app/shared/shared-main/shared-main.module.ts
@@ -30,7 +30,7 @@ import { ActionDropdownComponent, ButtonComponent, DeleteButtonComponent, EditBu
 import { DateToggleComponent } from './date'
 import { FeedComponent } from './feeds'
 import { LoaderComponent, SmallLoaderComponent } from './loaders'
-import { HelpComponent, ListOverflowComponent, TopMenuDropdownComponent } from './misc'
+import { HelpComponent, ListOverflowComponent, TopMenuDropdownComponent, SimpleSearchInputComponent } from './misc'
 import { UserHistoryService, UserNotificationsComponent, UserNotificationService, UserQuotaComponent } from './users'
 import { RedundancyService, VideoImportService, VideoOwnershipService, VideoService } from './video'
 import { VideoCaptionService } from './video-caption'
@@ -88,6 +88,7 @@ import { VideoChannelService } from './video-channel'
     HelpComponent,
     ListOverflowComponent,
     TopMenuDropdownComponent,
+    SimpleSearchInputComponent,
 
     UserQuotaComponent,
     UserNotificationsComponent
@@ -140,6 +141,7 @@ import { VideoChannelService } from './video-channel'
     HelpComponent,
     ListOverflowComponent,
     TopMenuDropdownComponent,
+    SimpleSearchInputComponent,
 
     UserQuotaComponent,
     UserNotificationsComponent

--- a/client/src/app/shared/shared-main/video/video.service.ts
+++ b/client/src/app/shared/shared-main/video/video.service.ts
@@ -140,8 +140,9 @@ export class VideoService implements VideosProvider {
     sort: VideoSortField
     nsfwPolicy?: NSFWPolicyType
     videoFilter?: VideoFilter
+    search?: string
   }): Observable<ResultList<Video>> {
-    const { account, videoPagination, sort, videoFilter, nsfwPolicy } = parameters
+    const { account, videoPagination, sort, videoFilter, nsfwPolicy, search } = parameters
 
     const pagination = this.restService.componentPaginationToRestPagination(videoPagination)
 
@@ -154,6 +155,10 @@ export class VideoService implements VideosProvider {
 
     if (videoFilter) {
       params = params.set('filter', videoFilter)
+    }
+
+    if (search) {
+      params = params.set('search', search)
     }
 
     return this.authHttp

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -665,6 +665,11 @@
         font-size: 130%;
       }
     }
+
+    list-overflow {
+      display: inline-block;
+      width: max-content;
+    }
   }
 }
 

--- a/server/controllers/api/accounts.ts
+++ b/server/controllers/api/accounts.ts
@@ -175,7 +175,8 @@ async function listAccountVideos (req: express.Request, res: express.Response) {
     withFiles: false,
     accountId: account.id,
     user: res.locals.oauth ? res.locals.oauth.token.User : undefined,
-    countVideos
+    countVideos,
+    search: req.query.search
   }, 'filter:api.accounts.videos.list.params')
 
   const resultList = await Hooks.wrapPromiseFun(

--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -6,6 +6,7 @@ import { MVideoFullLight } from '@server/types/models'
 import { ServerErrorCode, UserRight, VideoChangeOwnershipStatus, VideoPrivacy } from '../../../../shared'
 import { VideoChangeOwnershipAccept } from '../../../../shared/models/videos/video-change-ownership-accept.model'
 import {
+  exists,
   isBooleanValid,
   isDateValid,
   isFileFieldValid,
@@ -444,6 +445,9 @@ const commonVideosFiltersValidator = [
     .optional()
     .customSanitizer(toBooleanOrNull)
     .custom(isBooleanValid).withMessage('Should have a valid skip count boolean'),
+  query('search')
+    .optional()
+    .custom(exists).withMessage('Should have a valid search'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking commons video filters query', { parameters: req.query })

--- a/server/tests/api/users/users-multiple-servers.ts
+++ b/server/tests/api/users/users-multiple-servers.ts
@@ -34,7 +34,7 @@ describe('Test users with multiple servers', function () {
   let userAvatarFilename: string
 
   before(async function () {
-    this.timeout(120000)
+    this.timeout(120_000)
 
     servers = await flushAndRunMultipleServers(3)
 
@@ -92,7 +92,7 @@ describe('Test users with multiple servers', function () {
   })
 
   it('Should be able to update my description', async function () {
-    this.timeout(10000)
+    this.timeout(10_000)
 
     await updateMyUser({
       url: servers[0].url,
@@ -109,7 +109,7 @@ describe('Test users with multiple servers', function () {
   })
 
   it('Should be able to update my avatar', async function () {
-    this.timeout(10000)
+    this.timeout(10_000)
 
     const fixture = 'avatar2.png'
 
@@ -164,8 +164,27 @@ describe('Test users with multiple servers', function () {
     }
   })
 
+  it('Should search through account videos', async function () {
+    this.timeout(10_000)
+
+    const resVideo = await uploadVideo(servers[0].url, userAccessToken, { name: 'Kami no chikara' })
+
+    await waitJobs(servers)
+
+    for (const server of servers) {
+      const res = await getAccountVideos(server.url, server.accessToken, 'user1@localhost:' + servers[0].port, 0, 5, undefined, {
+        search: 'Kami'
+      })
+
+      expect(res.body.total).to.equal(1)
+      expect(res.body.data).to.be.an('array')
+      expect(res.body.data).to.have.lengthOf(1)
+      expect(res.body.data[0].uuid).to.equal(resVideo.body.video.uuid)
+    }
+  })
+
   it('Should remove the user', async function () {
-    this.timeout(10000)
+    this.timeout(10_000)
 
     for (const server of servers) {
       const resAccounts = await getAccountsList(server.url, '-createdAt')

--- a/shared/extra-utils/videos/videos.ts
+++ b/shared/extra-utils/videos/videos.ts
@@ -194,7 +194,10 @@ function getAccountVideos (
   start: number,
   count: number,
   sort?: string,
-  query: { nsfw?: boolean } = {}
+  query: {
+    nsfw?: boolean
+    search?: string
+  } = {}
 ) {
   const path = '/api/v1/accounts/' + accountName + '/videos'
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Adds a search icon that on click reveals a search input. Upon validating the search (pressing enter), a listing of videos is taken and filtered with the search terms.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
related to meta #3486

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, I added tests to the test suite

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
![Screenshot_2021-01-12 Search videos within account - PeerTube](https://user-images.githubusercontent.com/6329880/104327069-b0c96080-54ea-11eb-827d-4b3bfb1780ed.png)