### PR TITLE
Update VideoFile structure in the API doc

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -4151,15 +4151,19 @@ components:
           description: 'Video file size in bytes'
         torrentUrl:
           type: string
+          description: Direct URL of the torrent file
           format: url
         torrentDownloadUrl:
           type: string
+          description: URL endpoint that transfers the torrent file as an attachment (so that the browser opens a download dialog)
           format: url
         fileUrl:
           type: string
+          description: Direct URL of the video
           format: url
         fileDownloadUrl:
           type: string
+          description: URL endpoint that transfers the video file as an attachment (so that the browser opens a download dialog)
           format: url
         fps:
           type: number


### PR DESCRIPTION
## Description

In https://framacolibri.org/t/more-details-about-the-video-file-type/11680 the difference between the 4 URL fields in the VideoFile structure was explained.

This PR adds this information in the REST API doc to share the knowledge :)

## Related issues

I didn't create an issue for such a simple change but if it's required, please let me know.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, I tested only in https://editor.swagger.io/
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
