### PR TITLE
correct inconsistency in spacing "Sort By" for narrow screens

### DIFF
--- a/client/src/app/+my-library/my-videos/my-videos.component.html
+++ b/client/src/app/+my-library/my-videos/my-videos.component.html
@@ -26,7 +26,7 @@
     <span class="sr-only" i18n>Clear filters</span>
   </div>
 
-  <div class="peertube-select-container peertube-select-button ml-2">
+  <div class="peertube-select-container peertube-select-button">
     <select [(ngModel)]="sort" (ngModelChange)="onChangeSortColumn()" class="form-control">
       <option value="undefined" disabled>Sort by</option>
       <option value="-publishedAt" i18n>Last published first</option>

--- a/client/src/app/+my-library/my-videos/my-videos.component.scss
+++ b/client/src/app/+my-library/my-videos/my-videos.component.scss
@@ -68,6 +68,7 @@ my-edit-button {
 
     input[type=text] {
       width: 100% !important;
+      margin-bottom: 12px;
     }
   }
 

--- a/client/src/app/+my-library/my-videos/my-videos.component.scss
+++ b/client/src/app/+my-library/my-videos/my-videos.component.scss
@@ -68,7 +68,7 @@ my-edit-button {
     flex-direction: column;
 
     input[type=text] {
-      width: 100% !important;
+      width: 100%;
       margin-bottom: 12px;
     }
     .peertube-select-container {

--- a/client/src/app/+my-library/my-videos/my-videos.component.scss
+++ b/client/src/app/+my-library/my-videos/my-videos.component.scss
@@ -7,6 +7,7 @@ input[type=text] {
 
 .peertube-select-container {
   @include peertube-select-container(auto);
+  margin-left: 0.5rem;
 }
 
 h1 {
@@ -69,6 +70,9 @@ my-edit-button {
     input[type=text] {
       width: 100% !important;
       margin-bottom: 12px;
+    }
+    .peertube-select-container {
+      margin-left: 0;
     }
   }
 


### PR DESCRIPTION
## Description

Corrected minor UI inconsistency in spacing around "Sort By" for narrow screens. 

## Related issues

Fixes #3936.

## Has this been tested?

- [X] 🙅 no, because they aren't needed

Visual inspection in Firefox on Linux and Bromite on Android.

## Screenshots
![sort-by](https://user-images.githubusercontent.com/8865084/113907594-8dd5e200-97a3-11eb-911f-05ab64b5d455.png)