### PR TITLE
Tighten hotkeys definitions

### DIFF
--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -527,6 +527,9 @@ export class PeertubePlayerManager {
   }
 
   private static addHotkeysOptions (plugins: VideoJSPluginOptions) {
+    const isNaked = (event: KeyboardEvent, key: string) =>
+      (!event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && event.key === key)
+
     Object.assign(plugins, {
       hotkeys: {
         skipInitialFocus: true,
@@ -542,7 +545,7 @@ export class PeertubePlayerManager {
 
         fullscreenKey: function (event: KeyboardEvent) {
           // fullscreen with the f key or Ctrl+Enter
-          return event.key === 'f' || (event.ctrlKey && event.key === 'Enter')
+          return isNaked(event, 'f') || (!event.altKey && event.ctrlKey && event.key === 'Enter')
         },
 
         seekStep: function (event: KeyboardEvent) {
@@ -561,7 +564,7 @@ export class PeertubePlayerManager {
         customKeys: {
           increasePlaybackRateKey: {
             key: function (event: KeyboardEvent) {
-              return event.key === '>'
+              return isNaked(event, '>')
             },
             handler: function (player: videojs.Player) {
               const newValue = Math.min(player.playbackRate() + 0.1, 5)
@@ -570,7 +573,7 @@ export class PeertubePlayerManager {
           },
           decreasePlaybackRateKey: {
             key: function (event: KeyboardEvent) {
-              return event.key === '<'
+              return isNaked(event, '<')
             },
             handler: function (player: videojs.Player) {
               const newValue = Math.max(player.playbackRate() - 0.1, 0.10)
@@ -579,7 +582,7 @@ export class PeertubePlayerManager {
           },
           frameByFrame: {
             key: function (event: KeyboardEvent) {
-              return event.key === '.'
+              return isNaked(event, '.')
             },
             handler: function (player: videojs.Player) {
               player.pause()

--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -543,22 +543,17 @@ export class PeertubePlayerManager {
         enableVolumeScroll: false,
         enableModifiersForNumbers: false,
 
+        rewindKey: function (event: KeyboardEvent) {
+          return isNaked(event, 'ArrowLeft')
+        },
+
+        forwardKey: function (event: KeyboardEvent) {
+          return isNaked(event, 'ArrowRight')
+        },
+
         fullscreenKey: function (event: KeyboardEvent) {
           // fullscreen with the f key or Ctrl+Enter
           return isNaked(event, 'f') || (!event.altKey && event.ctrlKey && event.key === 'Enter')
-        },
-
-        seekStep: function (event: KeyboardEvent) {
-          // mimic VLC seek behavior, and default to 5 (original value is 5).
-          if (event.ctrlKey && event.altKey) {
-            return 5 * 60
-          } else if (event.ctrlKey) {
-            return 60
-          } else if (event.altKey) {
-            return 10
-          } else {
-            return 5
-          }
         },
 
         customKeys: {


### PR DESCRIPTION
## Description
* Stricten _fullscreen_ hotkey to only be targeted when shift, ctrl, alt and meta key isn't pressed.
* Stricten _increase/decrease playback rate_ hotkey to only be targeted when shift, ctrl, alt and meta key isn't pressed.
* Stricten _frame by frame_ hotkey to only be targeted when ctrl, alt and meta key isn't pressed.
* Remove VLC mimic when using arrow keys to instead popular video web apps.

## Related issues

fixes #2810

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Play a video and try hotkeys listen under _Description_.