### PR TITLE
add best trending strategy based on Reddit's best

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -271,6 +271,7 @@
                   <option i18n value="/videos/overview">Discover videos</option>
                   <optgroup i18n-label label="Trending pages">
                     <option i18n value="/videos/trending">Default trending page</option>
+                    <option i18n value="/videos/trending?alg=best" [disabled]="!trendingVideosAlgorithmsEnabledIncludes('best')">Best videos</option>
                     <option i18n value="/videos/trending?alg=hot" [disabled]="!trendingVideosAlgorithmsEnabledIncludes('hot')">Hot videos</option>
                     <option i18n value="/videos/trending?alg=most-viewed" [disabled]="!trendingVideosAlgorithmsEnabledIncludes('most-viewed')">Most viewed videos</option>
                     <option i18n value="/videos/trending?alg=most-liked" [disabled]="!trendingVideosAlgorithmsEnabledIncludes('most-liked')">Most liked videos</option>
@@ -288,6 +289,7 @@
                   <label i18n for="trendingVideosAlgorithmsDefault">Default trending page</label>
                   <div class="peertube-select-container">
                     <select id="trendingVideosAlgorithmsDefault" formControlName="default" class="form-control">
+                      <option i18n value="best">Best videos</option>
                       <option i18n value="hot">Hot videos</option>
                       <option i18n value="most-viewed">Most viewed videos</option>
                       <option i18n value="most-liked">Most liked videos</option>

--- a/client/src/app/+videos/video-list/trending/video-trending-header.component.ts
+++ b/client/src/app/+videos/video-list/trending/video-trending-header.component.ts
@@ -36,6 +36,13 @@ export class VideoTrendingHeaderComponent extends VideoListHeaderComponent imple
 
     this.buttons = [
       {
+        label: $localize`:A variant of Trending videos based on the number of recent interactions, minus user history:Best`,
+        iconName: 'award',
+        value: 'best',
+        tooltip: $localize`Videos totalizing the most interactions for recent videos, minus user history`,
+        hidden: true
+      },
+      {
         label: $localize`:A variant of Trending videos based on the number of recent interactions:Hot`,
         iconName: 'flame',
         value: 'hot',

--- a/client/src/app/core/server/server.service.ts
+++ b/client/src/app/core/server/server.service.ts
@@ -131,7 +131,7 @@ export class ServerService {
       videos: {
         intervalDays: 0,
         algorithms: {
-          enabled: [ 'hot', 'most-viewed', 'most-liked' ],
+          enabled: [ 'best', 'hot', 'most-viewed', 'most-liked' ],
           default: 'most-viewed'
         }
       }

--- a/client/src/app/shared/shared-icons/global-icon.component.ts
+++ b/client/src/app/shared/shared-icons/global-icon.component.ts
@@ -71,7 +71,8 @@ const icons = {
   'live': require('!!raw-loader?!../../../assets/images/feather/live.svg').default,
   'repeat': require('!!raw-loader?!../../../assets/images/feather/repeat.svg').default,
   'message-circle': require('!!raw-loader?!../../../assets/images/feather/message-circle.svg').default,
-  'codesandbox': require('!!raw-loader?!../../../assets/images/feather/codesandbox.svg').default
+  'codesandbox': require('!!raw-loader?!../../../assets/images/feather/codesandbox.svg').default,
+  'award': require('!!raw-loader?!../../../assets/images/feather/award.svg').default
 }
 
 export type GlobalIconName = keyof typeof icons

--- a/client/src/assets/images/feather/award.svg
+++ b/client/src/assets/images/feather/award.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-award"><circle cx="12" cy="8" r="7"></circle><polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88"></polyline></svg>

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -110,7 +110,8 @@ trending:
     interval_days: 7 # Compute trending videos for the last x days
     algorithms:
       enabled:
-        - 'hot' # adaptation of the Reddit 'Hot' algorithm
+        - 'best' # adaptation of Reddit's 'Best' algorithm (Hot minus History)
+        - 'hot' # adaptation of Reddit's 'Hot' algorithm
         - 'most-viewed' # default, used initially by PeerTube as the trending page
         - 'most-liked'
       default: 'most-viewed'

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -108,7 +108,8 @@ trending:
     interval_days: 7 # Compute trending videos for the last x days
     algorithms:
       enabled:
-        - 'hot' # adaptation of the Reddit 'Hot' algorithm
+        - 'best' # adaptation of Reddit's 'Best' algorithm (Hot minus History)
+        - 'hot' # adaptation of Reddit's 'Hot' algorithm
         - 'most-viewed' # default, used initially by PeerTube as the trending page
         - 'most-liked'
       default: 'most-viewed'

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -72,7 +72,7 @@ const SORTABLE_COLUMNS = {
   FOLLOWERS: [ 'createdAt', 'state', 'score' ],
   FOLLOWING: [ 'createdAt', 'redundancyAllowed', 'state' ],
 
-  VIDEOS: [ 'name', 'duration', 'createdAt', 'publishedAt', 'originallyPublishedAt', 'views', 'likes', 'trending', 'hot' ],
+  VIDEOS: [ 'name', 'duration', 'createdAt', 'publishedAt', 'originallyPublishedAt', 'views', 'likes', 'trending', 'hot', 'best' ],
 
   // Don't forget to update peertube-search-index with the same values
   VIDEOS_SEARCH: [ 'name', 'duration', 'createdAt', 'publishedAt', 'originallyPublishedAt', 'views', 'likes', 'match' ],

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1090,7 +1090,9 @@ export class VideoModel extends Model {
     const trendingDays = options.sort.endsWith('trending')
       ? CONFIG.TRENDING.VIDEOS.INTERVAL_DAYS
       : undefined
-    const hot = options.sort.endsWith('hot')
+    let trendingAlgorithm
+    if (options.sort.endsWith('hot')) trendingAlgorithm = 'hot'
+    if (options.sort.endsWith('best')) trendingAlgorithm = 'best'
 
     const serverActor = await getServerActor()
 
@@ -1120,7 +1122,7 @@ export class VideoModel extends Model {
       user: options.user,
       historyOfUser: options.historyOfUser,
       trendingDays,
-      hot,
+      trendingAlgorithm,
       search: options.search
     }
 

--- a/server/tests/api/check-params/config.ts
+++ b/server/tests/api/check-params/config.ts
@@ -141,7 +141,7 @@ describe('Test config API validators', function () {
     trending: {
       videos: {
         algorithms: {
-          enabled: [ 'hot', 'most-viewed', 'most-liked' ],
+          enabled: [ 'best', 'hot', 'most-viewed', 'most-liked' ],
           default: 'most-viewed'
         }
       }

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -375,7 +375,7 @@ describe('Test config', function () {
       trending: {
         videos: {
           algorithms: {
-            enabled: [ 'hot', 'most-viewed', 'most-liked' ],
+            enabled: [ 'best', 'hot', 'most-viewed', 'most-liked' ],
             default: 'hot'
           }
         }

--- a/server/tests/api/videos/single-server.ts
+++ b/server/tests/api/videos/single-server.ts
@@ -363,6 +363,14 @@ describe('Test a single server', function () {
     expect(videos.length).to.equal(2)
   })
 
+  it('Should list and sort by best in descending order', async function () {
+    const res = await getVideosListPagination(server.url, 0, 2, '-best')
+
+    const videos = res.body.data
+    expect(res.body.total).to.equal(6)
+    expect(videos.length).to.equal(2)
+  })
+
   it('Should update a video', async function () {
     const attributes = {
       name: 'my super video updated',

--- a/shared/extra-utils/server/config.ts
+++ b/shared/extra-utils/server/config.ts
@@ -164,7 +164,7 @@ function updateCustomSubConfig (url: string, token: string, newConfig: DeepParti
     trending: {
       videos: {
         algorithms: {
-          enabled: [ 'hot', 'most-viewed', 'most-liked' ],
+          enabled: [ 'best', 'hot', 'most-viewed', 'most-liked' ],
           default: 'hot'
         }
       }

--- a/shared/models/videos/video-sort-field.type.ts
+++ b/shared/models/videos/video-sort-field.type.ts
@@ -8,4 +8,5 @@ export type VideoSortField =
 
   // trending sorts
   'trending' | '-trending' |
-  'hot' | '-hot'
+  'hot' | '-hot' |
+  'best' | '-best'


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
inspired from https://www.reddit.com/r/changelog/comments/7spgg0/best_is_the_new_hotness/
this implementation only adds freshness, and doesn't personalize based
on subscribed communities yet.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
None.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, I added tests to the test suite

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
![Screenshot_2021-02-02 Trending videos - PeerTube](https://user-images.githubusercontent.com/6329880/106602032-bd2a6180-655c-11eb-8b9c-675f890c3a24.png)

## Questions

Should I merge this with `hot` sort?
Should I only display `best` sort for logged-in users?