### PR TITLE
Implemented configurable minimum signup age

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-basic-configuration.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-basic-configuration.component.html
@@ -167,6 +167,20 @@
 
                 <small i18n *ngIf="hasUnlimitedSignup()" class="text-muted">Signup won't be limited to a fixed number of users.</small>
               </div>
+              
+              <div [ngClass]="getDisabledSignupClass()" class="mt-3">
+                <label i18n for="signupMinimumAge">Minimum required age to create an account</label>
+
+                <div class="number-with-unit">
+                    <input
+                      type="number" min="1" id="signupMinimumAge" class="form-control"
+                      formControlName="minimumAge" [ngClass]="{ 'input-error': formErrors['signup.minimumAge'] }"
+                    >
+                    <span i18n>{form.value['signup']['minimumAge'], plural, =1 {year old} other {years old}}</span>
+                </div>
+
+                <div *ngIf="formErrors.signup.minimumAge" class="form-error">{{ formErrors.signup.minimumAge }}</div>
+              </div>
             </ng-container>
           </my-peertube-checkbox>
         </div>
@@ -478,7 +492,7 @@
         <ng-container formGroupName="twitter">
 
           <div class="form-group">
-            <label i18n for="signupLimit">Your Twitter username</label>
+            <label i18n>Your Twitter username</label>
 
             <input
               type="text" id="servicesTwitterUsername" class="form-control"

--- a/client/src/app/+admin/config/edit-custom-config/edit-basic-configuration.component.ts
+++ b/client/src/app/+admin/config/edit-custom-config/edit-basic-configuration.component.ts
@@ -1,4 +1,3 @@
-
 import { pairwise } from 'rxjs/operators'
 import { Component, Input, OnInit } from '@angular/core'
 import { FormGroup } from '@angular/forms'

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
@@ -20,6 +20,7 @@ import {
   SEARCH_INDEX_URL_VALIDATOR,
   SERVICES_TWITTER_USERNAME_VALIDATOR,
   SIGNUP_LIMIT_VALIDATOR,
+  SIGNUP_MINIMUM_AGE_VALIDATOR,
   TRANSCODING_THREADS_VALIDATOR
 } from '@app/shared/form-validators/custom-config-validators'
 import { USER_VIDEO_QUOTA_DAILY_VALIDATOR, USER_VIDEO_QUOTA_VALIDATOR } from '@app/shared/form-validators/user-validators'
@@ -113,7 +114,8 @@ export class EditCustomConfigComponent extends FormReactive implements OnInit {
       signup: {
         enabled: null,
         limit: SIGNUP_LIMIT_VALIDATOR,
-        requiresEmailVerification: null
+        requiresEmailVerification: null,
+        minimumAge: SIGNUP_MINIMUM_AGE_VALIDATOR
       },
       import: {
         videos: {

--- a/client/src/app/+signup/+register/register-step-terms.component.html
+++ b/client/src/app/+signup/+register/register-step-terms.component.html
@@ -2,8 +2,8 @@
   <div class="form-group form-group-terms">
     <my-peertube-checkbox inputName="terms" formControlName="terms">
       <ng-template ptTemplate="label">
-        <ng-container i18n>
-          I am at least 16 years old and agree
+        <ng-container i18n> 
+          I am at least {{ minimumAge }} years old and agree 
           to the <a class="terms-anchor" (click)="onTermsClick($event)" href='#'>Terms</a>
           <ng-container *ngIf="hasCodeOfConduct"> and to the <a (click)="onCodeOfConductClick($event)" href='#'>Code of Conduct</a></ng-container>
           of this instance

--- a/client/src/app/+signup/+register/register-step-terms.component.html
+++ b/client/src/app/+signup/+register/register-step-terms.component.html
@@ -3,7 +3,7 @@
     <my-peertube-checkbox inputName="terms" formControlName="terms">
       <ng-template ptTemplate="label">
         <ng-container i18n> 
-          I am at least {{ minimumAge }} years old and agree 
+          I am at least {{ minimumAge }} years old and agree
           to the <a class="terms-anchor" (click)="onTermsClick($event)" href='#'>Terms</a>
           <ng-container *ngIf="hasCodeOfConduct"> and to the <a (click)="onCodeOfConductClick($event)" href='#'>Code of Conduct</a></ng-container>
           of this instance

--- a/client/src/app/+signup/+register/register-step-terms.component.ts
+++ b/client/src/app/+signup/+register/register-step-terms.component.ts
@@ -12,6 +12,7 @@ import { FormReactive, FormValidatorService } from '@app/shared/shared-forms'
 })
 export class RegisterStepTermsComponent extends FormReactive implements OnInit {
   @Input() hasCodeOfConduct = false
+  @Input() minimumAge = 16
 
   @Output() formBuilt = new EventEmitter<FormGroup>()
   @Output() termsClick = new EventEmitter<void>()

--- a/client/src/app/+signup/+register/register.component.html
+++ b/client/src/app/+signup/+register/register.component.html
@@ -17,7 +17,7 @@
 
           <my-register-step-terms
             [hasCodeOfConduct]="!!aboutHtml.codeOfConduct"
-            [minimumAge]="this.minimumAge"
+            [minimumAge]="minimumAge"
             (formBuilt)="onTermsFormBuilt($event)" (termsClick)="onTermsClick()" (codeOfConductClick)="onCodeOfConductClick()"
           ></my-register-step-terms>
 

--- a/client/src/app/+signup/+register/register.component.html
+++ b/client/src/app/+signup/+register/register.component.html
@@ -17,6 +17,7 @@
 
           <my-register-step-terms
             [hasCodeOfConduct]="!!aboutHtml.codeOfConduct"
+            [minimumAge]="this.minimumAge"
             (formBuilt)="onTermsFormBuilt($event)" (termsClick)="onTermsClick()" (codeOfConductClick)="onCodeOfConductClick()"
           ></my-register-step-terms>
 

--- a/client/src/app/+signup/+register/register.component.ts
+++ b/client/src/app/+signup/+register/register.component.ts
@@ -5,7 +5,7 @@ import { AuthService, UserService } from '@app/core'
 import { HooksService } from '@app/core/plugins/hooks.service'
 import { NgbAccordion } from '@ng-bootstrap/ng-bootstrap'
 import { UserRegister } from '@shared/models'
-import { ServerConfig } from '@shared/models/server'
+import { ServerConfig } from '@shared/models'
 import { InstanceAboutAccordionComponent } from '@app/shared/shared-instance'
 
 @Component({
@@ -56,7 +56,12 @@ export class RegisterComponent implements OnInit {
     return this.serverConfig.signup.requiresEmailVerification
   }
 
+  get minimumAge() {
+    return this.serverConfig.signup.minimumAge
+  }
+
   ngOnInit (): void {
+    console.log(this.route.snapshot.data.serverConfig)
     this.serverConfig = this.route.snapshot.data.serverConfig
 
     this.videoUploadDisabled = this.serverConfig.user.videoQuota === 0

--- a/client/src/app/+signup/+register/register.component.ts
+++ b/client/src/app/+signup/+register/register.component.ts
@@ -56,7 +56,7 @@ export class RegisterComponent implements OnInit {
     return this.serverConfig.signup.requiresEmailVerification
   }
 
-  get minimumAge() {
+  get minimumAge () {
     return this.serverConfig.signup.minimumAge
   }
 

--- a/client/src/app/+signup/+register/register.component.ts
+++ b/client/src/app/+signup/+register/register.component.ts
@@ -5,7 +5,7 @@ import { AuthService, UserService } from '@app/core'
 import { HooksService } from '@app/core/plugins/hooks.service'
 import { NgbAccordion } from '@ng-bootstrap/ng-bootstrap'
 import { UserRegister } from '@shared/models'
-import { ServerConfig } from '@shared/models'
+import { ServerConfig } from '@shared/models/server'
 import { InstanceAboutAccordionComponent } from '@app/shared/shared-instance'
 
 @Component({
@@ -61,7 +61,6 @@ export class RegisterComponent implements OnInit {
   }
 
   ngOnInit (): void {
-    console.log(this.route.snapshot.data.serverConfig)
     this.serverConfig = this.route.snapshot.data.serverConfig
 
     this.videoUploadDisabled = this.serverConfig.user.videoQuota === 0

--- a/client/src/app/core/server/server.service.ts
+++ b/client/src/app/core/server/server.service.ts
@@ -63,7 +63,8 @@ export class ServerService {
     signup: {
       allowed: false,
       allowedForCurrentIP: false,
-      requiresEmailVerification: false
+      requiresEmailVerification: false,
+      minimumAge: 16
     },
     transcoding: {
       profile: 'default',

--- a/client/src/app/shared/form-validators/custom-config-validators.ts
+++ b/client/src/app/shared/form-validators/custom-config-validators.ts
@@ -49,6 +49,15 @@ export const SIGNUP_LIMIT_VALIDATOR: BuildFormValidator = {
   }
 }
 
+export const SIGNUP_MINIMUM_AGE_VALIDATOR: BuildFormValidator = {
+  VALIDATORS: [Validators.required, Validators.min(1), Validators.pattern('[0-9]+')],
+  MESSAGES: {
+    'required': $localize`Signup minimum age is required.`,
+    'min': $localize`Signup minimum age must be greater than 1.`,
+    'pattern': $localize`Signup minimum age must be a number.`
+  }
+}
+
 export const ADMIN_EMAIL_VALIDATOR: BuildFormValidator = {
   VALIDATORS: [Validators.required, Validators.email],
   MESSAGES: {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -229,7 +229,7 @@ contact_form:
 signup:
   enabled: false
   limit: 10 # When the limit is reached, registrations are disabled. -1 == unlimited
-  minimum_age: 16
+  minimum_age: 16 # Used to configure the signup form
   requires_email_verification: false
   filters:
     cidr: # You can specify CIDR ranges to whitelist (empty = no filtering) or blacklist

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -229,6 +229,7 @@ contact_form:
 signup:
   enabled: false
   limit: 10 # When the limit is reached, registrations are disabled. -1 == unlimited
+  minimum_age: 16
   requires_email_verification: false
   filters:
     cidr: # You can specify CIDR ranges to whitelist (empty = no filtering) or blacklist

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -239,6 +239,7 @@ contact_form:
 signup:
   enabled: false
   limit: 10 # When the limit is reached, registrations are disabled. -1 == unlimited
+  mimimum_age: 16
   requires_email_verification: false
   filters:
     cidr: # You can specify CIDR ranges to whitelist (empty = no filtering) or blacklist

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -171,7 +171,8 @@ function customConfig (): CustomConfig {
     signup: {
       enabled: CONFIG.SIGNUP.ENABLED,
       limit: CONFIG.SIGNUP.LIMIT,
-      requiresEmailVerification: CONFIG.SIGNUP.REQUIRES_EMAIL_VERIFICATION
+      requiresEmailVerification: CONFIG.SIGNUP.REQUIRES_EMAIL_VERIFICATION,
+      minimumAge: CONFIG.SIGNUP.MINIMUM_AGE
     },
     admin: {
       email: CONFIG.ADMIN.EMAIL

--- a/server/initializers/checker-before-init.ts
+++ b/server/initializers/checker-before-init.ts
@@ -19,7 +19,7 @@ function checkMissedConfig () {
     'csp.enabled', 'csp.report_only', 'csp.report_uri',
     'security.frameguard.enabled',
     'cache.previews.size', 'cache.captions.size', 'cache.torrents.size', 'admin.email', 'contact_form.enabled',
-    'signup.enabled', 'signup.limit', 'signup.requires_email_verification',
+    'signup.enabled', 'signup.limit', 'signup.requires_email_verification', 'signup.minimum_age',
     'signup.filters.cidr.whitelist', 'signup.filters.cidr.blacklist',
     'redundancy.videos.strategies', 'redundancy.videos.check_interval',
     'transcoding.enabled', 'transcoding.threads', 'transcoding.allow_additional_extensions', 'transcoding.hls.enabled',

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -185,7 +185,7 @@ const CONFIG = {
     get ENABLED () { return config.get<boolean>('signup.enabled') },
     get LIMIT () { return config.get<number>('signup.limit') },
     get REQUIRES_EMAIL_VERIFICATION () { return config.get<boolean>('signup.requires_email_verification') },
-    get MINIMUM_AGE() { return config.get<number>('signup.minimum_age') },
+    get MINIMUM_AGE () { return config.get<number>('signup.minimum_age') },
     FILTERS: {
       CIDR: {
         get WHITELIST () { return config.get<string[]>('signup.filters.cidr.whitelist') },

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -185,6 +185,7 @@ const CONFIG = {
     get ENABLED () { return config.get<boolean>('signup.enabled') },
     get LIMIT () { return config.get<number>('signup.limit') },
     get REQUIRES_EMAIL_VERIFICATION () { return config.get<boolean>('signup.requires_email_verification') },
+    get MINIMUM_AGE() { return config.get<number>('signup.minimum_age') },
     FILTERS: {
       CIDR: {
         get WHITELIST () { return config.get<string[]>('signup.filters.cidr.whitelist') },

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -69,7 +69,8 @@ async function getServerConfig (ip?: string): Promise<ServerConfig> {
     signup: {
       allowed,
       allowedForCurrentIP,
-      requiresEmailVerification: CONFIG.SIGNUP.REQUIRES_EMAIL_VERIFICATION
+      requiresEmailVerification: CONFIG.SIGNUP.REQUIRES_EMAIL_VERIFICATION,
+      minimumAge: CONFIG.SIGNUP.MINIMUM_AGE
     },
     transcoding: {
       hls: {

--- a/server/middlewares/validators/config.ts
+++ b/server/middlewares/validators/config.ts
@@ -30,6 +30,7 @@ const customConfigUpdateValidator = [
   body('signup.enabled').isBoolean().withMessage('Should have a valid signup enabled boolean'),
   body('signup.limit').isInt().withMessage('Should have a valid signup limit'),
   body('signup.requiresEmailVerification').isBoolean().withMessage('Should have a valid requiresEmailVerification boolean'),
+  body('signup.minimumAge').isInt().withMessage("Should have a valid minimum age required"),
 
   body('admin.email').isEmail().withMessage('Should have a valid administrator email'),
   body('contactForm.enabled').isBoolean().withMessage('Should have a valid contact form enabled boolean'),

--- a/server/tests/api/check-params/config.ts
+++ b/server/tests/api/check-params/config.ts
@@ -73,7 +73,8 @@ describe('Test config API validators', function () {
     signup: {
       enabled: false,
       limit: 5,
-      requiresEmailVerification: false
+      requiresEmailVerification: false,
+      minimumAge: 16
     },
     admin: {
       email: 'superadmin1@example.com'

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -316,7 +316,8 @@ describe('Test config', function () {
       signup: {
         enabled: false,
         limit: 5,
-        requiresEmailVerification: false
+        requiresEmailVerification: false,
+        minimumAge: 16
       },
       admin: {
         email: 'superadmin1@example.com'

--- a/shared/extra-utils/server/config.ts
+++ b/shared/extra-utils/server/config.ts
@@ -98,7 +98,8 @@ function updateCustomSubConfig (url: string, token: string, newConfig: DeepParti
     signup: {
       enabled: false,
       limit: 5,
-      requiresEmailVerification: false
+      requiresEmailVerification: false,
+      minimumAge: 16
     },
     admin: {
       email: 'superadmin1@example.com'

--- a/shared/models/server/custom-config.model.ts
+++ b/shared/models/server/custom-config.model.ts
@@ -69,6 +69,7 @@ export interface CustomConfig {
     enabled: boolean
     limit: number
     requiresEmailVerification: boolean
+    minimumAge: number
   }
 
   admin: {

--- a/shared/models/server/server-config.model.ts
+++ b/shared/models/server/server-config.model.ts
@@ -84,6 +84,7 @@ export interface ServerConfig {
     allowed: boolean
     allowedForCurrentIP: boolean
     requiresEmailVerification: boolean
+    minimumAge: number
   }
 
   transcoding: {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
I added a config option to set the minimum age required in order to signup to the instance. It defaults to 16 (which has been the "default" age on PeerTube up to now).
I therefore modified the RegisterComponent so that it can display this age.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/3612.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

I believe light tests were enough, but should tests be added to the test suite?
If so:
* On which test suit?
* Which tests scenarios?

## Screenshots

In the sign up page:
![image](https://user-images.githubusercontent.com/20014332/115955136-2df66f80-a4f5-11eb-82cf-1301439d98cd.png)

In the admin "Basic configuration" editor :
![image](https://user-images.githubusercontent.com/20014332/115955160-52eae280-a4f5-11eb-9124-e42a7000fd35.png)
