### PR TITLE
Use database.name config value in upgrade script

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -39,8 +39,9 @@ then
   DB_PASS=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['password'])")
   DB_HOST=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['hostname'])")
   DB_SUFFIX=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['suffix'])")
+  DB_NAME=$(node -e "console.log(require('js-yaml').load(fs.readFileSync('$PEERTUBE_PATH/config/production.yaml', 'utf8'))['database']['name'] || '')")
   mkdir -p $PEERTUBE_PATH/backup
-  PGPASSWORD=$DB_PASS pg_dump -U $DB_USER -h $DB_HOST -F c "peertube${DB_SUFFIX}" -f "$SQL_BACKUP_PATH"
+  PGPASSWORD=$DB_PASS pg_dump -U $DB_USER -h $DB_HOST -F c "${DB_NAME:-'peertube${DB_SUFFIX}'}" -f "$SQL_BACKUP_PATH"
 else
   echo "pg_dump not found. Cannot make a SQL backup!"
 fi


### PR DESCRIPTION
## Description
Fixes so that the upgrade script is using the `database.name` config if it's set.

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Copy line 34-47 to the top of upgrade.sh and add `echo $PGPASSWORD` to see the value.
1) Run script and verify output.
1) Set `database.name` in config.
1) Run script and verify output.