### PR TITLE
Fixing disappearing hamburger menu for narrow screens

### DIFF
--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -77,10 +77,6 @@ $assets-path: '../assets';
         display: none;
       }
     }
-
-    @media screen and (max-width: 350px) {
-      flex: auto;
-    }
   }
 
   .header-right {

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -43,6 +43,10 @@ $assets-path: '../assets';
         background-color: pvar(--mainForegroundColor);
         mask-image: url('#{$assets-path}/images/misc/menu.svg');
         margin: 0 18px 0 20px;
+        
+        @media screen and (max-width: $mobile-view) {
+          margin: 0 10px;
+        }
       }
     }
 
@@ -71,7 +75,6 @@ $assets-path: '../assets';
     }
 
     @media screen and (max-width: $mobile-view) {
-      width: 70px;
 
       .peertube-title {
         display: none;

--- a/client/src/app/header/search-typeahead.component.scss
+++ b/client/src/app/header/search-typeahead.component.scss
@@ -86,7 +86,7 @@ li.suggestion {
     flex: 1;
 
     input {
-      width: unset;
+      width: 70px;
     }
   }
 


### PR DESCRIPTION
## Description

Fixed the hamburger menu button disappearing on (physically) narrow screens through CSS tweaks.

## Related issues

Fixes #3199.

## Has this been tested?

- [X] 🙅 no, because they aren't needed

Resized the browser window to be sufficiently narrow to reproduce #3199 and added scaling to the search field to make it exceedingly unlikely that the hamburger menu button will disappear. It will still disappear for screen widths under `160px`, but at that point other portions of the UI need work as well; at `184px` and up, it is present without being scaled down, and the search field is barely usable at that point anyway.

## Screenshots
![image](https://user-images.githubusercontent.com/8865084/113780903-da66e200-96fd-11eb-85f9-6ac66f9b097e.png)
