### PR TITLE
cancel Import video job

### DIFF
--- a/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.html
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.html
@@ -32,10 +32,13 @@
       ></my-select-options>
     </div>
 
-    <input
-      type="button" i18n-value value="Import"
-      [disabled]="!isTargetUrlValid() || isImportingVideo" (click)="importVideo()"
-    />
+      <input
+        *ngIf="!isImportingVideo" type="button" i18n-value value="Import"
+        [disabled]="!isTargetUrlValid() || isImportingVideo" (click)="importVideo()"
+      />
+
+      <input *ngIf="isImportingVideo" type="button" class="grey-button" i18n-value value="Cancel" 
+        [disabled]="isCanceling" (click)="cancelImport()"/>
   </div>
 </div>
 
@@ -50,7 +53,7 @@
 </div>
 
 <!-- Hidden because we want to load the component -->
-<form [hidden]="!hasImportedVideo" novalidate [formGroup]="form">
+<form [hidden]="!hasImportedVideo || isCanceling" novalidate [formGroup]="form">
   <my-video-edit
     [form]="form" [formErrors]="formErrors" [videoCaptions]="videoCaptions" [schedulePublicationPossible]="false"
     [validationMessages]="validationMessages" [userVideoChannels]="userVideoChannels"


### PR DESCRIPTION
## Description
When importing a video with url, it was impossible to cancel the import.
Thanks to a cancel button and an action confirmation component, you can now cancel the import that is in progress.

_Torrent import will come soon 😀_

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
work on #3541

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots
![photo 3](https://user-images.githubusercontent.com/46953622/106249513-bc1eca80-6212-11eb-8bdf-912768654d76.png)

<!-- delete if not relevant -->
