### PR TITLE
Reducing tag input excessive padding; fixes #3915

### DIFF
--- a/client/src/sass/ng-select.scss
+++ b/client/src/sass/ng-select.scss
@@ -22,7 +22,7 @@ $ng-select-height: 30px;
 
 .ng-input,
 .ng-select .ng-select-container .ng-value-container {
-  padding-left: 15px !important;
+  padding-left: 15px;
 }
 
 .ng-select {
@@ -43,5 +43,16 @@ $ng-select-height: 30px;
 
   &.ng-select-single .ng-value-container .ng-value {
     color: pvar(--inputForegroundColor);
+  }
+
+  &.ng-select-multiple {
+    .ng-select-container {
+      .ng-value-container {
+        padding-left: 12px;
+        .ng-value {
+          margin-left: 3px;
+        }
+      }
+    }
   }
 }

--- a/client/src/sass/ng-select.scss
+++ b/client/src/sass/ng-select.scss
@@ -11,18 +11,13 @@ $ng-select-highlight: #f2690d;
 $ng-select-box-shadow: #{$focus-box-shadow-form} pvar(--mainColorLightest);
 // $ng-select-placeholder: lighten($ng-select-primary-text, 40) !default;
 $ng-select-height: 30px;
-// $ng-select-value-padding-left: 10px !default;
+$ng-select-value-padding-left: 15px;
 // $ng-select-value-font-size: 0.9em !default;
 
 @import "~@ng-select/ng-select/scss/default.theme.scss";
 
 .ng-input {
   font-size: .9em;
-}
-
-.ng-input,
-.ng-select .ng-select-container .ng-value-container {
-  padding-left: 15px;
 }
 
 .ng-select {

--- a/client/src/sass/ng-select.scss
+++ b/client/src/sass/ng-select.scss
@@ -40,14 +40,10 @@ $ng-select-value-padding-left: 15px;
     color: pvar(--inputForegroundColor);
   }
 
-  &.ng-select-multiple {
-    .ng-select-container {
-      .ng-value-container {
-        padding-left: 12px;
-        .ng-value {
-          margin-left: 3px;
-        }
-      }
+  &.ng-select-multiple .ng-select-container .ng-value-container {
+    padding-left: 12px;
+    .ng-value {
+      margin-left: 3px;
     }
   }
 }


### PR DESCRIPTION
## Description

Removed the use of `!important` that caused this issue, and specified rules more in line with `theme.default.css` to minimize overrides and unnecessary rules to ensure tag input fields do not have excessive padding. Ensured entered tags have a `3px` margin on the left to maintain their positioning (because `.ng-input` gets `3px` padding by default already).

## Related issues

Fixes #3915.

## Has this been tested?
- [X] 🙅 no, because they aren't needed

Visually inspected the following relevant input fields in Firefox and a Chrome-based browser (screenshots below, in order listed):
- Advanced search tag inputs
- Video (metadata) editing tag input
- Transcoding configuration inputs (for which 149e4cc, which contained the CSS rule with `!important` seemed to be intended)

## Screenshots
![advanced-search-tags](https://user-images.githubusercontent.com/8865084/113741927-197e3e80-96d0-11eb-965d-da6972765338.png)
![video-tags](https://user-images.githubusercontent.com/8865084/113741928-197e3e80-96d0-11eb-89b2-fd0ccd7ded90.png)
![transcoding_config_inputs](https://user-images.githubusercontent.com/8865084/113741926-197e3e80-96d0-11eb-840d-305103f05777.png)