### PR TITLE
add support for inputOptions and videoFilters in transcode plugin

### DIFF
--- a/server/helpers/ffmpeg-utils.ts
+++ b/server/helpers/ffmpeg-utils.ts
@@ -277,6 +277,7 @@ async function getLiveTranscodingCommand (options: {
       logger.debug('Apply ffmpeg live video params from %s using %s profile.', builderResult.encoder, profile, builderResult)
 
       command.outputOption(`${buildStreamSuffix('-c:v', i)} ${builderResult.encoder}`)
+      command.addInputOptions(builderResult.result.inputOptions)
       command.addOutputOptions(builderResult.result.outputOptions)
     }
 
@@ -294,6 +295,7 @@ async function getLiveTranscodingCommand (options: {
       logger.debug('Apply ffmpeg live audio params from %s using %s profile.', builderResult.encoder, profile, builderResult)
 
       command.outputOption(`${buildStreamSuffix('-c:a', i)} ${builderResult.encoder}`)
+      command.addInputOptions(builderResult.result.inputOptions)
       command.addOutputOptions(builderResult.result.outputOptions)
     }
 
@@ -605,6 +607,7 @@ async function presetVideo (
       localCommand.audioCodec(builderResult.encoder)
     }
 
+    command.addInputOptions(builderResult.result.inputOptions)
     command.addOutputOptions(builderResult.result.outputOptions)
     addDefaultEncoderParams({ command: localCommand, encoder: builderResult.encoder, fps })
   }

--- a/server/helpers/ffmpeg-utils.ts
+++ b/server/helpers/ffmpeg-utils.ts
@@ -396,8 +396,8 @@ async function buildx264VODCommand (command: ffmpeg.FfmpegCommand, options: Tran
 
   if (options.resolution !== undefined) {
     scaleFilterValue = options.isPortraitMode === true
-      ? `${options.resolution}:-2`
-      : `-2:${options.resolution}`
+      ? `w=${options.resolution}:h=-2`
+      : `w=-2:h=${options.resolution}`
   }
 
   command = await presetVideo({ command, input: options.inputPath, transcodeOptions: options, fps, scaleFilterValue })

--- a/server/helpers/ffmpeg-utils.ts
+++ b/server/helpers/ffmpeg-utils.ts
@@ -9,6 +9,7 @@ import { execPromise, promisify0 } from './core-utils'
 import { computeFPS, getAudioStream, getVideoFileFPS } from './ffprobe-utils'
 import { processImage } from './image-utils'
 import { logger } from './logger'
+import { FilterSpecification } from 'fluent-ffmpeg'
 
 /**
  *
@@ -226,21 +227,14 @@ async function getLiveTranscodingCommand (options: {
 
   const varStreamMap: string[] = []
 
-  command.complexFilter([
+  const complexFilter: FilterSpecification[] = [
     {
       inputs: '[v:0]',
       filter: 'split',
       options: resolutions.length,
       outputs: resolutions.map(r => `vtemp${r}`)
-    },
-
-    ...resolutions.map(r => ({
-      inputs: `vtemp${r}`,
-      filter: 'scale',
-      options: `w=-2:h=${r}`,
-      outputs: `vout${r}`
-    }))
-  ])
+    }
+  ]
 
   command.outputOption('-preset superfast')
   command.outputOption('-sc_threshold 0')
@@ -278,6 +272,13 @@ async function getLiveTranscodingCommand (options: {
 
       command.outputOption(`${buildStreamSuffix('-c:v', i)} ${builderResult.encoder}`)
       applyEncoderOptions(command, builderResult.result)
+
+      complexFilter.push({
+        inputs: `vtemp${resolution}`,
+        filter: getScaleFilter(builderResult.result),
+        options: `w=-2:h=${resolution}`,
+        outputs: `vout${resolution}`
+      })
     }
 
     {
@@ -299,6 +300,8 @@ async function getLiveTranscodingCommand (options: {
 
     varStreamMap.push(`v:${i},a:${i}`)
   }
+
+  command.complexFilter(complexFilter)
 
   addDefaultLiveHLSParams(command, outPath)
 
@@ -389,16 +392,15 @@ async function buildx264VODCommand (command: ffmpeg.FfmpegCommand, options: Tran
   let fps = await getVideoFileFPS(options.inputPath)
   fps = computeFPS(fps, options.resolution)
 
-  command = await presetVideo(command, options.inputPath, options, fps)
+  let scaleFilterValue: string
 
   if (options.resolution !== undefined) {
-    // '?x720' or '720x?' for example
-    const size = options.isPortraitMode === true
-      ? `${options.resolution}x?`
-      : `?x${options.resolution}`
-
-    command = command.size(size)
+    scaleFilterValue = options.isPortraitMode === true
+      ? `${options.resolution}:-2`
+      : `-2:${options.resolution}`
   }
+
+  command = await presetVideo({ command, input: options.inputPath, transcodeOptions: options, fps, scaleFilterValue })
 
   return command
 }
@@ -406,12 +408,13 @@ async function buildx264VODCommand (command: ffmpeg.FfmpegCommand, options: Tran
 async function buildAudioMergeCommand (command: ffmpeg.FfmpegCommand, options: MergeAudioTranscodeOptions) {
   command = command.loop(undefined)
 
-  command = await presetVideo(command, options.audioPath, options)
+  // Avoid "height not divisible by 2" error
+  const scaleFilterValue = 'trunc(iw/2)*2:trunc(ih/2)*2'
+  command = await presetVideo({ command, input: options.audioPath, transcodeOptions: options, scaleFilterValue })
 
   command.outputOption('-preset:v veryfast')
 
   command = command.input(options.audioPath)
-                   .videoFilter('scale=trunc(iw/2)*2:trunc(ih/2)*2') // Avoid "height not divisible by 2" error
                    .outputOption('-tune stillimage')
                    .outputOption('-shortest')
 
@@ -555,12 +558,15 @@ async function getEncoderBuilderResult (options: {
   return null
 }
 
-async function presetVideo (
-  command: ffmpeg.FfmpegCommand,
-  input: string,
-  transcodeOptions: TranscodeOptions,
+async function presetVideo (options: {
+  command: ffmpeg.FfmpegCommand
+  input: string
+  transcodeOptions: TranscodeOptions
   fps?: number
-) {
+  scaleFilterValue?: string
+}) {
+  const { command, input, transcodeOptions, fps, scaleFilterValue } = options
+
   let localCommand = command
     .format('mp4')
     .outputOption('-movflags faststart')
@@ -601,9 +607,14 @@ async function presetVideo (
 
     if (streamType === 'video') {
       localCommand.videoCodec(builderResult.encoder)
+
+      if (scaleFilterValue) {
+        localCommand.outputOption(`-vf ${getScaleFilter(builderResult.result)}=${scaleFilterValue}`)
+      }
     } else if (streamType === 'audio') {
       localCommand.audioCodec(builderResult.encoder)
     }
+
     applyEncoderOptions(localCommand, builderResult.result)
     addDefaultEncoderParams({ command: localCommand, encoder: builderResult.encoder, fps })
   }
@@ -628,8 +639,13 @@ function presetOnlyAudio (command: ffmpeg.FfmpegCommand): ffmpeg.FfmpegCommand {
 function applyEncoderOptions (command: ffmpeg.FfmpegCommand, options: EncoderOptions): ffmpeg.FfmpegCommand {
   return command
     .inputOptions(options.inputOptions ?? [])
-    .videoFilters(options.videoFilters ?? [])
     .outputOptions(options.outputOptions ?? [])
+}
+
+function getScaleFilter (options: EncoderOptions): string {
+  if (options.scaleFilter) return options.scaleFilter.name
+
+  return 'scale'
 }
 
 // ---------------------------------------------------------------------------

--- a/server/lib/video-transcoding-profiles.ts
+++ b/server/lib/video-transcoding-profiles.ts
@@ -24,10 +24,9 @@ import { VIDEO_TRANSCODING_FPS } from '../initializers/constants'
 
 const defaultX264VODOptionsBuilder: EncoderOptionsBuilder = async ({ input, resolution, fps }) => {
   const targetBitrate = await buildTargetBitrate({ input, resolution, fps })
-  if (!targetBitrate) return { inputOptions: [ ], outputOptions: [ ] }
+  if (!targetBitrate) return { outputOptions: [ ] }
 
   return {
-    inputOptions: [ ],
     outputOptions: [
       `-preset veryfast`,
       `-r ${fps}`,
@@ -41,7 +40,6 @@ const defaultX264LiveOptionsBuilder: EncoderOptionsBuilder = async ({ resolution
   const targetBitrate = getTargetBitrate(resolution, fps, VIDEO_TRANSCODING_FPS)
 
   return {
-    inputOptions: [ ],
     outputOptions: [
       `-preset veryfast`,
       `${buildStreamSuffix('-r:v', streamNum)} ${fps}`,
@@ -57,7 +55,7 @@ const defaultAACOptionsBuilder: EncoderOptionsBuilder = async ({ input, streamNu
 
   if (await canDoQuickAudioTranscode(input, probe)) {
     logger.debug('Copy audio stream %s by AAC encoder.', input)
-    return { copy: true, inputOptions: [ ], outputOptions: [ ] }
+    return { copy: true, outputOptions: [ ] }
   }
 
   const parsedAudio = await getAudioStream(input, probe)
@@ -72,14 +70,14 @@ const defaultAACOptionsBuilder: EncoderOptionsBuilder = async ({ input, streamNu
   logger.debug('Calculating audio bitrate of %s by AAC encoder.', input, { bitrate: parsedAudio.bitrate, audioCodecName })
 
   if (bitrate !== undefined && bitrate !== -1) {
-    return { inputOptions: [ ], outputOptions: [ buildStreamSuffix('-b:a', streamNum), bitrate + 'k' ] }
+    return { outputOptions: [ buildStreamSuffix('-b:a', streamNum), bitrate + 'k' ] }
   }
 
-  return { inputOptions: [ ], outputOptions: [ ] }
+  return { outputOptions: [ ] }
 }
 
 const defaultLibFDKAACVODOptionsBuilder: EncoderOptionsBuilder = ({ streamNum }) => {
-  return { inputOptions: [ ], outputOptions: [ buildStreamSuffix('-q:a', streamNum), '5' ] }
+  return { outputOptions: [ buildStreamSuffix('-q:a', streamNum), '5' ] }
 }
 
 // Used to get and update available encoders

--- a/server/lib/video-transcoding-profiles.ts
+++ b/server/lib/video-transcoding-profiles.ts
@@ -24,9 +24,10 @@ import { VIDEO_TRANSCODING_FPS } from '../initializers/constants'
 
 const defaultX264VODOptionsBuilder: EncoderOptionsBuilder = async ({ input, resolution, fps }) => {
   const targetBitrate = await buildTargetBitrate({ input, resolution, fps })
-  if (!targetBitrate) return { outputOptions: [ ] }
+  if (!targetBitrate) return { inputOptions: [ ], outputOptions: [ ] }
 
   return {
+    inputOptions: [ ],
     outputOptions: [
       `-preset veryfast`,
       `-r ${fps}`,
@@ -40,6 +41,7 @@ const defaultX264LiveOptionsBuilder: EncoderOptionsBuilder = async ({ resolution
   const targetBitrate = getTargetBitrate(resolution, fps, VIDEO_TRANSCODING_FPS)
 
   return {
+    inputOptions: [ ],
     outputOptions: [
       `-preset veryfast`,
       `${buildStreamSuffix('-r:v', streamNum)} ${fps}`,
@@ -55,7 +57,7 @@ const defaultAACOptionsBuilder: EncoderOptionsBuilder = async ({ input, streamNu
 
   if (await canDoQuickAudioTranscode(input, probe)) {
     logger.debug('Copy audio stream %s by AAC encoder.', input)
-    return { copy: true, outputOptions: [] }
+    return { copy: true, inputOptions: [ ], outputOptions: [ ] }
   }
 
   const parsedAudio = await getAudioStream(input, probe)
@@ -70,14 +72,14 @@ const defaultAACOptionsBuilder: EncoderOptionsBuilder = async ({ input, streamNu
   logger.debug('Calculating audio bitrate of %s by AAC encoder.', input, { bitrate: parsedAudio.bitrate, audioCodecName })
 
   if (bitrate !== undefined && bitrate !== -1) {
-    return { outputOptions: [ buildStreamSuffix('-b:a', streamNum), bitrate + 'k' ] }
+    return { inputOptions: [ ], outputOptions: [ buildStreamSuffix('-b:a', streamNum), bitrate + 'k' ] }
   }
 
-  return { outputOptions: [ ] }
+  return { inputOptions: [ ], outputOptions: [ ] }
 }
 
 const defaultLibFDKAACVODOptionsBuilder: EncoderOptionsBuilder = ({ streamNum }) => {
-  return { outputOptions: [ buildStreamSuffix('-q:a', streamNum), '5' ] }
+  return { inputOptions: [ ], outputOptions: [ buildStreamSuffix('-q:a', streamNum), '5' ] }
 }
 
 // Used to get and update available encoders

--- a/server/tests/cli/print-transcode-command.ts
+++ b/server/tests/cli/print-transcode-command.ts
@@ -22,7 +22,8 @@ describe('Test create transcoding jobs', function () {
       const command = await execCLI(`npm run print-transcode-command -- ${fixturePath} -r ${resolution}`)
       const targetBitrate = Math.min(getTargetBitrate(resolution, fps, VIDEO_TRANSCODING_FPS), bitrate)
 
-      expect(command).to.includes(`-y -acodec aac -vcodec libx264 -filter:v scale=w=trunc(oh*a/2)*2:h=${resolution}`)
+      expect(command).to.includes(`-vf scale=w=-2:h=${resolution}`)
+      expect(command).to.includes(`-y -acodec aac -vcodec libx264`)
       expect(command).to.includes('-f mp4')
       expect(command).to.includes('-movflags faststart')
       expect(command).to.includes('-b:a 256k')

--- a/server/tests/fixtures/peertube-plugin-test-transcoding-one/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-transcoding-one/main.js
@@ -13,6 +13,30 @@ async function register ({ transcodingManager }) {
   }
 
   {
+    const builder = () => {
+      return {
+        videoFilters: [
+          'fps=10'
+        ]
+      }
+    }
+
+    transcodingManager.addVODProfile('libx264', 'video-filters-vod', builder)
+  }
+
+  {
+    const builder = () => {
+      return {
+        inputOptions: [
+          '-r 5'
+        ]
+      }
+    }
+
+    transcodingManager.addVODProfile('libx264', 'input-options-vod', builder)
+  }
+
+  {
     const builder = (options) => {
       return {
         outputOptions: [
@@ -23,7 +47,20 @@ async function register ({ transcodingManager }) {
 
     transcodingManager.addLiveProfile('libx264', 'low-live', builder)
   }
+
+  {
+    const builder = () => {
+      return {
+        inputOptions: [
+          '-r 5'
+        ]
+      }
+    }
+
+    transcodingManager.addLiveProfile('libx264', 'input-options-live', builder)
+  }
 }
+
 
 async function unregister () {
   return

--- a/server/tests/fixtures/peertube-plugin-test-transcoding-one/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-transcoding-one/main.js
@@ -1,63 +1,84 @@
 async function register ({ transcodingManager }) {
 
+  // Output options
   {
-    const builder = () => {
-      return {
-        outputOptions: [
-          '-r 10'
-        ]
+    {
+      const builder = () => {
+        return {
+          outputOptions: [
+            '-r 10'
+          ]
+        }
       }
+
+      transcodingManager.addVODProfile('libx264', 'low-vod', builder)
     }
 
-    transcodingManager.addVODProfile('libx264', 'low-vod', builder)
+    {
+      const builder = (options) => {
+        return {
+          outputOptions: [
+            '-r:' + options.streamNum + ' 5'
+          ]
+        }
+      }
+
+      transcodingManager.addLiveProfile('libx264', 'low-live', builder)
+    }
   }
 
+  // Input options
   {
-    const builder = () => {
-      return {
-        videoFilters: [
-          'fps=10'
-        ]
+    {
+      const builder = () => {
+        return {
+          inputOptions: [
+            '-r 5'
+          ]
+        }
       }
+
+      transcodingManager.addVODProfile('libx264', 'input-options-vod', builder)
     }
 
-    transcodingManager.addVODProfile('libx264', 'video-filters-vod', builder)
+    {
+      const builder = () => {
+        return {
+          inputOptions: [
+            '-r 5'
+          ]
+        }
+      }
+
+      transcodingManager.addLiveProfile('libx264', 'input-options-live', builder)
+    }
   }
 
+  // Scale filters
   {
-    const builder = () => {
-      return {
-        inputOptions: [
-          '-r 5'
-        ]
+    {
+      const builder = () => {
+        return {
+          scaleFilter: {
+            name: 'Glomgold'
+          }
+        }
       }
+
+      transcodingManager.addVODProfile('libx264', 'bad-scale-vod', builder)
     }
 
-    transcodingManager.addVODProfile('libx264', 'input-options-vod', builder)
-  }
-
-  {
-    const builder = (options) => {
-      return {
-        outputOptions: [
-          '-r:' + options.streamNum + ' 5'
-        ]
+    {
+      const builder = () => {
+        return {
+          scaleFilter: {
+            name: 'Flintheart'
+          }
+        }
       }
+
+      transcodingManager.addLiveProfile('libx264', 'bad-scale-live', builder)
     }
-
-    transcodingManager.addLiveProfile('libx264', 'low-live', builder)
-  }
-
-  {
-    const builder = () => {
-      return {
-        inputOptions: [
-          '-r 5'
-        ]
-      }
-    }
-
-    transcodingManager.addLiveProfile('libx264', 'input-options-live', builder)
   }
 }
 

--- a/server/tests/plugins/plugin-transcoding.ts
+++ b/server/tests/plugins/plugin-transcoding.ts
@@ -19,7 +19,6 @@ import {
   uninstallPlugin,
   updateCustomSubConfig,
   uploadVideoAndGetId,
-  waitFfmpegUntilError,
   waitJobs,
   waitUntilLivePublished
 } from '../../../shared/extra-utils'

--- a/shared/models/videos/video-transcoding.model.ts
+++ b/shared/models/videos/video-transcoding.model.ts
@@ -12,8 +12,9 @@ export type EncoderOptionsBuilder = (params: {
 export interface EncoderOptions {
   copy?: boolean // Copy stream? Default to false
 
-  inputOptions: string[]
-  outputOptions: string[]
+  inputOptions?: string[]
+  videoFilters?: string[]
+  outputOptions?: string[]
 }
 
 // All our encoders

--- a/shared/models/videos/video-transcoding.model.ts
+++ b/shared/models/videos/video-transcoding.model.ts
@@ -12,6 +12,7 @@ export type EncoderOptionsBuilder = (params: {
 export interface EncoderOptions {
   copy?: boolean // Copy stream? Default to false
 
+  inputOptions: string[]
   outputOptions: string[]
 }
 

--- a/shared/models/videos/video-transcoding.model.ts
+++ b/shared/models/videos/video-transcoding.model.ts
@@ -12,8 +12,11 @@ export type EncoderOptionsBuilder = (params: {
 export interface EncoderOptions {
   copy?: boolean // Copy stream? Default to false
 
+  scaleFilter?: {
+    name: string
+  }
+
   inputOptions?: string[]
-  videoFilters?: string[]
   outputOptions?: string[]
 }
 

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -328,8 +328,6 @@ function register (...) {
 Adding transcoding profiles allow admins to change ffmpeg encoding parameters and/or encoders.
 A transcoding profile has to be chosen by the admin of the instance using the admin configuration.
 
-Transcoding profiles used for live transcoding must not provide any `videoFilters`.
-
 ```js
 async function register ({
   transcodingManager
@@ -346,9 +344,6 @@ async function register ({
       // All these options are optional and defaults to []
       return {
         inputOptions: [],
-        videoFilters: [
-          'vflip' // flip the video vertically
-        ],
         outputOptions: [
         // Use a custom bitrate
           '-b' + streamString + ' 10K'
@@ -364,7 +359,6 @@ async function register ({
 
     // And/Or support this profile for live transcoding
     transcodingManager.addLiveProfile(encoder, profileName, builder)
-    // Note: this profile will fail for live transcode because it specifies videoFilters
   }
 
   {
@@ -401,7 +395,6 @@ async function register ({
     const builder = () => {
       return {
         inputOptions: [],
-        videoFilters: [],
         outputOptions: []
       }
     }

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -328,6 +328,8 @@ function register (...) {
 Adding transcoding profiles allow admins to change ffmpeg encoding parameters and/or encoders.
 A transcoding profile has to be chosen by the admin of the instance using the admin configuration.
 
+Transcoding profiles used for live transcoding must not provide any `videoFilters`.
+
 ```js
 async function register ({
   transcodingManager
@@ -341,8 +343,12 @@ async function register ({
       const streamString = streamNum ? ':' + streamNum : ''
 
       // You can also return a promise
+      // All these options are optional and defaults to []
       return {
         inputOptions: [],
+        videoFilters: [
+          'vflip' // flip the video vertically
+        ],
         outputOptions: [
         // Use a custom bitrate
           '-b' + streamString + ' 10K'
@@ -358,6 +364,7 @@ async function register ({
 
     // And/Or support this profile for live transcoding
     transcodingManager.addLiveProfile(encoder, profileName, builder)
+    // Note: this profile will fail for live transcode because it specifies videoFilters
   }
 
   {
@@ -394,6 +401,7 @@ async function register ({
     const builder = () => {
       return {
         inputOptions: [],
+        videoFilters: [],
         outputOptions: []
       }
     }
@@ -412,6 +420,9 @@ async function register ({
     transcodingManager.addLiveEncoderPriority('audio', 'libopus', 1000)
   }
 ```
+
+During live transcode input options are applied once for each target resolution.
+Plugins are responsible for detecting such situation and applying input options only once if necessary.
 
 ### Helpers
 

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -341,9 +341,16 @@ async function register ({
       const streamString = streamNum ? ':' + streamNum : ''
 
       // You can also return a promise
-      // All these options are optional and defaults to []
+      // All these options are optional
       return {
+        scaleFilter: {
+          // Used to define an alternative scale filter, needed by some encoders
+          // Default to 'scale'
+          name: 'scale_vaapi'
+        },
+        // Default to []
         inputOptions: [],
+        // Default to []
         outputOptions: [
         // Use a custom bitrate
           '-b' + streamString + ' 10K'

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -342,6 +342,7 @@ async function register ({
 
       // You can also return a promise
       return {
+        inputOptions: [],
         outputOptions: [
         // Use a custom bitrate
           '-b' + streamString + ' 10K'
@@ -392,6 +393,7 @@ async function register ({
   {
     const builder = () => {
       return {
+        inputOptions: [],
         outputOptions: []
       }
     }


### PR DESCRIPTION
## Description

This PR adds support for inputOptions and videoFilters in transcode plugins.
Transcode plugins can be used to add support for new encoders.
However, some require inputOptions and thus cannot be used with current transcode plugin API.

For instance, vaapi hardware accelerated encoders require these input options `-hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128`

## Related issues

Closes #3846


## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help
