### PR TITLE
Add missing dependency to Debian / Ubuntu section

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -39,7 +39,7 @@ _note_: only **LTS** versions of external dependencies are supported. If no LTS 
 
 ```
 sudo apt update
-sudo apt install certbot nginx ffmpeg postgresql postgresql-contrib openssl g++ make redis-server git python-dev cron
+sudo apt install certbot nginx ffmpeg postgresql postgresql-contrib openssl g++ make redis-server git python-dev cron wget
 ffmpeg -version # Should be >= 4.1
 g++ -v # Should be >= 5.x
 ```


### PR DESCRIPTION
## Description

The "Production guide" states to use `wget` to download the latest version of the Peertube client, and it was not included in the `apt install` dependency list

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->
