### PR TITLE
Show error modal upon uncatched JS error

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import 'focus-visible'
 import { environment } from 'src/environments/environment'
 import { APP_BASE_HREF, registerLocaleData } from '@angular/common'
-import { NgModule } from '@angular/core'
+import { ErrorHandler, NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { ServiceWorkerModule } from '@angular/service-worker'
 import { ServerService } from '@app/core'
@@ -24,6 +24,7 @@ import { SharedGlobalIconModule } from './shared/shared-icons'
 import { SharedInstanceModule } from './shared/shared-instance'
 import { SharedMainModule } from './shared/shared-main'
 import { SharedUserInterfaceSettingsModule } from './shared/shared-user-settings'
+import { CustomErrorHandler } from './custom-error-handler'
 
 registerLocaleData(localeOc, 'oc')
 
@@ -83,6 +84,10 @@ registerLocaleData(localeOc, 'oc')
     {
       provide: APP_BASE_HREF,
       useValue: '/'
+    },
+    {
+      provide: ErrorHandler,
+      useClass: CustomErrorHandler
     }
   ]
 })

--- a/client/src/app/custom-error-handler.ts
+++ b/client/src/app/custom-error-handler.ts
@@ -1,0 +1,56 @@
+import { ErrorHandler } from '@angular/core'
+
+export class CustomErrorHandler implements ErrorHandler {
+  isModalOpen = false
+
+  handleError (error: any) {
+    if (!this.isModalOpen) {
+      this.showModal()
+    }
+
+    console.error(error)
+  }
+
+  private createElement ({
+        className = '',
+        type = 'div'
+    }) {
+    const elem = document.createElement(type)
+    elem.className = className
+
+    return elem
+  }
+
+  private showModal () {
+    const modal = this.createElement({ className: 'd-block modal show fade' })
+    const modalDialog = this.createElement({ className: 'modal-dialog modal-dialog-centered' })
+    modal.appendChild(modalDialog)
+    const modalContent = this.createElement({ className: 'modal-content' })
+    modalDialog.appendChild(modalContent)
+    const modalHeader = this.createElement({ className: 'modal-header' })
+    modalContent.appendChild(modalHeader)
+    const modalTitle = this.createElement({ className: 'modal-title', type: 'h4' })
+    modalTitle.innerText = 'Something went wrong'
+    modalHeader.appendChild(modalTitle)
+    const modalBody = this.createElement({ className: 'modal-body' })
+    modalContent.appendChild(modalBody)
+    const modalBodyInner = this.createElement({})
+    modalBodyInner.innerText = 'We are sorry but it seems that an unexpected error happened. Please contact the site administrator if the error remains.'
+    modalBody.appendChild(modalBodyInner)
+    const modalFooter = this.createElement({ className: 'modal-footer inputs' })
+    modalContent.appendChild(modalFooter)
+    const okButton = this.createElement({ className: 'action-button-submit', type: 'input' })
+    okButton.setAttribute('value', 'Close')
+    okButton.setAttribute('type', 'button')
+    okButton.addEventListener('click', () => {
+      this.isModalOpen = false
+      document.body.removeChild(modal)
+      document.body.className = document.body.className.replace(' modal-open', '')
+    })
+    modalFooter.appendChild(okButton)
+
+    document.body.appendChild(modal)
+    document.body.className += ' modal-open'
+    this.isModalOpen = true
+  }
+}


### PR DESCRIPTION
## Description
Handle uncatched JS errors by logging the error and show a modal.

## Related issues
closes #3736

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1. Add `throw Error();` in AppComponents `ngOnInit`.
2. Load the page.

1. Load PeerTube in Chrome 40.
2. See "Incompatible browser" screen.

## Screenshots

![image](https://user-images.githubusercontent.com/6680299/108061501-b588b380-7058-11eb-9a0d-035b46432d71.png)

![image](https://user-images.githubusercontent.com/6680299/108062233-c980e500-7059-11eb-8846-942fb02d49d6.png)
