### PR TITLE
render plaintext descriptions on link previews

### DIFF
--- a/server/helpers/markdown.ts
+++ b/server/helpers/markdown.ts
@@ -1,0 +1,26 @@
+import { SANITIZE_OPTIONS, TEXT_WITH_HTML_RULES } from '@shared/core-utils'
+
+const sanitizeHtml = require('sanitize-html')
+const markdownItEmoji = require('markdown-it-emoji/light')
+const MarkdownItClass = require('markdown-it')
+const markdownIt = new MarkdownItClass('default', { linkify: true, breaks: true, html: true })
+
+markdownIt.enable(TEXT_WITH_HTML_RULES)
+markdownIt.use(markdownItEmoji)
+
+const toSafeHtml = text => {
+  // Restore line feed
+  const textWithLineFeed = text.replace(/<br.?\/?>/g, '\r\n')
+
+  // Convert possible markdown (emojis, emphasis and lists) to html
+  const html = markdownIt.render(textWithLineFeed)
+
+  // Convert to safe Html
+  return sanitizeHtml(html, SANITIZE_OPTIONS)
+}
+
+// ---------------------------------------------------------------------------
+
+export {
+  toSafeHtml
+}

--- a/server/helpers/markdown.ts
+++ b/server/helpers/markdown.ts
@@ -19,8 +19,21 @@ const toSafeHtml = text => {
   return sanitizeHtml(html, SANITIZE_OPTIONS)
 }
 
+const mdToPlainText = text => {
+  // Convert possible markdown (emojis, emphasis and lists) to html
+  const html = markdownIt.render(text)
+
+  // Convert to safe Html
+  const safeHtml = sanitizeHtml(html, SANITIZE_OPTIONS)
+
+  return safeHtml.replace(/<[^>]+>/g, '')
+                 .replace(/\n$/, '')
+                 .replace('\n', ', ')
+}
+
 // ---------------------------------------------------------------------------
 
 export {
-  toSafeHtml
+  toSafeHtml,
+  mdToPlainText
 }

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -24,6 +24,7 @@ import { VideoChannelModel } from '../models/video/video-channel'
 import { getActivityStreamDuration } from '../models/video/video-format-utils'
 import { VideoPlaylistModel } from '../models/video/video-playlist'
 import { MAccountActor, MChannelActor } from '../types/models'
+import { toSafeHtml } from '../helpers/markdown'
 
 type Tags = {
   ogType: string
@@ -52,6 +53,10 @@ type Tags = {
     width?: number
     height?: number
   }
+}
+
+const toPlainText = (content: string) => {
+  return toSafeHtml(content).replace(/<[^>]+>/g, '')
 }
 
 class ClientHtml {
@@ -94,13 +99,13 @@ class ClientHtml {
     }
 
     let customHtml = ClientHtml.addTitleTag(html, escapeHTML(video.name))
-    customHtml = ClientHtml.addDescriptionTag(customHtml, escapeHTML(video.description))
+    customHtml = ClientHtml.addDescriptionTag(customHtml, toPlainText(video.description))
 
     const url = WEBSERVER.URL + video.getWatchStaticPath()
     const originUrl = video.url
     const title = escapeHTML(video.name)
     const siteName = escapeHTML(CONFIG.INSTANCE.NAME)
-    const description = escapeHTML(video.description)
+    const description = toPlainText(video.description)
 
     const image = {
       url: WEBSERVER.URL + video.getPreviewStaticPath()
@@ -152,13 +157,13 @@ class ClientHtml {
     }
 
     let customHtml = ClientHtml.addTitleTag(html, escapeHTML(videoPlaylist.name))
-    customHtml = ClientHtml.addDescriptionTag(customHtml, escapeHTML(videoPlaylist.description))
+    customHtml = ClientHtml.addDescriptionTag(customHtml, toPlainText(videoPlaylist.description))
 
     const url = videoPlaylist.getWatchUrl()
     const originUrl = videoPlaylist.url
     const title = escapeHTML(videoPlaylist.name)
     const siteName = escapeHTML(CONFIG.INSTANCE.NAME)
-    const description = escapeHTML(videoPlaylist.description)
+    const description = toPlainText(videoPlaylist.description)
 
     const image = {
       url: videoPlaylist.getThumbnailUrl()
@@ -236,13 +241,13 @@ class ClientHtml {
     }
 
     let customHtml = ClientHtml.addTitleTag(html, escapeHTML(entity.getDisplayName()))
-    customHtml = ClientHtml.addDescriptionTag(customHtml, escapeHTML(entity.description))
+    customHtml = ClientHtml.addDescriptionTag(customHtml, toPlainText(entity.description))
 
     const url = entity.getLocalUrl()
     const originUrl = entity.Actor.url
     const siteName = escapeHTML(CONFIG.INSTANCE.NAME)
     const title = escapeHTML(entity.getDisplayName())
-    const description = escapeHTML(entity.description)
+    const description = toPlainText(entity.description)
 
     const image = {
       url: entity.Actor.getAvatarUrl(),

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -24,7 +24,7 @@ import { VideoChannelModel } from '../models/video/video-channel'
 import { getActivityStreamDuration } from '../models/video/video-format-utils'
 import { VideoPlaylistModel } from '../models/video/video-playlist'
 import { MAccountActor, MChannelActor } from '../types/models'
-import { toSafeHtml } from '../helpers/markdown'
+import { mdToPlainText } from '../helpers/markdown'
 
 type Tags = {
   ogType: string
@@ -53,10 +53,6 @@ type Tags = {
     width?: number
     height?: number
   }
-}
-
-const toPlainText = (content: string) => {
-  return toSafeHtml(content).replace(/<[^>]+>/g, '')
 }
 
 class ClientHtml {
@@ -99,13 +95,13 @@ class ClientHtml {
     }
 
     let customHtml = ClientHtml.addTitleTag(html, escapeHTML(video.name))
-    customHtml = ClientHtml.addDescriptionTag(customHtml, toPlainText(video.description))
+    customHtml = ClientHtml.addDescriptionTag(customHtml, mdToPlainText(video.description))
 
     const url = WEBSERVER.URL + video.getWatchStaticPath()
     const originUrl = video.url
     const title = escapeHTML(video.name)
     const siteName = escapeHTML(CONFIG.INSTANCE.NAME)
-    const description = toPlainText(video.description)
+    const description = mdToPlainText(video.description)
 
     const image = {
       url: WEBSERVER.URL + video.getPreviewStaticPath()
@@ -157,13 +153,13 @@ class ClientHtml {
     }
 
     let customHtml = ClientHtml.addTitleTag(html, escapeHTML(videoPlaylist.name))
-    customHtml = ClientHtml.addDescriptionTag(customHtml, toPlainText(videoPlaylist.description))
+    customHtml = ClientHtml.addDescriptionTag(customHtml, mdToPlainText(videoPlaylist.description))
 
     const url = videoPlaylist.getWatchUrl()
     const originUrl = videoPlaylist.url
     const title = escapeHTML(videoPlaylist.name)
     const siteName = escapeHTML(CONFIG.INSTANCE.NAME)
-    const description = toPlainText(videoPlaylist.description)
+    const description = mdToPlainText(videoPlaylist.description)
 
     const image = {
       url: videoPlaylist.getThumbnailUrl()
@@ -241,13 +237,13 @@ class ClientHtml {
     }
 
     let customHtml = ClientHtml.addTitleTag(html, escapeHTML(entity.getDisplayName()))
-    customHtml = ClientHtml.addDescriptionTag(customHtml, toPlainText(entity.description))
+    customHtml = ClientHtml.addDescriptionTag(customHtml, mdToPlainText(entity.description))
 
     const url = entity.getLocalUrl()
     const originUrl = entity.Actor.url
     const siteName = escapeHTML(CONFIG.INSTANCE.NAME)
     const title = escapeHTML(entity.getDisplayName())
-    const description = toPlainText(entity.description)
+    const description = mdToPlainText(entity.description)
 
     const image = {
       url: entity.Actor.getAvatarUrl(),
@@ -383,7 +379,7 @@ class ClientHtml {
     }
 
     metaTags['og:url'] = tags.url
-    metaTags['og:description'] = tags.description
+    metaTags['og:description'] = mdToPlainText(tags.description)
 
     if (tags.embed) {
       metaTags['og:video:url'] = tags.embed.url
@@ -399,7 +395,7 @@ class ClientHtml {
   private static generateStandardMetaTags (tags: Tags) {
     return {
       name: tags.title,
-      description: tags.description,
+      description: mdToPlainText(tags.description),
       image: tags.image.url
     }
   }

--- a/server/lib/emailer.ts
+++ b/server/lib/emailer.ts
@@ -5,7 +5,6 @@ import { join } from 'path'
 import { VideoChannelModel } from '@server/models/video/video-channel'
 import { MVideoBlacklistLightVideo, MVideoBlacklistVideo } from '@server/types/models/video/video-blacklist'
 import { MVideoImport, MVideoImportVideo } from '@server/types/models/video/video-import'
-import { SANITIZE_OPTIONS, TEXT_WITH_HTML_RULES } from '@shared/core-utils'
 import { AbuseState, EmailPayload, UserAbuse } from '@shared/models'
 import { SendEmailDefaultOptions } from '../../shared/models/server/emailer.model'
 import { isTestInstance, root } from '../helpers/core-utils'
@@ -15,26 +14,7 @@ import { WEBSERVER } from '../initializers/constants'
 import { MAbuseFull, MAbuseMessage, MAccountDefault, MActorFollowActors, MActorFollowFull, MPlugin, MUser } from '../types/models'
 import { MCommentOwnerVideo, MVideo, MVideoAccountLight } from '../types/models/video'
 import { JobQueue } from './job-queue'
-
-const sanitizeHtml = require('sanitize-html')
-const markdownItEmoji = require('markdown-it-emoji/light')
-const MarkdownItClass = require('markdown-it')
-const markdownIt = new MarkdownItClass('default', { linkify: true, breaks: true, html: true })
-
-markdownIt.enable(TEXT_WITH_HTML_RULES)
-
-markdownIt.use(markdownItEmoji)
-
-const toSafeHtml = text => {
-  // Restore line feed
-  const textWithLineFeed = text.replace(/<br.?\/?>/g, '\r\n')
-
-  // Convert possible markdown (emojis, emphasis and lists) to html
-  const html = markdownIt.render(textWithLineFeed)
-
-  // Convert to safe Html
-  return sanitizeHtml(html, SANITIZE_OPTIONS)
-}
+import { toSafeHtml } from '../helpers/markdown'
 
 const Email = require('email-templates')
 

--- a/server/tests/client.ts
+++ b/server/tests/client.ts
@@ -39,7 +39,8 @@ describe('Test a client controllers', function () {
   let account: Account
 
   const videoName = 'my super name for server 1'
-  const videoDescription = 'my super description for server 1'
+  const videoDescription = 'my<br> super __description__ for *server* 1<p></p>'
+  const videoDescriptionPlainText = 'my super description for server 1'
 
   const playlistName = 'super playlist name'
   const playlistDescription = 'super playlist description'
@@ -169,7 +170,7 @@ describe('Test a client controllers', function () {
         .expect(HttpStatusCode.OK_200)
 
       expect(res.text).to.contain(`<meta property="og:title" content="${videoName}" />`)
-      expect(res.text).to.contain(`<meta property="og:description" content="${videoDescription}" />`)
+      expect(res.text).to.contain(`<meta property="og:description" content="${videoDescriptionPlainText}" />`)
       expect(res.text).to.contain('<meta property="og:type" content="video" />')
       expect(res.text).to.contain(`<meta property="og:url" content="${servers[0].url}/videos/watch/${servers[0].video.uuid}" />`)
     })
@@ -181,7 +182,7 @@ describe('Test a client controllers', function () {
         .expect(HttpStatusCode.OK_200)
 
       expect(res.text).to.contain(`<meta property="og:title" content="${videoName}" />`)
-      expect(res.text).to.contain(`<meta property="og:description" content="${videoDescription}" />`)
+      expect(res.text).to.contain(`<meta property="og:description" content="${videoDescriptionPlainText}" />`)
       expect(res.text).to.contain('<meta property="og:type" content="video" />')
       expect(res.text).to.contain(`<meta property="og:url" content="${servers[0].url}/videos/watch/${servers[0].video.uuid}" />`)
     })
@@ -210,7 +211,7 @@ describe('Test a client controllers', function () {
       expect(res.text).to.contain('<meta property="twitter:card" content="summary_large_image" />')
       expect(res.text).to.contain('<meta property="twitter:site" content="@Chocobozzz" />')
       expect(res.text).to.contain(`<meta property="twitter:title" content="${videoName}" />`)
-      expect(res.text).to.contain(`<meta property="twitter:description" content="${videoDescription}" />`)
+      expect(res.text).to.contain(`<meta property="twitter:description" content="${videoDescriptionPlainText}" />`)
     })
 
     it('Should have valid twitter card on the watch playlist page', async function () {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Render markdown then strip html tags for link previews.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
fixes #3839

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, modified tests to cover the existing descriptions contained in the tests
- [x] 👍 yes, light tests as follows

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->
Tested manually video/playlist pages with markdown descriptions (lists, emphasis, etc.) on https://socialsharepreview.com/