### PR TITLE
fix: long text on modals

### DIFF
--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -115,6 +115,7 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
 
   .modal-content {
     background-color: pvar(--mainBackgroundColor);
+    word-break: break-all;
   }
 
   .modal-header {


### PR DESCRIPTION
## Description
Fix long word on modal.

## Related issues
Fixes #3492 

## Tested
- Tested in chrome. With this video: https://videos.lukesmith.xyz/videos/watch/e0f5a4d7-070d-4a03-aca4-3d898b5c5002

## Screenshots
![Screenshot_29](https://user-images.githubusercontent.com/12100597/110237460-815c3080-7f3c-11eb-9ee5-8e6709f8445f.png)


