### PR TITLE
rephrase signup limit validator error

### DIFF
--- a/client/src/app/shared/form-validators/custom-config-validators.ts
+++ b/client/src/app/shared/form-validators/custom-config-validators.ts
@@ -44,7 +44,7 @@ export const SIGNUP_LIMIT_VALIDATOR: BuildFormValidator = {
   VALIDATORS: [Validators.required, Validators.min(-1), Validators.pattern('-?[0-9]+')],
   MESSAGES: {
     'required': $localize`Signup limit is required.`,
-    'min': $localize`Signup limit must be greater than 1.`,
+    'min': $localize`Signup limit must be greater than -1.`,
     'pattern': $localize`Signup limit must be a number.`
   }
 }

--- a/client/src/app/shared/form-validators/custom-config-validators.ts
+++ b/client/src/app/shared/form-validators/custom-config-validators.ts
@@ -44,7 +44,7 @@ export const SIGNUP_LIMIT_VALIDATOR: BuildFormValidator = {
   VALIDATORS: [Validators.required, Validators.min(-1), Validators.pattern('-?[0-9]+')],
   MESSAGES: {
     'required': $localize`Signup limit is required.`,
-    'min': $localize`Signup limit must be greater than -1.`,
+    'min': $localize`Signup limit must be greater than 1. Use -1 to disable it.`,
     'pattern': $localize`Signup limit must be a number.`
   }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
While working on #3612, I noticed there was a typo in the 'min' error message of the SIGNUP_LIMIT_VALIDATOR.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
None.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->
None.