### PR TITLE
generate unique thumbnail/preview filenames

### DIFF
--- a/server/controllers/lazy-static.ts
+++ b/server/controllers/lazy-static.ts
@@ -18,7 +18,7 @@ lazyStaticRouter.use(
 )
 
 lazyStaticRouter.use(
-  LAZY_STATIC_PATHS.PREVIEWS + ':uuid.jpg',
+  LAZY_STATIC_PATHS.PREVIEWS + ':filename',
   asyncMiddleware(getPreview)
 )
 
@@ -71,7 +71,7 @@ async function getAvatar (req: express.Request, res: express.Response) {
 }
 
 async function getPreview (req: express.Request, res: express.Response) {
-  const result = await VideosPreviewCache.Instance.getFilePath(req.params.uuid)
+  const result = await VideosPreviewCache.Instance.getFilePath(req.params.filename)
   if (!result) return res.sendStatus(HttpStatusCode.NOT_FOUND_404)
 
   return res.sendFile(result.path, { maxAge: STATIC_MAX_AGE.SERVER })

--- a/server/lib/files-cache/videos-preview-cache.ts
+++ b/server/lib/files-cache/videos-preview-cache.ts
@@ -1,6 +1,7 @@
 import { join } from 'path'
 import { FILES_CACHE } from '../../initializers/constants'
 import { VideoModel } from '../../models/video/video'
+import { ThumbnailModel } from '../../models/video/thumbnail'
 import { AbstractVideoStaticFileCache } from './abstract-video-static-file-cache'
 import { doRequestAndSaveToFile } from '@server/helpers/requests'
 
@@ -16,13 +17,14 @@ class VideosPreviewCache extends AbstractVideoStaticFileCache <string> {
     return this.instance || (this.instance = new this())
   }
 
-  async getFilePathImpl (videoUUID: string) {
-    const video = await VideoModel.loadByUUID(videoUUID)
+  async getFilePathImpl (filename: string) {
+    const { videoId } = await ThumbnailModel.loadByName(filename)
+    const video = await VideoModel.load(videoId)
     if (!video) return undefined
 
     if (video.isOwned()) return { isOwned: true, path: video.getPreview().getPath() }
 
-    return this.loadRemoteFile(videoUUID)
+    return this.loadRemoteFile(video.uuid)
   }
 
   protected async loadRemoteFile (key: string) {

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1826,7 +1826,7 @@ export class VideoModel extends Model {
   }
 
   generateThumbnailName () {
-    return this.uuid + '.jpg'
+    return this.uuid + '_' + +((new Date()).getTime() / 1000) + '.jpg'
   }
 
   getMiniature () {
@@ -1836,7 +1836,7 @@ export class VideoModel extends Model {
   }
 
   generatePreviewName () {
-    return this.uuid + '.jpg'
+    return this.uuid + '_' + +((new Date()).getTime() / 1000) + '.jpg'
   }
 
   hasPreview () {


### PR DESCRIPTION
## Description
Each time a new preview image is uploaded a new filename is generated. This makes it possible to use aggressive caching for the previews and new file uploads will give immediate effect.

## Related issues
closes #3678


## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

* Change video preview image and verify that the preview and thumbnail image is getting updated without doing a reload in the browser.