### PR TITLE
Added a "previous" button on player when watching playlist

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch-playlist.component.ts
@@ -137,6 +137,33 @@ export class VideoWatchPlaylistComponent {
     this.onPlaylistVideosNearOfBottom(position)
   }
 
+  findPreviousPlaylistVideo (position = this.currentPlaylistPosition): VideoPlaylistElement {
+    if (this.currentPlaylistPosition <= 1) {
+      // we have reached the top of the playlist: either loop or stop
+      if (this.loopPlaylist) {
+        this.currentPlaylistPosition = position = this.playlistPagination.totalItems
+      } else {
+        return
+      }
+    }
+    const previous = this.playlistElements.find(e => e.position === position)
+
+    if (!previous || !previous.video) {
+      return this.findPreviousPlaylistVideo(position - 1)
+    }
+
+    return previous
+  }
+
+  navigateToPreviousPlaylistVideo () {
+    const previous = this.findPreviousPlaylistVideo(this.currentPlaylistPosition - 1)
+    if (!previous) return
+
+    const start = previous.startTimestamp
+    const stop = previous.stopTimestamp
+    this.router.navigate([],{ queryParams: { playlistPosition: previous.position, start, stop } })
+  }
+
   findNextPlaylistVideo (position = this.currentPlaylistPosition): VideoPlaylistElement {
     if (this.currentPlaylistPosition >= this.playlistPagination.totalItems) {
       // we have reached the end of the playlist: either loop or stop

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -799,10 +799,6 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       common: {
         autoplay: this.isAutoplay(),
         nextVideo: () => this.zone.run(() => this.autoplayNext()),
-        previousVideo: () => this.zone.run(() => {
-          // FIXME: Only show if this is a playlist
-          if (this.playlist) this.zone.run(() => this.videoWatchPlaylist.navigateToPreviousPlaylistVideo())
-        }),
 
         playerElement: this.playerElement,
         onPlayerElementChange: (element: HTMLVideoElement) => this.playerElement = element,
@@ -849,6 +845,11 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       webtorrent: {
         videoFiles: video.files
       }
+    }
+
+    // Only set this if we're in a playlist
+    if (this.playlist) options.common.previousVideo = () => {
+      this.zone.run(() => this.videoWatchPlaylist.navigateToPreviousPlaylistVideo())
     }
 
     let mode: PlayerMode

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -799,6 +799,10 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       common: {
         autoplay: this.isAutoplay(),
         nextVideo: () => this.zone.run(() => this.autoplayNext()),
+        previousVideo: () => this.zone.run(() => {
+          // FIXME: Only show if this is a playlist
+          if (this.playlist) this.zone.run(() => this.videoWatchPlaylist.navigateToPreviousPlaylistVideo())
+        }),
 
         playerElement: this.playerElement,
         onPlayerElementChange: (element: HTMLVideoElement) => this.playerElement = element,

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -848,8 +848,10 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     }
 
     // Only set this if we're in a playlist
-    if (this.playlist) options.common.previousVideo = () => {
-      this.zone.run(() => this.videoWatchPlaylist.navigateToPreviousPlaylistVideo())
+    if (this.playlist) {
+      options.common.previousVideo = () => {
+        this.zone.run(() => this.videoWatchPlaylist.navigateToPreviousPlaylistVideo())
+      }
     }
 
     let mode: PlayerMode


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

I have added a "previous" button on the player, as requested in https://github.com/Chocobozzz/PeerTube/issues/3485. 

There are currently a few issues though:
* It duplicates code from `findNextPlaylistVideo()` and `navigateToNextPlaylistVideo()`
* Light tests showed this button was showing even when the user was not watching a playlist 

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/3485

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

![image](https://user-images.githubusercontent.com/20014332/115139614-289baf80-a033-11eb-8f8c-060579cbcc2b.png)
