### PR TITLE
localize decimal separator in video miniatures

### DIFF
--- a/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
+++ b/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
@@ -1,14 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core'
+import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core'
 
 // Thanks: https://github.com/danrevah/ngx-pipes/blob/master/src/ng-pipes/pipes/math/bytes.ts
 
 @Pipe({ name: 'myNumberFormatter' })
 export class NumberFormatterPipe implements PipeTransform {
-  private dictionary: Array<{max: number, type: string}> = [
-    { max: 1000, type: '' },
-    { max: 1000000, type: 'K' },
-    { max: 1000000000, type: 'M' }
-  ]
 
   /**
    * @param x number
@@ -21,14 +16,25 @@ export class NumberFormatterPipe implements PipeTransform {
     return +f
   }
 
+  private dictionary: Array<{max: number, type: string}> = [
+    { max: 1000, type: '' },
+    { max: 1000000, type: 'K' },
+    { max: 1000000000, type: 'M' }
+  ]
+  constructor (@Inject(LOCALE_ID) private localeId: string) {}
+
   transform (value: number) {
     const format = this.dictionary.find(d => value < d.max) || this.dictionary[this.dictionary.length - 1]
     const calc = value / (format.max / 1000)
     const integralPart = Math.floor(calc)
     const decimalPart = NumberFormatterPipe.getDecimalForNumber(calc)
+    const decimalSeparator = Intl.NumberFormat(this.localeId)
+      .formatToParts(1.1)
+      .find(part => part.type === 'decimal')
+      .value
 
     return integralPart < 10 && decimalPart > 0
-      ? `${integralPart}.${decimalPart}${format.type}`
+      ? `${integralPart}${decimalSeparator}${decimalPart}${format.type}`
       : `${integralPart}${format.type}`
   }
 }

--- a/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
+++ b/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
@@ -1,3 +1,4 @@
+import { formatNumber } from '@angular/common'
 import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core'
 
 // Thanks: https://github.com/danrevah/ngx-pipes/blob/master/src/ng-pipes/pipes/math/bytes.ts
@@ -28,13 +29,9 @@ export class NumberFormatterPipe implements PipeTransform {
     const calc = value / (format.max / 1000)
     const integralPart = Math.floor(calc)
     const decimalPart = NumberFormatterPipe.getDecimalForNumber(calc)
-    const decimalSeparator = Intl.NumberFormat(this.localeId)
-      .formatToParts(1.1)
-      .find(part => part.type === 'decimal')
-      .value
 
     return integralPart < 10 && decimalPart > 0
-      ? `${integralPart}${decimalSeparator}${decimalPart}${format.type}`
+      ? formatNumber(parseFloat(`${integralPart}.${decimalPart}`), this.localeId) + format.type
       : `${integralPart}${format.type}`
   }
 }

--- a/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
+++ b/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
@@ -28,10 +28,16 @@ export class NumberFormatterPipe implements PipeTransform {
     const calc = value / (format.max / 1000)
     const integralPart = Math.floor(calc)
     const decimalPart = NumberFormatterPipe.getDecimalForNumber(calc)
-    const decimalSeparator = Intl.NumberFormat(this.localeId)
-      .formatToParts(1.1)
-      .find(part => part.type === 'decimal')
-      .value
+    let decimalSeparator
+
+    try {
+      decimalSeparator = Intl.NumberFormat(this.localeId)
+        .formatToParts(1.1)
+        .find(part => part.type === 'decimal')
+        .value
+    } catch (error) {
+      decimalSeparator = ','
+    }
 
     return integralPart < 10 && decimalPart > 0
       ? `${integralPart}${decimalSeparator}${decimalPart}${format.type}`

--- a/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
+++ b/client/src/app/shared/shared-main/angular/number-formatter.pipe.ts
@@ -28,16 +28,10 @@ export class NumberFormatterPipe implements PipeTransform {
     const calc = value / (format.max / 1000)
     const integralPart = Math.floor(calc)
     const decimalPart = NumberFormatterPipe.getDecimalForNumber(calc)
-    let decimalSeparator
-
-    try {
-      decimalSeparator = Intl.NumberFormat(this.localeId)
-        .formatToParts(1.1)
-        .find(part => part.type === 'decimal')
-        .value
-    } catch (error) {
-      decimalSeparator = ','
-    }
+    const decimalSeparator = Intl.NumberFormat(this.localeId)
+      .formatToParts(1.1)
+      .find(part => part.type === 'decimal')
+      .value
 
     return integralPart < 10 && decimalPart > 0
       ? `${integralPart}${decimalSeparator}${decimalPart}${format.type}`

--- a/client/src/app/shared/shared-video-miniature/video-download.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.ts
@@ -1,5 +1,5 @@
 import { mapValues, pick } from 'lodash-es'
-import { Component, ElementRef, ViewChild } from '@angular/core'
+import { Component, ElementRef, Inject, LOCALE_ID, ViewChild } from '@angular/core'
 import { AuthService, Notifier } from '@app/core'
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { VideoCaption, VideoFile, VideoPrivacy } from '@shared/models'
@@ -34,13 +34,14 @@ export class VideoDownloadComponent {
   private numbersPipe: NumberFormatterPipe
 
   constructor (
+    @Inject(LOCALE_ID) private localeId: string,
     private notifier: Notifier,
     private modalService: NgbModal,
     private videoService: VideoService,
     private auth: AuthService
   ) {
     this.bytesPipe = new BytesPipe()
-    this.numbersPipe = new NumberFormatterPipe()
+    this.numbersPipe = new NumberFormatterPipe(this.localeId)
   }
 
   get typeText () {


### PR DESCRIPTION
## Description
[Some countries](https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_decimal_comma) are using comma as decimal separator.
https://caniuse.com/internationalization

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Switch language to Swedish.
1) See that decimal points for video views are comma.

## Screenshots

<!-- delete if not relevant -->
![image](https://user-images.githubusercontent.com/6680299/105882566-1860cf00-6006-11eb-9cde-df538f3b2157.png)
