### PR TITLE
Rewrite prose for JavaScript disabled message

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -18,6 +18,12 @@
       .icon-logo {
         background-image: url(/client/assets/images/logo.svg?[logoContentHash]);
       }
+      .script-disclaimer {
+        display: block;
+        font-size: 20px;
+        max-width: 600px;
+        margin: 0 auto;
+      }
     </style>
 
     <!-- base url -->
@@ -37,11 +43,23 @@
   <body id="custom-css">
 
     <noscript>
-      <p>It seems you are either <strong>blocking or disabling Javascript</strong> on your browser, and we totally get that. However this endpoint uses Angular, so the front end is in full JavaScript and won't work without it.</p>
+      <div class="script-disclaimer">
+        <h1>PeerTube</h1>
 
-      <p>There might be numerous reasons you refuse to use JavaScript. If it just has to do with security (or lack thereof) of JavaScript-based web applications, then depending on your threat menace you might want to go through the code running on the node you are trying to access, and look for security audits.</p>
+        <h2>JavaScript required</h2>
 
-      <p>There are other non JS-based unofficial clients to access PeerTube. You can find a list maintained by the PeerTube project in <a href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md">the thid-party applications section</a>. You can also develop your own as our code is open source and libre software under the <a href="https://github.com/Chocobozzz/PeerTube/blob/develop/LICENSE" target="_blank" rel="noopener">GNU AGPLv3.0</a> and documented on <a href="https://docs.joinpeertube.org/api-rest-reference.html">docs.joinpeertube.org</a>.</p>
+        <p>It seems you've either blocked or disabled JavaScript in your web browser. We totally get that. However, this frontend won't work without it.</p>
+
+        <p>If you are concerned about the security and privacy (or lack thereof) of JavaScript web applications, you may like to review the source code of the instance you're accessing, or look for security audits.</p>
+
+        <h2>Your options</h2>
+
+        <ul>
+          <li>Allow JavaScript in your browser</li>
+          <li><a href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md">Use a third-party application to browse</a></li>
+          <li>Review the source code on <a href="https://github.com/Chocobozzz/PeerTube">GitHub</a> or <a href="https://framagit.org/framasoft/peertube/PeerTube">Framasoft's GitLab</a>
+        </ul>
+      </div>
     </noscript>
 
     <div id="incompatible-browser" class="alert alert-danger" style="display: none">

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -18,12 +18,6 @@
       .icon-logo {
         background-image: url(/client/assets/images/logo.svg?[logoContentHash]);
       }
-      .script-disclaimer {
-        display: block;
-        font-size: 20px;
-        max-width: 600px;
-        margin: 0 auto;
-      }
     </style>
 
     <!-- base url -->
@@ -42,30 +36,33 @@
   <!-- 3. Display the application -->
   <body id="custom-css">
 
-    <noscript>
-      <div class="script-disclaimer">
-        <h1>PeerTube</h1>
+    <noscript class="alert alert-light" role="alert">
+      <h1 class="alert-heading">PeerTube</h1>
+      <h2 class="mb-3">JavaScript required</h2>
 
-        <h2>JavaScript required</h2>
+      <p>It seems JavaScript is either blocked or disabled in your web browser. We totally get that. However, this page will not work without it.</p>
+      <p>If you are concerned about the security and privacy (or lack thereof) of JavaScript web applications, you might want to review the source code of the instance you are trying to access, or look for security audits.</p>
 
-        <p>It seems you've either blocked or disabled JavaScript in your web browser. We totally get that. However, this frontend won't work without it.</p>
+      <hr>
 
-        <p>If you are concerned about the security and privacy (or lack thereof) of JavaScript web applications, you may like to review the source code of the instance you're accessing, or look for security audits.</p>
+      <h2 class="mb-3">Your options</h2>
 
-        <h2>Your options</h2>
-
-        <ul>
-          <li>Allow JavaScript in your browser</li>
-          <li><a href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md">Use a third-party application to browse</a></li>
-          <li>Review the source code on <a href="https://github.com/Chocobozzz/PeerTube">GitHub</a> or <a href="https://framagit.org/framasoft/peertube/PeerTube">Framasoft's GitLab</a>
-        </ul>
-      </div>
+      <ul>
+        <li>Allow JavaScript in your browser</li>
+        <li>Use one of the <a class="alert-link" href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md" target="_blank">third-party applications</a> to browse this instance</li>
+        <li>Review the source code on <a class="alert-link" href="https://github.com/Chocobozzz/PeerTube" target="_blank">GitHub</a> or <a class="alert-link" href="https://framagit.org/framasoft/peertube/PeerTube" target="_blank">Framasoft's GitLab</a>, and ask for eventual modifications to the instance owner.
+      </ul>
     </noscript>
 
-    <div id="incompatible-browser" class="alert alert-danger" style="display: none">
+    <div id="incompatible-browser" class="alert alert-light" role="alert" style="display: none">
+      <h1 class="alert-heading">PeerTube</h1>
+      <h2 class="mb-3">Incompatible browser</h2>
+
       <p>We are sorry but it seems that PeerTube is not compatible with your web browser.</p>
-      <p>Please try with the latest version of <a href="https://www.mozilla.org" target="_blank">Mozilla Firefox</a>.</p>
-      <p>If you think this is a mistake, do not hesitate <a href="https://github.com/Chocobozzz/PeerTube/issues/new" target="_blank">to report it</a>.</p>
+
+      <hr>
+      <p>Please try with the latest version of <a class="alert-link" href="https://www.mozilla.org" target="_blank">Mozilla Firefox</a>.</p>
+      <p class="mb-0">If you think this is a mistake, please <a class="alert-link" href="https://github.com/Chocobozzz/PeerTube/issues/new" target="_blank">report it</a>.</p>
     </div>
 
     <script type="text/javascript">

--- a/client/src/sass/application.scss
+++ b/client/src/sass/application.scss
@@ -71,12 +71,12 @@ body {
   background-color: pvar(--mainHoverColor);
 }
 
+noscript,
 #incompatible-browser {
-  display: none;
-  text-align: center;
-  position: absolute;
-  width: 100%;
-  top: 45%;
+  display: block;
+  font-size: 1.2rem;
+  max-width: 600px;
+  margin: 1rem auto;
 }
 
 strong {


### PR DESCRIPTION
## Description

This should improve the clarity of the message and make it easy to
understand what the problem is at a glance.

- Clearly show that the page is PeerTube, without having to read the whole prose
- Clearly show that the problem is JavaScript, without having to read the whole prose
- Reorganise suggestions into a bullet list

I figured this was trivial enough that I didn't need to open an issue for discussion first. Just let me know if you have comments :)

## Has this been tested?

Yes, manually, by loading the HTML file in a browser with scripts disabled, and checking that the page looked like what I wanted.