### PR TITLE
Show less information in download modal

### DIFF
--- a/client/src/app/shared/shared-video-miniature/video-download.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.html
@@ -17,22 +17,12 @@
   </div>
 
   <div class="modal-body">
-    <div class="form-group">
-      <div class="alert alert-warning" *ngIf="isConfidentialVideo()" i18n>
-        The following link contains a private token and should not be shared with anyone.
-      </div>
+    <div class="alert alert-warning" *ngIf="isConfidentialVideo()" i18n>
+      The following link contains a private token and should not be shared with anyone.
+    </div>
 
+    <ng-container *ngIf="type === 'subtitles'">
       <div class="input-group input-group-sm">
-        <div class="input-group-prepend peertube-select-container">
-          <select *ngIf="type === 'video'" [(ngModel)]="resolutionId" (ngModelChange)="onResolutionIdChange()">
-            <option *ngFor="let file of getVideoFiles()" [value]="file.resolution.id">{{ file.resolution.label }}</option>
-          </select>
-
-          <select *ngIf="type === 'subtitles'" [(ngModel)]="subtitleLanguageId">
-            <option *ngFor="let caption of videoCaptions" [value]="caption.language.id">{{ caption.language.label }}</option>
-          </select>
-        </div>
-
         <input #urlInput (click)="urlInput.select()" type="text" class="form-control input-sm readonly" readonly [value]="getLink()" />
         <div class="input-group-append" *ngIf="!isConfidentialVideo()">
           <button [cdkCopyToClipboard]="urlInput.value" (click)="activateCopiedMessage()" type="button" class="btn btn-outline-secondary">
@@ -40,62 +30,103 @@
           </button>
         </div>
       </div>
-    </div>
-
-    <ng-container *ngIf="type === 'video' && videoFile?.metadata">
-      <div ngbNav #nav="ngbNav" class="nav-tabs">
-
-        <ng-container ngbNavItem>
-          <a ngbNavLink i18n>Format</a>
-          <ng-template ngbNavContent>
-            <div class="file-metadata">
-              <div class="metadata-attribute metadata-attribute-tags" *ngFor="let item of videoFileMetadataFormat | keyvalue">
-                <span i18n class="metadata-attribute-label">{{ item.value.label }}</span>
-                <span class="metadata-attribute-value">{{ item.value.value }}</span>
-              </div>
-            </div>
-          </ng-template>
-        </ng-container>
-
-        <ng-container ngbNavItem [disabled]="videoFileMetadataVideoStream === undefined">
-          <a ngbNavLink i18n>Video stream</a>
-          <ng-template ngbNavContent>
-            <div class="file-metadata">
-              <div class="metadata-attribute metadata-attribute-tags" *ngFor="let item of videoFileMetadataVideoStream | keyvalue">
-                <span i18n class="metadata-attribute-label">{{ item.value.label }}</span>
-                <span class="metadata-attribute-value">{{ item.value.value }}</span>
-              </div>
-            </div>
-          </ng-template>
-        </ng-container>
-
-        <ng-container ngbNavItem [disabled]="videoFileMetadataAudioStream === undefined">
-          <a ngbNavLink i18n>Audio stream</a>
-          <ng-template ngbNavContent>
-            <div class="file-metadata">
-              <div class="metadata-attribute metadata-attribute-tags" *ngFor="let item of videoFileMetadataAudioStream | keyvalue">
-                <span i18n class="metadata-attribute-label">{{ item.value.label }}</span>
-                <span class="metadata-attribute-value">{{ item.value.value }}</span>
-              </div>
-            </div>
-          </ng-template>
-        </ng-container>
-      </div>
-
-      <div [ngbNavOutlet]="nav"></div>
     </ng-container>
 
-    <div class="download-type" *ngIf="type === 'video'">
-      <div class="peertube-radio-container">
-        <input type="radio" name="download" id="download-direct" [(ngModel)]="downloadType" value="direct">
-        <label i18n for="download-direct">Direct download</label>
-      </div>
+    <ng-container *ngIf="type === 'video'">
+      <div ngbNav #resolutionNav="ngbNav" class="nav-tabs" [activeId]="resolutionId" (activeIdChange)="onResolutionIdChange($event)">
 
-      <div class="peertube-radio-container">
-        <input type="radio" name="download" id="download-torrent" [(ngModel)]="downloadType" value="torrent">
-        <label i18n for="download-torrent">Torrent (.torrent file)</label>
+        <ng-container *ngFor="let file of getVideoFiles()" [ngbNavItem]="file.resolution.id">
+          <a ngbNavLink i18n>{{ file.resolution.label }}</a>
+  
+          <ng-template ngbNavContent>
+            <div class="nav-content">
+              <div class="input-group input-group-sm">
+                <input #urlInput (click)="urlInput.select()" type="text" class="form-control input-sm readonly" readonly [value]="getLink()" />
+                <div class="input-group-append" *ngIf="!isConfidentialVideo()">
+                  <button [cdkCopyToClipboard]="urlInput.value" (click)="activateCopiedMessage()" type="button" class="btn btn-outline-secondary">
+                    <span class="glyphicon glyphicon-duplicate"></span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </ng-template>
+        </ng-container>
       </div>
-    </div>
+      <div [ngbNavOutlet]="resolutionNav"></div>
+  
+      <div class="advanced-filters collapse-transition" [ngbCollapse]="isAdvancedCustomizationCollapsed">
+        <ng-container *ngIf="videoFile?.metadata">
+          <div ngbNav #nav="ngbNav" class="nav-tabs nav-metadata">
+            <ng-container ngbNavItem>
+              <a ngbNavLink i18n>Format</a>
+              <ng-template ngbNavContent>
+                <div class="file-metadata">
+                  <div class="metadata-attribute metadata-attribute-tags" *ngFor="let item of videoFileMetadataFormat | keyvalue">
+                    <span i18n class="metadata-attribute-label">{{ item.value.label }}</span>
+                    <span class="metadata-attribute-value">{{ item.value.value }}</span>
+                  </div>
+                </div>
+              </ng-template>
+  
+              <ng-container ngbNavItem [disabled]="videoFileMetadataVideoStream === undefined">
+                <a ngbNavLink i18n>Video stream</a>
+                <ng-template ngbNavContent>
+                  <div class="file-metadata">
+                    <div class="metadata-attribute metadata-attribute-tags" *ngFor="let item of videoFileMetadataVideoStream | keyvalue">
+                      <span i18n class="metadata-attribute-label">{{ item.value.label }}</span>
+                      <span class="metadata-attribute-value">{{ item.value.value }}</span>
+                    </div>
+                  </div>
+                </ng-template>
+              </ng-container>
+  
+              <ng-container ngbNavItem [disabled]="videoFileMetadataAudioStream === undefined">
+                <a ngbNavLink i18n>Audio stream</a>
+                <ng-template ngbNavContent>
+                  <div class="file-metadata">
+                    <div class="metadata-attribute metadata-attribute-tags" *ngFor="let item of videoFileMetadataAudioStream | keyvalue">
+                      <span i18n class="metadata-attribute-label">{{ item.value.label }}</span>
+                      <span class="metadata-attribute-value">{{ item.value.value }}</span>
+                    </div>
+                  </div>
+                </ng-template>
+              </ng-container>
+  
+            </ng-container>
+          </div>
+          <div [ngbNavOutlet]="nav"></div>
+          <div class="download-type">
+            <div class="peertube-radio-container">
+              <input type="radio" name="download" id="download-direct" [(ngModel)]="downloadType" value="direct">
+              <label i18n for="download-direct">Direct download</label>
+            </div>
+            <div class="peertube-radio-container">
+              <input type="radio" name="download" id="download-torrent" [(ngModel)]="downloadType" value="torrent">
+              <label i18n for="download-torrent">Torrent (.torrent file)</label>
+            </div>
+          </div>
+        </ng-container>
+      </div>
+  
+      <div (click)="isAdvancedCustomizationCollapsed = !isAdvancedCustomizationCollapsed" role="button" class="advanced-filters-button"
+      [attr.aria-expanded]="!isAdvancedCustomizationCollapsed" aria-controls="collapseBasic">
+        <ng-container *ngIf="isAdvancedCustomizationCollapsed">
+          <span class="glyphicon glyphicon-menu-down"></span>
+  
+          <ng-container i18n>
+            Advanced
+          </ng-container>
+        </ng-container>
+  
+        <ng-container *ngIf="!isAdvancedCustomizationCollapsed">
+          <span class="glyphicon glyphicon-menu-up"></span>
+  
+          <ng-container i18n>
+            Simple
+          </ng-container>
+        </ng-container>
+      </div>
+    </ng-container>
   </div>
 
   <div class="modal-footer inputs">

--- a/client/src/app/shared/shared-video-miniature/video-download.component.scss
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.scss
@@ -17,6 +17,10 @@
   .nav-tabs {
     margin-top: 10x;
   }
+  
+  .glyphicon {
+    margin-right: 5px;
+  }
 }
 
 .peertube-select-container {

--- a/client/src/app/shared/shared-video-miniature/video-download.component.scss
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.scss
@@ -1,6 +1,24 @@
 @import 'variables';
 @import 'mixins';
 
+.nav-content {
+  margin-top: 30px;
+}
+
+.advanced-filters-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+
+  .nav-tabs {
+    margin-top: 10x;
+  }
+}
+
 .peertube-select-container {
   @include peertube-select-container(85px);
 
@@ -15,12 +33,21 @@
   }
 }
 
+.action-button-cancel {
+  @include peertube-button-link;
+}
+
+.action-button-submit {
+  @include peertube-button-link;
+  @include orange-button;
+}
+
 #dropdownDownloadType {
   cursor: pointer;
 }
 
 .download-type {
-  margin-top: 30px;
+  margin-top: 20px;
 
   .peertube-radio-container {
     @include peertube-radio-container;
@@ -28,6 +55,10 @@
     display: inline-block;
     margin-right: 30px;
   }
+}
+
+.nav-metadata {
+  margin-top: 20px;
 }
 
 .file-metadata {

--- a/client/src/app/shared/shared-video-miniature/video-download.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.ts
@@ -30,6 +30,8 @@ export class VideoDownloadComponent {
   videoCaptions: VideoCaption[]
   activeModal: NgbModalRef
 
+  isAdvancedCustomizationCollapsed = true
+
   type: DownloadType = 'video'
 
   private bytesPipe: BytesPipe
@@ -65,8 +67,7 @@ export class VideoDownloadComponent {
 
     this.activeModal = this.modalService.open(this.modal, { centered: true })
 
-    this.resolutionId = this.getVideoFiles()[0].resolution.id
-    this.onResolutionIdChange()
+    this.onResolutionIdChange(this.getVideoFiles()[0].resolution.id)
 
     if (this.videoCaptions) this.subtitleLanguageId = this.videoCaptions[0].language.id
 
@@ -91,8 +92,10 @@ export class VideoDownloadComponent {
       : this.getVideoFileLink()
   }
 
-  async onResolutionIdChange () {
+  async onResolutionIdChange (resolutionId: number) {
+    this.resolutionId = resolutionId
     this.videoFile = this.getVideoFile()
+
     if (this.videoFile.metadata || !this.videoFile.metadataUrl) return
 
     await this.hydrateMetadataFromMetadataUrl(this.videoFile)
@@ -110,9 +113,6 @@ export class VideoDownloadComponent {
   }
 
   getVideoFile () {
-    // HTML select send us a string, so convert it to a number
-    this.resolutionId = parseInt(this.resolutionId.toString(), 10)
-
     const file = this.getVideoFiles().find(f => f.resolution.id === this.resolutionId)
     if (!file) {
       console.error('Could not find file with resolution %d.', this.resolutionId)

--- a/client/src/app/shared/shared-video-miniature/video-download.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-download.component.ts
@@ -96,10 +96,11 @@ export class VideoDownloadComponent {
     this.resolutionId = resolutionId
     this.videoFile = this.getVideoFile()
 
-    if (this.videoFile.metadata || !this.videoFile.metadataUrl) return
+    if (!this.videoFile.metadata) {
+      if (!this.videoFile.metadataUrl) return
 
-    await this.hydrateMetadataFromMetadataUrl(this.videoFile)
-    if (!this.videoFile.metadata) return
+      await this.hydrateMetadataFromMetadataUrl(this.videoFile)
+    }
 
     this.videoFileMetadataFormat = this.videoFile
       ? this.getMetadataFormat(this.videoFile.metadata.format)


### PR DESCRIPTION
## Description
* Resolution is switched with tabs instead of select list.
* Metadata is collapsed by default.
* Solves a bug: previously the metadata wasn't updated when choosing a resolution for the second time (check the last commit).

## Related issues
Closes #3810 

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Visit a video that has subtitles and multiple resolutions.
1) Open Download modal.
1) Switch between video and subtitle.
1) Switch between resolutions.

## Screenshots

![Peek 2021-03-26 09-58](https://user-images.githubusercontent.com/6680299/112607794-dc859280-8e19-11eb-9b58-1f0bba4da807.gif)

