### PR TITLE
Added ability to reply to comments with remote interaction

### DIFF
--- a/client/src/app/+videos/+video-watch/comment/video-comment.component.html
+++ b/client/src/app/+videos/+video-watch/comment/video-comment.component.html
@@ -35,7 +35,7 @@
         ></div>
 
         <div class="comment-actions">
-          <div *ngIf="isUserLoggedIn()" tabindex=0 (click)="onWantToReply()" class="comment-action-reply" i18n>Reply</div>
+          <div tabindex=0 (click)="onWantToReply()" class="comment-action-reply" i18n>Reply</div>
 
           <my-user-moderation-dropdown
             [prependActions]="prependModerationActions" tabindex=0 [buttonStyled]="false"
@@ -57,7 +57,7 @@
       </ng-container>
 
       <my-video-comment-add
-        *ngIf="!comment.isDeleted && isUserLoggedIn() && inReplyToCommentId === comment.id"
+        *ngIf="!comment.isDeleted && inReplyToCommentId === comment.id"
         [user]="user"
         [video]="video"
         [parentComment]="comment"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
I got rid of the conditions that required a user to be logged in in order to reply to comments.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/3725

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

While non-logged-in users now have access to the reply button (see screenshot), I could not test if the reply worked properly (I expect it should, though) because my pleroma instance wouldn't let me do a remote interaction (no clue why that is).

## Screenshots

![image](https://user-images.githubusercontent.com/20014332/115973233-b60b6200-a553-11eb-856c-05ed7d391cd5.png)
