### PR TITLE
Add 1.75 option to playback rates

### DIFF
--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -271,7 +271,7 @@ export class PeertubePlayerManager {
 
       poster: commonOptions.poster,
       inactivityTimeout: commonOptions.inactivityTimeout,
-      playbackRates: [ 0.5, 0.75, 1, 1.25, 1.5, 2 ],
+      playbackRates: [ 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2 ],
 
       plugins,
 


### PR DESCRIPTION
## Description

Option to set playback speed to 1.75

## Related issues

closes https://github.com/Chocobozzz/PeerTube/issues/3881

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
I opened the client in dev mode, show the added playback rate and tested that it works.
-->

## Screenshots

![image](https://user-images.githubusercontent.com/1964904/112496606-8ec34880-8d8d-11eb-95fb-76ab2b6fa4e1.png)

