### PR TITLE
Update dependencies.md

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -25,7 +25,7 @@ _note_: only **LTS** versions of external dependencies are supported. If no LTS 
 1. On a fresh Debian/Ubuntu, as root user, install basic utility programs needed for the installation
 
 ```
-# apt-get install curl sudo unzip vim
+# apt-get install curl sudo unzip vim cron
 ```
 
 2. It would be wise to disable root access and to continue this tutorial with a user with sudoers group access


### PR DESCRIPTION
## Description

Cron is not installed on fresh Debian.

## Related issues

If "cron" is not installed, certbot can not renew certificate.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

