### PR TITLE
Set direct download as default download method

### DIFF
--- a/client/src/app/shared/shared-video-miniature/video-download.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.ts
@@ -16,7 +16,7 @@ type FileMetadata = { [key: string]: { label: string, value: string }}
 export class VideoDownloadComponent {
   @ViewChild('modal', { static: true }) modal: ElementRef
 
-  downloadType: 'direct' | 'torrent' = 'torrent'
+  downloadType: 'direct' | 'torrent' = 'direct'
   resolutionId: number | string = -1
   subtitleLanguageId: string
 


### PR DESCRIPTION
## Description
By setting direct download as default method users with low tech skills can just click "Download" and it works as they expect. Whilst users that want to use torrent probably also are more technological skilled and therefore more comfortable in the UX and can easily switch to torrent if they'd like.

## Related issues
Relates to #3810 

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Go to a video watch page.
1) Open download modal.
1) See that direct dl is checked as default.