### PR TITLE
Auto load new comments

### DIFF
--- a/client/src/app/+videos/+video-watch/comment/video-comments.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comments.component.html
@@ -25,6 +25,11 @@
       [textValue]="commentThreadRedraftValue"
     ></my-video-comment-add>
 
+    <div *ngIf="newComments.length > 0" class="alert alert-primary">
+      <a class="alert-link" (click)="onClickShowNewComments($event)" href="">
+        {newComments.length, plural, =0 {Comments} =1 {1 new comment} other {{{newComments.length}} new comments}}
+      </a>
+    </div>
     <div *ngIf="totalNotDeletedComments === 0 && comments.length === 0" i18n>No comments.</div>
 
     <div


### PR DESCRIPTION
## Description
When watching a video new comments will automatically be loaded with a notification above the comments field.

Possible improvements:
- [ ] Don't load when video is in fullscreen.
- [ ] Don't load when page isn't visible.
- [ ] Make the update interval configurable and possible to disable in the config file.
- [ ] Notify new comments via web socket instead.

## Related issues
#212

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Screenshots
![image](https://user-images.githubusercontent.com/6680299/115732475-50b74580-a388-11eb-9885-e422f353bde6.png)
