### PR TITLE
remove unnecessary black border above and below video in player

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/+videos/+video-watch/video-watch.component.scss
@@ -3,7 +3,7 @@
 @import '_bootstrap-variables';
 @import '_miniature';
 
-$player-factor: 1.7; // 16/9
+$player-factor: #{16/9};
 $video-info-margin-left: 44px;
 
 @function getPlayerHeight($width){


### PR DESCRIPTION
## Description
This removes the unnecessary black border/space above and below the video in normal player mode (if browser window is wide). It's achieved by further precising the aspect ratio 16/9 which is not just 1.7, but ~1.777777778. Therefore the video control take a little less vertical space and a 16/9 video fits perfectly into the same space. (see Screenshots below)

## Related issues
none AFAIK
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->
visual difference can be seen on Screenshots below

## Screenshots

<!-- delete if not relevant -->
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/22591354/113494210-9221a700-94e6-11eb-9a11-94d36175cb13.png) | ![image](https://user-images.githubusercontent.com/22591354/113494219-a4034a00-94e6-11eb-83fb-64a65c637a0c.png) |


