### PR TITLE
Fix titles do not trim leading and trailing spaces

### DIFF
--- a/client/src/app/shared/form-validators/video-validators.ts
+++ b/client/src/app/shared/form-validators/video-validators.ts
@@ -1,12 +1,22 @@
-import { AbstractControl, ValidationErrors, ValidatorFn, Validators } from '@angular/forms'
+import { AbstractControl, ValidationErrors, ValidatorFn, Validators, FormControl } from '@angular/forms'
 import { BuildFormValidator } from './form-validator.model'
 
+export const trimValidator: ValidatorFn = (control: FormControl) => {
+  if (control.value.startsWith(' ') || control.value.endsWith(' ')) {
+    return {
+      'spaces': true
+    }
+  }
+  return null;
+};
+
 export const VIDEO_NAME_VALIDATOR: BuildFormValidator = {
-  VALIDATORS: [ Validators.required, Validators.minLength(3), Validators.maxLength(120) ],
+  VALIDATORS: [ Validators.required, Validators.minLength(3), Validators.maxLength(120), trimValidator ],
   MESSAGES: {
     'required': $localize`Video name is required.`,
     'minlength': $localize`Video name must be at least 3 characters long.`,
-    'maxlength': $localize`Video name cannot be more than 120 characters long.`
+    'maxlength': $localize`Video name cannot be more than 120 characters long.`,
+    'spaces': $localize`Video name has leading or trailing whitespace.`
   }
 }
 


### PR DESCRIPTION
## Description

Fix titles do not trim leading and trailing spaces

## Related issues

fixes #3623 

## Has this been tested?

- [x ] 🙅 no, because they aren't needed

1. Upload/Edit video properties
2. Type a leading space or a trailing space


