### PR TITLE
use yaml.load instead of yaml.safeLoad in upgrade script

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -35,10 +35,10 @@ fi
 if [ -x "$(command -v pg_dump)" ]
 then 
   SQL_BACKUP_PATH="$PEERTUBE_PATH/backup/sql-peertube_prod-$(date +"%Y%m%d-%H%M").bak" 
-  DB_USER=$(node -e "console.log(require('js-yaml').safeLoad(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['username'])")
-  DB_PASS=$(node -e "console.log(require('js-yaml').safeLoad(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['password'])")
-  DB_HOST=$(node -e "console.log(require('js-yaml').safeLoad(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['hostname'])")
-  DB_SUFFIX=$(node -e "console.log(require('js-yaml').safeLoad(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['suffix'])")
+  DB_USER=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['username'])")
+  DB_PASS=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['password'])")
+  DB_HOST=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['hostname'])")
+  DB_SUFFIX=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['suffix'])")
   mkdir -p $PEERTUBE_PATH/backup
   PGPASSWORD=$DB_PASS pg_dump -U $DB_USER -h $DB_HOST -F c "peertube${DB_SUFFIX}" -f "$SQL_BACKUP_PATH"
 else


### PR DESCRIPTION
## Description

fix upgrade.sh after 3.1.0

I just upgraded to v3.1.0-rc.1, but the upgrade got interrupted (I didn't have a symlink from python3 to python, which the youtube-dl installer expected).

I ran the upgrade script again and only got the following error:

> /var/www/peertube/versions/peertube-v3.1.0-rc.1/node_modules/js-yaml/index.js:10
>     throw new Error('Function yaml.' + from + ' is removed in js-yaml 4. ' +
>     ^
> 
> Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
>     at Object.safeLoad (/var/www/peertube/versions/peertube-v3.1.0-rc.1/node_modules/js-yaml/index.js:10:11)
>     at [eval]:1:32
>     at Script.runInThisContext (vm.js:120:18)
>     at Object.runInThisContext (vm.js:309:38)
>     at Object.<anonymous> ([eval]-wrapper:10:26)
>     at Module._compile (internal/modules/cjs/loader.js:999:30)
>     at evalScript (internal/process/execution.js:94:25)
>     at internal/main/eval_string.js:23:3

I guess this part of the npm install has already finished and it seems like js-yaml doesn't allow using yaml.safeLoad any more. 
So I had to apply this change to the upgrade script for it to work again.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

