### PR TITLE
Resume videos for non-logged in users

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -28,7 +28,7 @@ import { MetaService } from '@ngx-meta/core'
 import { peertubeLocalStorage } from '@root-helpers/peertube-web-storage'
 import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
 import { ServerConfig, ServerErrorCode, UserVideoRateType, VideoCaption, VideoPrivacy, VideoState } from '@shared/models'
-import { getStoredP2PEnabled, getStoredTheater, getVideoWatch } from '../../../assets/player/peertube-player-local-storage'
+import { cleanupVideoWatch, getStoredP2PEnabled, getStoredTheater, getStoredVideoWatchHistory } from '../../../assets/player/peertube-player-local-storage'
 import {
   CustomizationOptions,
   P2PMediaLoaderOptions,
@@ -195,6 +195,8 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     this.theaterEnabled = getStoredTheater()
 
     this.hooks.runAction('action:video-watch.init', 'video-watch')
+
+    setTimeout(cleanupVideoWatch, 1500) // Run in timeout to ensure we're not blocking the UI
   }
 
   ngOnDestroy () {
@@ -768,7 +770,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     const getStartTime = () => {
       const byUrl = urlOptions.startTime !== undefined
       const byHistory = video.userHistory && (!this.playlist || urlOptions.resume !== undefined)
-      const byLocalStorage = getVideoWatch(video.uuid)
+      const byLocalStorage = getStoredVideoWatchHistory(video.uuid)
 
       if (byUrl) return timeToInt(urlOptions.startTime)
       if (byHistory) return video.userHistory.currentTime

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -28,7 +28,7 @@ import { MetaService } from '@ngx-meta/core'
 import { peertubeLocalStorage } from '@root-helpers/peertube-web-storage'
 import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
 import { ServerConfig, ServerErrorCode, UserVideoRateType, VideoCaption, VideoPrivacy, VideoState } from '@shared/models'
-import { getStoredP2PEnabled, getStoredTheater } from '../../../assets/player/peertube-player-local-storage'
+import { getStoredP2PEnabled, getStoredTheater, getVideoWatch } from '../../../assets/player/peertube-player-local-storage'
 import {
   CustomizationOptions,
   P2PMediaLoaderOptions,
@@ -768,9 +768,11 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     const getStartTime = () => {
       const byUrl = urlOptions.startTime !== undefined
       const byHistory = video.userHistory && (!this.playlist || urlOptions.resume !== undefined)
+      const byLocalStorage = getVideoWatch(video.uuid)
 
       if (byUrl) return timeToInt(urlOptions.startTime)
       if (byHistory) return video.userHistory.currentTime
+      if (byLocalStorage) return byLocalStorage.duration
 
       return 0
     }
@@ -827,7 +829,9 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
         serverUrl: environment.apiUrl,
 
-        videoCaptions: playerCaptions
+        videoCaptions: playerCaptions,
+
+        videoUUID: video.uuid
       },
 
       webtorrent: {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -19,6 +19,7 @@ import { BroadcastMessageLevel, ServerConfig, UserRole } from '@shared/models'
 import { MenuService } from './core/menu/menu.service'
 import { POP_STATE_MODAL_DISMISS } from './helpers'
 import { InstanceService } from './shared/shared-instance'
+import { cleanupVideoWatch } from 'src/assets/player/peertube-player-local-storage'
 
 @Component({
   selector: 'my-app',
@@ -99,6 +100,8 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.openModalsIfNeeded()
 
     this.document.documentElement.lang = getShortLocale(this.localeId)
+
+    setTimeout(cleanupVideoWatch, 5)
   }
 
   ngAfterViewInit () {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -101,7 +101,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     this.document.documentElement.lang = getShortLocale(this.localeId)
 
-    setTimeout(cleanupVideoWatch, 5)
+    setTimeout(cleanupVideoWatch, 1500) // Run in timeout to ensure we're not blocking the UI
   }
 
   ngAfterViewInit () {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -19,7 +19,6 @@ import { BroadcastMessageLevel, ServerConfig, UserRole } from '@shared/models'
 import { MenuService } from './core/menu/menu.service'
 import { POP_STATE_MODAL_DISMISS } from './helpers'
 import { InstanceService } from './shared/shared-instance'
-import { cleanupVideoWatch } from 'src/assets/player/peertube-player-local-storage'
 
 @Component({
   selector: 'my-app',
@@ -100,8 +99,6 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.openModalsIfNeeded()
 
     this.document.documentElement.lang = getShortLocale(this.localeId)
-
-    setTimeout(cleanupVideoWatch, 1500) // Run in timeout to ensure we're not blocking the UI
   }
 
   ngAfterViewInit () {

--- a/client/src/assets/player/peertube-player-local-storage.ts
+++ b/client/src/assets/player/peertube-player-local-storage.ts
@@ -68,26 +68,23 @@ function getStoredLastSubtitle () {
   return getLocalStorage('last-subtitle')
 }
 
-function saveVideoWatch(videoUUID: string, duration: number) {
-  const data = getVideoWatch()
-  const now = new Date()
-
-  return setLocalStorage(`video-watch`, JSON.stringify({
-    ...data,
+function saveVideoWatchHistory(videoUUID: string, duration: number) {
+  return setLocalStorage(`video-watch-history`, JSON.stringify({
+    ...getStoredVideoWatchHistory(),
     [videoUUID]: {
       duration,
-      date: `${now.getFullYear()}-${now.getUTCMonth() + 1}-${now.getUTCDate()}`
+      date: `${(new Date()).toISOString()}`
     }
   }))
 }
 
-function getVideoWatch(videoUUID?: string) {
+function getStoredVideoWatchHistory(videoUUID?: string) {
   let data
 
   try {
-    data = JSON.parse(getLocalStorage('video-watch'))
+    data = JSON.parse(getLocalStorage('video-watch-history'))
   } catch (error) {
-    console.error(error)
+    console.error('Cannot parse video watch history from local storage: ', error)
   }
 
   data = data || {}
@@ -98,7 +95,7 @@ function getVideoWatch(videoUUID?: string) {
 }
 
 function cleanupVideoWatch() {
-  const data = getVideoWatch()
+  const data = getStoredVideoWatchHistory()
 
   const newData = Object.keys(data).reduce((acc, videoUUID) => {
     const date = Date.parse(data[videoUUID].date)
@@ -113,7 +110,7 @@ function cleanupVideoWatch() {
     }
   }, {})
 
-  setLocalStorage('video-watch', JSON.stringify(newData))
+  setLocalStorage('video-watch-history', JSON.stringify(newData))
 }
 
 // ---------------------------------------------------------------------------
@@ -130,8 +127,8 @@ export {
   getAverageBandwidthInStore,
   saveLastSubtitle,
   getStoredLastSubtitle,
-  saveVideoWatch,
-  getVideoWatch,
+  saveVideoWatchHistory,
+  getStoredVideoWatchHistory,
   cleanupVideoWatch
 }
 

--- a/client/src/assets/player/peertube-player-local-storage.ts
+++ b/client/src/assets/player/peertube-player-local-storage.ts
@@ -68,6 +68,54 @@ function getStoredLastSubtitle () {
   return getLocalStorage('last-subtitle')
 }
 
+function saveVideoWatch(videoUUID: string, duration: number) {
+  const data = getVideoWatch()
+  const now = new Date()
+
+  return setLocalStorage(`video-watch`, JSON.stringify({
+    ...data,
+    [videoUUID]: {
+      duration,
+      date: `${now.getFullYear()}-${now.getUTCMonth() + 1}-${now.getUTCDate()}`
+    }
+  }))
+}
+
+function getVideoWatch(videoUUID?: string) {
+  let data
+
+  try {
+    data = JSON.parse(getLocalStorage('video-watch'))
+  } catch (error) {
+    console.error(error)
+  }
+
+  data = data || {}
+
+  if (videoUUID) return data[videoUUID]
+
+  return data
+}
+
+function cleanupVideoWatch() {
+  const data = getVideoWatch()
+
+  const newData = Object.keys(data).reduce((acc, videoUUID) => {
+    const date = Date.parse(data[videoUUID].date)
+
+    const diff = Math.ceil(((new Date()).getTime() - date) / (1000 * 3600 * 24))
+
+    if (diff > 30) return acc
+
+    return {
+      ...acc,
+      [videoUUID]: data[videoUUID]
+    }
+  }, {})
+
+  setLocalStorage('video-watch', JSON.stringify(newData))
+}
+
 // ---------------------------------------------------------------------------
 
 export {
@@ -81,7 +129,10 @@ export {
   saveAverageBandwidth,
   getAverageBandwidthInStore,
   saveLastSubtitle,
-  getStoredLastSubtitle
+  getStoredLastSubtitle,
+  saveVideoWatch,
+  getVideoWatch,
+  cleanupVideoWatch
 }
 
 // ---------------------------------------------------------------------------

--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -105,6 +105,8 @@ export interface CommonOptions extends CustomizationOptions {
 
   videoCaptions: VideoJSCaption[]
 
+  videoUUID: string
+
   userWatching?: UserWatching
 
   serverUrl: string
@@ -230,7 +232,8 @@ export class PeertubePlayerManager {
         subtitle: commonOptions.subtitle,
         videoCaptions: commonOptions.videoCaptions,
         stopTime: commonOptions.stopTime,
-        isLive: commonOptions.isLive
+        isLive: commonOptions.isLive,
+        videoUUID: commonOptions.videoUUID
       }
     }
 

--- a/client/src/assets/player/peertube-plugin.ts
+++ b/client/src/assets/player/peertube-plugin.ts
@@ -13,7 +13,7 @@ import {
   getStoredVolume,
   saveLastSubtitle,
   saveMuteInStore,
-  saveVideoWatch,
+  saveVideoWatchHistory,
   saveVolumeInStore
 } from './peertube-player-local-storage'
 
@@ -190,9 +190,9 @@ class PeerTubePlugin extends Plugin {
 
         if (options) {
           this.notifyUserIsWatching(currentTime, options.url, options.authorizationHeader)
-          .catch(err => console.error('Cannot notify user is watching.', err))
+            .catch(err => console.error('Cannot notify user is watching.', err))
         } else {
-          saveVideoWatch(videoUUID, currentTime)
+          saveVideoWatchHistory(videoUUID, currentTime)
         }
       }
     }, this.CONSTANTS.USER_WATCHING_VIDEO_INTERVAL)

--- a/client/src/assets/player/peertube-plugin.ts
+++ b/client/src/assets/player/peertube-plugin.ts
@@ -13,6 +13,7 @@ import {
   getStoredVolume,
   saveLastSubtitle,
   saveMuteInStore,
+  saveVideoWatch,
   saveVolumeInStore
 } from './peertube-player-local-storage'
 
@@ -120,7 +121,7 @@ class PeerTubePlugin extends Plugin {
       this.initializePlayer()
       this.runViewAdd()
 
-      if (options.userWatching) this.runUserWatchVideo(options.userWatching)
+      this.runUserWatchVideo(options.userWatching, options.videoUUID)
     })
   }
 
@@ -178,7 +179,7 @@ class PeerTubePlugin extends Plugin {
     }, 1000)
   }
 
-  private runUserWatchVideo (options: UserWatching) {
+  private runUserWatchVideo (options: UserWatching, videoUUID: string) {
     let lastCurrentTime = 0
 
     this.userWatchingVideoInterval = setInterval(() => {
@@ -187,8 +188,12 @@ class PeerTubePlugin extends Plugin {
       if (currentTime - lastCurrentTime >= 1) {
         lastCurrentTime = currentTime
 
-        this.notifyUserIsWatching(currentTime, options.url, options.authorizationHeader)
+        if (options) {
+          this.notifyUserIsWatching(currentTime, options.url, options.authorizationHeader)
           .catch(err => console.error('Cannot notify user is watching.', err))
+        } else {
+          saveVideoWatch(videoUUID, currentTime)
+        }
       }
     }, this.CONSTANTS.USER_WATCHING_VIDEO_INTERVAL)
   }

--- a/client/src/assets/player/peertube-videojs-typings.ts
+++ b/client/src/assets/player/peertube-videojs-typings.ts
@@ -108,6 +108,8 @@ type PeerTubePluginOptions = {
   stopTime: number | string
 
   isLive: boolean
+
+  videoUUID: string
 }
 
 type PlaylistPluginOptions = {

--- a/client/src/standalone/videos/embed.ts
+++ b/client/src/standalone/videos/embed.ts
@@ -531,6 +531,7 @@ export class PeerTubeEmbed {
         videoCaptions,
         inactivityTimeout: 2500,
         videoViewUrl: this.getVideoUrl(videoInfo.uuid) + '/views',
+        videoUUID: videoInfo.uuid,
 
         isLive: videoInfo.isLive,
 


### PR DESCRIPTION
## Description
Stores the current video duration in local storage for non-logged in users so that they can go back to a video and continue where they ended.

Upon app init a check is done to cleanup old durations.

## Related issues
closes #3866

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

## Resume
1) Logout.
1) Watch a video for a few seconds.
1) Reload the page.

## Cleanup
1) Edit the local storage and change the date in `peertube-videojs-video-watch` to a date more than 31 days back.
1) Reload the page.
1) See that the duration has been cleared.