### PR TITLE
Add libvips to OpenBSD dependencies list

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -347,7 +347,7 @@ rc-service postgresql-11 start
 1. Install Packages:
 
 ```
-pkg_add sudo bash wget git python nginx pkgconf postgresql-server postgresql-contrib redis openssl
+pkg_add sudo bash wget git python nginx pkgconf postgresql-server postgresql-contrib redis openssl libvips
 ```
 
 2. Install yarn:


### PR DESCRIPTION
## Description
Forgot to include libvips as a dependency. This change fixes that

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
