### PR TITLE
[support/docker] expose webtorrent setting in os variable settings

### DIFF
--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -117,6 +117,10 @@ transcoding:
     2160p:
       __name: "PEERTUBE_TRANSCODING_2160P"
       __format: "json"
+  webtorrent:
+    enabled:
+      __name: "PEERTUBE_TRANSCODING_WEBTORRENT_ENABLED"
+      __format: "json"
   hls:
     enabled:
       __name: "PEERTUBE_TRANSCODING_HLS_ENABLED"


### PR DESCRIPTION
## Description

When enabling hls, one might want to disable webtorrent, so exposing it in the OS variable config

## Related issues

Related to our work on #3864 

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
