### PR TITLE
Update production.md

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -149,6 +149,7 @@ Since our nginx template supports webroot renewal, we suggest you to update the 
 
 ```
 $ # Replace authenticator = standalone by authenticator = webroot
+$ # Add webroot_path = /var/www/certbot
 $ sudo vim /etc/letsencrypt/renewal/your-domain.com.conf
 ```
 


### PR DESCRIPTION
## Description

Add webroot_path to the certbot renew configuration.

## Related issues

If not preset, "certbot renew" is not working.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

