### PR TITLE
Change copy icon

### DIFF
--- a/client/src/app/+accounts/accounts.component.html
+++ b/client/src/app/+accounts/accounts.component.html
@@ -12,7 +12,7 @@
             <button [cdkCopyToClipboard]="account.nameWithHostForced" (click)="activateCopiedMessage()"
                     class="btn btn-outline-secondary btn-sm copy-button"
             >
-              <span class="glyphicon glyphicon-copy"></span>
+              <span class="glyphicon glyphicon-duplicate"></span>
             </button>
           </div>
           <span *ngIf="accountUser?.blocked" [ngbTooltip]="accountUser.blockedReason" class="badge badge-danger" i18n>Banned</span>

--- a/client/src/app/+video-channels/video-channels.component.html
+++ b/client/src/app/+video-channels/video-channels.component.html
@@ -12,7 +12,7 @@
             <button [cdkCopyToClipboard]="videoChannel.nameWithHostForced" (click)="activateCopiedMessage()"
                     class="btn btn-outline-secondary btn-sm copy-button"
             >
-              <span class="glyphicon glyphicon-copy"></span>
+              <span class="glyphicon glyphicon-duplicate"></span>
             </button>
           </div>
         </div>

--- a/client/src/app/shared/shared-forms/input-toggle-hidden.component.html
+++ b/client/src/app/shared/shared-forms/input-toggle-hidden.component.html
@@ -14,7 +14,7 @@
       *ngIf="withCopy" [cdkCopyToClipboard]="input.value" (click)="activateCopiedMessage()" type="button"
       class="btn btn-outline-secondary" i18n-title title="Copy"
     >
-      <span class="glyphicon glyphicon-copy"></span>
+      <span class="glyphicon glyphicon-duplicate"></span>
     </button>
   </div>
 </div>

--- a/client/src/app/shared/shared-forms/input-toggle-hidden.component.html
+++ b/client/src/app/shared/shared-forms/input-toggle-hidden.component.html
@@ -12,9 +12,10 @@
 
     <button
       *ngIf="withCopy" [cdkCopyToClipboard]="input.value" (click)="activateCopiedMessage()" type="button"
-      class="btn btn-outline-secondary" i18n-title title="Copy"
+      class="btn btn-outline-secondary text-uppercase" i18n-title title="Copy"
     >
       <span class="glyphicon glyphicon-duplicate"></span>
+      Copy
     </button>
   </div>
 </div>

--- a/client/src/app/shared/shared-video-miniature/video-download.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.html
@@ -32,7 +32,7 @@
         <input #urlInput (click)="urlInput.select()" type="text" class="form-control input-sm readonly" readonly [value]="getLink()" />
         <div class="input-group-append">
           <button [cdkCopyToClipboard]="urlInput.value" (click)="activateCopiedMessage()" type="button" class="btn btn-outline-secondary">
-            <span class="glyphicon glyphicon-copy"></span>
+            <span class="glyphicon glyphicon-duplicate"></span>
           </button>
         </div>
       </div>

--- a/client/src/app/shared/shared-video-miniature/video-download.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.html
@@ -31,8 +31,9 @@
 
         <input #urlInput (click)="urlInput.select()" type="text" class="form-control input-sm readonly" readonly [value]="getLink()" />
         <div class="input-group-append">
-          <button [cdkCopyToClipboard]="urlInput.value" (click)="activateCopiedMessage()" type="button" class="btn btn-outline-secondary">
+          <button [cdkCopyToClipboard]="urlInput.value" (click)="activateCopiedMessage()" type="button" class="btn btn-outline-secondary text-uppercase">
             <span class="glyphicon glyphicon-duplicate"></span>
+            Copy
           </button>
         </div>
       </div>

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -9,6 +9,10 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
   animation: spin .7s infinite linear;
 }
 
+.glyphicon-duplicate {
+  font-size: 70%;
+}
+
 .flex-auto {
   flex: auto;
 }


### PR DESCRIPTION
## Description
1) Replaces `icon-copy` with `icon-duplicate` since the latter is more common (https://www.google.com/search?q=copy+icon&source=lnms&tbm=isch&sa=X&ved=2ahUKEwiI1OS1rpLvAhVpkosKHfrTBAQQ_AUoAXoECBQQAw&biw=1650&bih=819)
1) Adds "Copy" text next to the icon when used in input fields.

## Related issues
* #3810 

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Visit a video page and open share modal.
1) Visit a video page and open download modal.
1) Visit an account page and check "copy account name" icon.
1) Visit a video channel page and check "copy channel name" icon.

## Screenshots

![image](https://user-images.githubusercontent.com/6680299/111596791-d36b4480-87cd-11eb-8177-f7ead6cbe58c.png)
![image](https://user-images.githubusercontent.com/6680299/111596822-dd8d4300-87cd-11eb-853c-30a7a0d7aabb.png)
![image](https://user-images.githubusercontent.com/6680299/111596870-eaaa3200-87cd-11eb-8546-72e65ce3eb54.png)
![image](https://user-images.githubusercontent.com/6680299/111596903-f3026d00-87cd-11eb-9953-2aa7f84f7563.png)
