### PR TITLE
client(video-watch): add share btn tooltip

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -104,7 +104,11 @@
                     <span class="icon-text" i18n>SUPPORT</span>
                   </button>
 
-                  <button (click)="showShareModal()" (keyup.enter)="showShareModal()" class="action-button">
+                  <button (click)="showShareModal()" (keyup.enter)="showShareModal()" class="action-button"
+                    [attr.aria-label]="tooltipShare"
+                    [ngbTooltip]="tooltipShare"
+                    placement="bottom auto"
+                    >
                     <my-global-icon iconName="share" aria-hidden="true"></my-global-icon>
                     <span class="icon-text" i18n>SHARE</span>
                   </button>

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -80,6 +80,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
   tooltipLike = ''
   tooltipDislike = ''
+  tooltipShare = ''
   tooltipSupport = ''
   tooltipSaveToPlaylist = ''
 
@@ -131,6 +132,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
   ) {
     this.tooltipLike = $localize`Like this video`
     this.tooltipDislike = $localize`Dislike this video`
+    this.tooltipShare = $localize`Share this video`
     this.tooltipSupport = $localize`Support options for this video`
     this.tooltipSaveToPlaylist = $localize`Save to playlist`
   }


### PR DESCRIPTION
## Description
Adds a tooltip to the share button below the video player.

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough


## Screenshots

![image](https://user-images.githubusercontent.com/6680299/106105313-17ce5280-6144-11eb-81fb-82bddab3c61b.png)

<!-- delete if not relevant -->
