### PR TITLE
use yarn instead of npm

### DIFF
--- a/support/systemd/peertube.service
+++ b/support/systemd/peertube.service
@@ -8,7 +8,7 @@ Environment=NODE_ENV=production
 Environment=NODE_CONFIG_DIR=/var/www/peertube/config
 User=peertube
 Group=peertube
-ExecStart=/usr/bin/npm start
+ExecStart=/usr/bin/yarn start
 WorkingDirectory=/var/www/peertube/peertube-latest
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
The current documentation instructs instance admins to install yarn, not npm.

## Description

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
