### PR TITLE
Added s3 edge signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "apicache": "^1.4.0",
     "async": "^3.0.1",
     "async-lru": "^1.1.1",
+    "aws4": "^1.11.0",
     "bcrypt": "5.0.0",
     "bittorrent-tracker": "^9.0.0",
     "bluebird": "^3.5.0",

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -72,6 +72,11 @@ const CONFIG = {
     PLUGINS_DIR: buildPath(config.get<string>('storage.plugins')),
     CLIENT_OVERRIDES_DIR: buildPath(config.get<string>('storage.client_overrides'))
   },
+  S3: {
+    HOST: config.get<string>('s3.host'),
+    KEY_ID: config.get<string>('s3.key_id'),
+    KEY_SECRET: config.get<string>('s3.key_secret')
+  },
   WEBSERVER: {
     SCHEME: config.get<boolean>('webserver.https') === true ? 'https' : 'http',
     WS: config.get<boolean>('webserver.https') === true ? 'wss' : 'ws',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,7 +1295,7 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.8.0:
+aws4@^1.11.0, aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==


### PR DESCRIPTION
## Description

Using digitalocean spaces as per the docs required files to be public (per s3), otherwise private acl files did not work.  For greater control setting files as private is needed and for access to private files, pre-signing is required.  This change uses the aws4 npm library to pre-sign files using 3 additional configuration keys:

S3: {
    HOST: config.get<string>('s3.host'),
    KEY_ID: config.get<string>('s3.key_id'),
    KEY_SECRET: config.get<string>('s3.key_secret')
  }

Because the PeerTube docs recommend using redirects for S3, pre-signing the query is done so that it will be passed thru to the nginx CDN redirect.  I tested the digitalocean spaces edge endpoint and it works.  Pre-signing is done using the origin host but as per the response I received from Digitalocean support folks, the signature works with the edge servers, and I confirmed as much.

![image](https://user-images.githubusercontent.com/11353590/106410875-bbe02400-63f8-11eb-80b2-e9c22eb5d8e8.png)

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] yes, tested in a running instance but no unit tests added. 
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help


