### PR TITLE
Added "last" and a reversed ?playlistPosition in playlist URL

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
@@ -117,6 +117,7 @@ export class VideoWatchPlaylistComponent {
 
   updatePlaylistIndex (position: number) {
     if (this.playlistElements.length === 0 || !position) return
+    if (position < 0) position = (this.playlistPagination.totalItems + 1) + position // Handle the "reverse" index
 
     for (const playlistElement of this.playlistElements) {
       // >= if the previous videos were not valid

--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
@@ -117,8 +117,11 @@ export class VideoWatchPlaylistComponent {
 
   updatePlaylistIndex (position: number) {
     if (this.playlistElements.length === 0 || !position) return
-    if (position < 0) position = (this.playlistPagination.totalItems + 1) + position // Handle the "reverse" index
 
+    // Handle the reverse index
+    if (position < 0) position = this.playlist.videosLength + position + 1;
+
+    console.log("updatePlaylistIndex: " + position)
     for (const playlistElement of this.playlistElements) {
       // >= if the previous videos were not valid
       if (playlistElement.video && playlistElement.position >= position) {

--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
@@ -121,7 +121,6 @@ export class VideoWatchPlaylistComponent {
     // Handle the reverse index
     if (position < 0) position = this.playlist.videosLength + position + 1;
 
-    console.log("updatePlaylistIndex: " + position)
     for (const playlistElement of this.playlistElements) {
       // >= if the previous videos were not valid
       if (playlistElement.video && playlistElement.position >= position) {

--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
@@ -119,7 +119,7 @@ export class VideoWatchPlaylistComponent {
     if (this.playlistElements.length === 0 || !position) return
 
     // Handle the reverse index
-    if (position < 0) position = this.playlist.videosLength + position + 1;
+    if (position < 0) position = this.playlist.videosLength + position + 1
 
     for (const playlistElement of this.playlistElements) {
       // >= if the previous videos were not valid

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -191,8 +191,8 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       // Handle the ?playlistPosition
       let position = queryParams[ 'playlistPosition' ]
       if (position === 'last') position = -1 // Handle the "last" index
-      if (typeof position === 'string') position = parseInt(position); // Sanitization needed for the "reverse" index
-      if (isNaN(position)) position = 1;
+      if (typeof position === 'string') position = parseInt(position, 10) // Sanitization needed for the "reverse" index
+      if (isNaN(position)) position = 1
 
       if (this.playlist && position < 0) this.playlistPosition = this.playlist.videosLength - position + 1
       else this.playlistPosition = position

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -188,7 +188,14 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     })
 
     this.queryParamsSub = this.route.queryParams.subscribe(queryParams => {
-      this.playlistPosition = queryParams[ 'playlistPosition' ]
+      // Handle the ?playlistPosition
+      let position = queryParams[ 'playlistPosition' ]
+      if (position === 'last') position = -1 // Handle the "last" index
+      if (typeof position === 'string') position = parseInt(position); // Sanitization needed for the "reverse" index
+      if (isNaN(position)) position = 1;
+
+      if (this.playlist && position < 0) this.playlistPosition = this.playlist.videosLength - position + 1
+      else this.playlistPosition = position
       this.videoWatchPlaylist.updatePlaylistIndex(this.playlistPosition)
 
       const start = queryParams[ 'start' ]

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -197,7 +197,6 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
         console.error("'?playlistPosition=" + positionParam + "' was parsed as NaN, defaulting to 1.")
       }
 
-      console.log("playlistPosition: " + this.playlistPosition)
       this.videoWatchPlaylist.updatePlaylistIndex(this.playlistPosition)
 
       const start = queryParams[ 'start' ]

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -189,13 +189,15 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
     this.queryParamsSub = this.route.queryParams.subscribe(queryParams => {
       // Handle the ?playlistPosition
-      let position = queryParams[ 'playlistPosition' ]
-      if (position === 'last') position = -1 // Handle the "last" index
-      if (typeof position === 'string') position = parseInt(position, 10) // Sanitization needed for the "reverse" index
-      if (isNaN(position)) position = 1
+      const positionParam = queryParams[ 'playlistPosition' ]
+      if (positionParam === 'last') this.playlistPosition = -1 // Handle the "last" index
+      else this.playlistPosition = parseInt(positionParam, 10)
+      if (isNaN(this.playlistPosition)) {
+        this.playlistPosition = 1
+        console.error("'?playlistPosition=" + positionParam + "' was parsed as NaN, defaulting to 1.")
+      }
 
-      if (this.playlist && position < 0) this.playlistPosition = this.playlist.videosLength - position + 1
-      else this.playlistPosition = position
+      console.log("playlistPosition: " + this.playlistPosition)
       this.videoWatchPlaylist.updatePlaylistIndex(this.playlistPosition)
 
       const start = queryParams[ 'start' ]

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -190,11 +190,14 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     this.queryParamsSub = this.route.queryParams.subscribe(queryParams => {
       // Handle the ?playlistPosition
       const positionParam = queryParams[ 'playlistPosition' ]
-      if (positionParam === 'last') this.playlistPosition = -1 // Handle the "last" index
-      else this.playlistPosition = parseInt(positionParam, 10)
+
+      this.playlistPosition = positionParam === 'last'
+        ? -1 // Handle the "last" index
+        : parseInt(positionParam, 10)
+
       if (isNaN(this.playlistPosition)) {
+        console.error(`playlistPosition query param '${positionParam}' was parsed as NaN, defaulting to 1.`)
         this.playlistPosition = 1
-        console.error("'?playlistPosition=" + positionParam + "' was parsed as NaN, defaulting to 1.")
       }
 
       this.videoWatchPlaylist.updatePlaylistIndex(this.playlistPosition)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

I implemented the `?playlistPosition=last` alongside a "new" feature: the ability to provide a negative playlistPosition, which acts like a "reversed" array index. `?playlistPosition=-1` selects the first video **from the bottom of the playlist**, `?playlistPosition=-2` the second, etc.

This was done as to avoid modifying the prototype of the `updatePlaylistIndex (position: number)` method. 

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/3897.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] ð yes, light tests as follows are enough

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

1. Create a playlist and add a dozen videos to it.
2. Check that `?playlistPosition=last` works.
3. Check that `?playlistPosition=-1`, `?playlistPosition=-3`, etc. works.
4. Check that `?playlistPosition=1`, `?playlistPosition=3`, etc. works.
5. Check that `?playlistPosition=-100` is defaulted to 1.
6. Check that `?playlistPosition=saladedefruit` is defaulted to 1.