### PR TITLE
Hide publish button when video publishing is unavailable

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="header-right">
-      <my-header class="w-100 d-flex justify-content-end"></my-header>
+      <my-header class="w-100 d-flex justify-content-end" [showPublishButton]="isUploadEnabled()"></my-header>
     </div>
   </div>
 

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -116,11 +116,9 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   isUploadEnabled () {
-    if (this.authService.isLoggedIn()) {
-      return this.authService.getUser().videoQuota !== 0
-    } else {
-      return this.serverConfig.user.videoQuota !== 0
-    }
+    return this.authService.isLoggedIn()
+      ? this.authService.getUser().videoQuota !== 0
+      : this.serverConfig.user.videoQuota !== 0
   }
 
   hideBroadcastMessage () {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -115,6 +115,14 @@ export class AppComponent implements OnInit, AfterViewInit {
     return this.authService.isLoggedIn()
   }
 
+  isUploadEnabled () {
+    if (this.authService.isLoggedIn()) {
+      return this.authService.getUser().videoQuota !== 0
+    } else {
+      return this.serverConfig.user.videoQuota !== 0
+    }
+  }
+
   hideBroadcastMessage () {
     peertubeLocalStorage.setItem(AppComponent.BROADCAST_MESSAGE_KEY, this.serverConfig.broadcastMessage.message)
 

--- a/client/src/app/header/header.component.html
+++ b/client/src/app/header/header.component.html
@@ -1,6 +1,6 @@
 <my-search-typeahead class="w-100 d-flex justify-content-end"></my-search-typeahead>
 
-<a class="publish-button" routerLink="/videos/upload">
+<a *ngIf="showPublishButton" class="publish-button" routerLink="/videos/upload">
   <my-global-icon iconName="upload" aria-hidden="true"></my-global-icon>
   <span i18n class="publish-button-label">Publish</span>
 </a>

--- a/client/src/app/header/header.component.ts
+++ b/client/src/app/header/header.component.ts
@@ -7,5 +7,5 @@ import { Component, Input } from '@angular/core'
 })
 
 export class HeaderComponent {
-  @Input() showPublishButton: boolean
+  @Input() showPublishButton = true
 }

--- a/client/src/app/header/header.component.ts
+++ b/client/src/app/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core'
+import { Component, Input } from '@angular/core'
 
 @Component({
   selector: 'my-header',
@@ -6,4 +6,6 @@ import { Component } from '@angular/core'
   styleUrls: [ './header.component.scss' ]
 })
 
-export class HeaderComponent {}
+export class HeaderComponent {
+  @Input() showPublishButton: boolean
+}


### PR DESCRIPTION
## Description
Hides publish button, top right corner, when uploads are disabled.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
Closes #3807 

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Set video quota for new users to unlimited.
1) Logout.
1) See the upload button.

1) Set video quota for new users to 0.
1) Logout.
1) Don't see the upload button.

1) Set the video quota for new users to 0.
1) Set the video quota for a particular user to unlimited.
1) Login as that user.
1) See the publish button.


## Screenshots

<!-- delete if not relevant -->
![image](https://user-images.githubusercontent.com/6680299/109695312-08e81f00-7b8c-11eb-9dc2-044498f64f9f.png)

