### PR TITLE
add channel and playlist stats to server stats endpoint

### DIFF
--- a/server/lib/stat-manager.ts
+++ b/server/lib/stat-manager.ts
@@ -3,8 +3,10 @@ import { UserModel } from '@server/models/account/user'
 import { ActorFollowModel } from '@server/models/activitypub/actor-follow'
 import { VideoRedundancyModel } from '@server/models/redundancy/video-redundancy'
 import { VideoModel } from '@server/models/video/video'
+import { VideoChannelModel } from '@server/models/video/video-channel'
 import { VideoCommentModel } from '@server/models/video/video-comment'
 import { VideoFileModel } from '@server/models/video/video-file'
+import { VideoPlaylistModel } from '@server/models/video/video-playlist'
 import { ActivityType, ServerStats, VideoRedundancyStrategyWithManual } from '@shared/models'
 
 class StatsManager {
@@ -46,21 +48,36 @@ class StatsManager {
     const { totalUsers, totalDailyActiveUsers, totalWeeklyActiveUsers, totalMonthlyActiveUsers } = await UserModel.getStats()
     const { totalInstanceFollowers, totalInstanceFollowing } = await ActorFollowModel.getStats()
     const { totalLocalVideoFilesSize } = await VideoFileModel.getStats()
+    const {
+      totalLocalVideoChannels,
+      totalLocalDailyActiveVideoChannels,
+      totalLocalWeeklyActiveVideoChannels,
+      totalLocalMonthlyActiveVideoChannels
+    } = await VideoChannelModel.getStats()
+    const { totalLocalPlaylists } = await VideoPlaylistModel.getStats()
 
     const videosRedundancyStats = await this.buildRedundancyStats()
 
     const data: ServerStats = {
-      totalLocalVideos,
-      totalLocalVideoViews,
-      totalLocalVideoFilesSize,
-      totalLocalVideoComments,
-      totalVideos,
-      totalVideoComments,
-
       totalUsers,
       totalDailyActiveUsers,
       totalWeeklyActiveUsers,
       totalMonthlyActiveUsers,
+
+      totalLocalVideos,
+      totalLocalVideoViews,
+      totalLocalVideoComments,
+      totalLocalVideoFilesSize,
+
+      totalVideos,
+      totalVideoComments,
+
+      totalLocalVideoChannels,
+      totalLocalDailyActiveVideoChannels,
+      totalLocalWeeklyActiveVideoChannels,
+      totalLocalMonthlyActiveVideoChannels,
+
+      totalLocalPlaylists,
 
       totalInstanceFollowers,
       totalInstanceFollowing,

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -347,11 +347,11 @@ export class VideoChannelModel extends Model {
       }
 
       const query = `
-SELECT          Count(DISTINCT("VideoChannelModel"."id")) AS "count"
+SELECT          COUNT(DISTINCT("VideoChannelModel"."id")) AS "count"
 FROM            "videoChannel"                            AS "VideoChannelModel"
 INNER JOIN      "video"                                   AS "Videos"
 ON              "VideoChannelModel"."id" = "Videos"."channelId"
-AND             ("Videos"."createdAt" > Now() - interval '${days}d')
+AND             ("Videos"."publishedAt" > Now() - interval '${days}d')
 INNER JOIN      "account" AS "Account"
 ON              "VideoChannelModel"."accountId" = "Account"."id"
 INNER JOIN      "actor" AS "Account->Actor"

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -1,4 +1,4 @@
-import { FindOptions, Includeable, literal, Op, ScopeOptions } from 'sequelize'
+import { FindOptions, Includeable, literal, Op, QueryTypes, ScopeOptions } from 'sequelize'
 import {
   AllowNull,
   BeforeDestroy,
@@ -336,6 +336,47 @@ export class VideoChannelModel extends Model {
     }
 
     return VideoChannelModel.count(query)
+  }
+
+  static async getStats () {
+
+    function getActiveVideoChannels (days: number) {
+      const options = {
+        type: QueryTypes.SELECT as QueryTypes.SELECT,
+        raw: true
+      }
+
+      const query = `
+SELECT          Count(DISTINCT("VideoChannelModel"."id")) AS "count"
+FROM            "videoChannel"                            AS "VideoChannelModel"
+INNER JOIN      "video"                                   AS "Videos"
+ON              "VideoChannelModel"."id" = "Videos"."channelId"
+AND             ("Videos"."createdAt" > Now() - interval '${days}d')
+INNER JOIN      "account" AS "Account"
+ON              "VideoChannelModel"."accountId" = "Account"."id"
+INNER JOIN      "actor" AS "Account->Actor"
+ON              "Account"."actorId" = "Account->Actor"."id"
+AND             "Account->Actor"."serverId" IS NULL
+LEFT OUTER JOIN "server" AS "Account->Actor->Server"
+ON              "Account->Actor"."serverId" = "Account->Actor->Server"."id"`
+
+      return VideoChannelModel.sequelize.query<{ count: string }>(query, options)
+                              .then(r => parseInt(r[0].count, 10))
+    }
+
+    const totalLocalVideoChannels = await VideoChannelModel.count()
+    const totalLocalDailyActiveVideoChannels = await getActiveVideoChannels(1)
+    const totalLocalWeeklyActiveVideoChannels = await getActiveVideoChannels(7)
+    const totalLocalMonthlyActiveVideoChannels = await getActiveVideoChannels(30)
+    const totalHalfYearActiveVideoChannels = await getActiveVideoChannels(180)
+
+    return {
+      totalLocalVideoChannels,
+      totalLocalDailyActiveVideoChannels,
+      totalLocalWeeklyActiveVideoChannels,
+      totalLocalMonthlyActiveVideoChannels,
+      totalHalfYearActiveVideoChannels
+    }
   }
 
   static listForApi (parameters: {

--- a/server/tests/api/server/stats.ts
+++ b/server/tests/api/server/stats.ts
@@ -70,6 +70,7 @@ describe('Test stats (excluding redundancy)', function () {
     expect(data.totalVideos).to.equal(1)
     expect(data.totalInstanceFollowers).to.equal(2)
     expect(data.totalInstanceFollowing).to.equal(1)
+    expect(data.totalLocalPlaylists).to.equal(0)
   })
 
   it('Should have the correct stats on instance 2', async function () {
@@ -85,6 +86,7 @@ describe('Test stats (excluding redundancy)', function () {
     expect(data.totalVideos).to.equal(1)
     expect(data.totalInstanceFollowers).to.equal(1)
     expect(data.totalInstanceFollowing).to.equal(1)
+    expect(data.totalLocalPlaylists).to.equal(0)
   })
 
   it('Should have the correct stats on instance 3', async function () {
@@ -99,6 +101,7 @@ describe('Test stats (excluding redundancy)', function () {
     expect(data.totalVideos).to.equal(1)
     expect(data.totalInstanceFollowing).to.equal(1)
     expect(data.totalInstanceFollowers).to.equal(0)
+    expect(data.totalLocalPlaylists).to.equal(0)
   })
 
   it('Should have the correct total videos stats after an unfollow', async function () {
@@ -113,7 +116,7 @@ describe('Test stats (excluding redundancy)', function () {
     expect(data.totalVideos).to.equal(0)
   })
 
-  it('Should have the correct active users stats', async function () {
+  it('Should have the correct active user/channels stats', async function () {
     const server = servers[0]
 
     {
@@ -122,6 +125,10 @@ describe('Test stats (excluding redundancy)', function () {
       expect(data.totalDailyActiveUsers).to.equal(1)
       expect(data.totalWeeklyActiveUsers).to.equal(1)
       expect(data.totalMonthlyActiveUsers).to.equal(1)
+
+      expect(data.totalLocalDailyActiveVideoChannels).to.equal(1)
+      expect(data.totalLocalWeeklyActiveVideoChannels).to.equal(1)
+      expect(data.totalLocalMonthlyActiveVideoChannels).to.equal(1)
     }
 
     {

--- a/shared/models/server/server-stats.model.ts
+++ b/shared/models/server/server-stats.model.ts
@@ -13,6 +13,13 @@ export interface ServerStats {
   totalVideos: number
   totalVideoComments: number
 
+  totalLocalVideoChannels: number
+  totalLocalDailyActiveVideoChannels: number
+  totalLocalWeeklyActiveVideoChannels: number
+  totalLocalMonthlyActiveVideoChannels: number
+
+  totalLocalPlaylists: number
+
   totalInstanceFollowers: number
   totalInstanceFollowing: number
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Adds the number of local playlists, local channels and active local channels on various timeframes (akin to active users stats): daily/weekly/monthly.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, I added tests to the test suite, though they might not be enough