### PR TITLE
Update hlsjs to v1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -80,7 +80,7 @@
     "dexie": "^3.0.0",
     "file-loader": "^6.0.0",
     "focus-visible": "^5.0.2",
-    "hls.js": "^0.14.16",
+    "hls.js": "^1.0.1",
     "html-loader": "^1.0.0",
     "html-webpack-plugin": "^4.0.3",
     "https-browserify": "^1.0.0",

--- a/client/src/assets/player/p2p-media-loader/hls-plugin.ts
+++ b/client/src/assets/player/p2p-media-loader/hls-plugin.ts
@@ -2,6 +2,7 @@
 // We duplicated this plugin to choose the hls.js version we want, because streamroot only provide a bundled file
 
 import * as Hlsjs from 'hls.js/dist/hls.light.js'
+import { Level } from 'hls.js'
 import videojs from 'video.js'
 import { HlsjsConfigHandlerOptions, QualityLevelRepresentation, QualityLevels, VideoJSTechHLS } from '../peertube-videojs-typings'
 
@@ -10,7 +11,7 @@ type ErrorCounts = {
 }
 
 type Metadata = {
-  levels: Hlsjs.Level[]
+  levels: Level[]
 }
 
 type CustomAudioTrack = Hlsjs.HlsAudioTrack & { name?: string, lang?: string }
@@ -285,7 +286,7 @@ class Html5Hlsjs {
     this.hls.nextLevel = qualityId
   }
 
-  private _levelLabel (level: Hlsjs.Level) {
+  private _levelLabel (level: Level) {
     if (this.player.srOptions_.levelLabelHandler) {
       return this.player.srOptions_.levelLabelHandler(level)
     }

--- a/client/src/assets/player/peertube-videojs-typings.ts
+++ b/client/src/assets/player/peertube-videojs-typings.ts
@@ -1,4 +1,5 @@
-import { Config, Level } from 'hls.js'
+import * as Hlsjs from 'hls.js'
+import { HlsConfig } from 'hls.js'
 import videojs from 'video.js'
 import { VideoFile, VideoPlaylist, VideoPlaylistElement } from '@shared/models'
 import { P2pMediaLoaderPlugin } from './p2p-media-loader/p2p-media-loader-plugin'
@@ -56,10 +57,10 @@ export interface VideoJSTechHLS extends videojs.Tech {
 }
 
 export interface HlsjsConfigHandlerOptions {
-  hlsjsConfig?: Config & { cueHandler: any }// FIXME: typings
+  hlsjsConfig?: HlsConfig & { cueHandler: any }// FIXME: typings
   captionConfig?: any // FIXME: typings
 
-  levelLabelHandler?: (level: Level) => string
+  levelLabelHandler?: (level: Hlsjs.Level) => string
 }
 
 type QualityLevelRepresentation = {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4736,7 +4736,7 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.3:
+eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -5610,13 +5610,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-hls.js@^0.14.16:
-  version "0.14.17"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.14.17.tgz#0127cff2ec2f994a54eb955fe669ef6153a8e317"
-  integrity sha512-25A7+m6qqp6UVkuzUQ//VVh2EEOPYlOBg32ypr34bcPO7liBMOkKFvbjbCBfiPAOTA/7BSx1Dujft3Th57WyFg==
-  dependencies:
-    eventemitter3 "^4.0.3"
-    url-toolkit "^2.1.6"
+hls.js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.0.1.tgz#d92bd0a9c78760f0f0e90d53c60192800ebc629f"
+  integrity sha512-ElPUW9VMY2uXdX07N872BSrVUcVd4jZGav4nqlY3vinpdMpW8esmdpUaeVA5vv3oIRSmiC/XtL9K+mSt6rlBpA==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -11384,7 +11381,7 @@ url-parse@^1.4.3, url-parse@^1.5.1:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url-toolkit@^2.1.6, url-toolkit@^2.2.1:
+url-toolkit@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.2.1.tgz#89009ed3d62a3574de079532a7266c14d2cc1c4f"
   integrity sha512-8+DzgrtDZYZGhHaAop5WGVghMdCfOLGbhcArsJD0qDll71FXa7EeKxi2hilPIscn2nwMz4PRjML32Sz4JTN0Xw==


### PR DESCRIPTION
## Description
Updates hls.js to latest version. Still waiting for p2p-media-loader-hlsjs to release a new version where hls.js v1 is supported.

According to https://github.com/Novage/p2p-media-loader/pull/178#issuecomment-817893861 there's still some issues with p2p-media-loader-hlsjs compatibility with hls.js v1. In my manual tests it looks good though.

## Related issues
#3962

## Has this been tested?
- [x] 🙅 no, because they aren't needed