### PR TITLE
update FAQ urls in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,14 @@ Feel free to reach out if you have any questions or ideas! :speech_balloon:
 :package: Create your own instance
 ----------------------------------------------------------------
 
-See the [production guide](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/production.md), which is the recommended way to install or upgrade PeerTube. For hardware requirements, see [Should I have a big server to run PeerTube?](https://github.com/Chocobozzz/PeerTube/blob/develop/FAQ.md#should-i-have-a-big-server-to-run-peertube) in the FAQ.
+See the [production guide](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/production.md), which is the recommended way to install or upgrade PeerTube. For hardware requirements, see [Should I have a big server to run PeerTube?](https://joinpeertube.org/faq#should-i-have-a-big-server-to-run-peertube) in the FAQ.
 
 See the [community packages](https://docs.joinpeertube.org/install-unofficial), which cover various platforms (including [YunoHost](https://install-app.yunohost.org/?app=peertube) and [Docker](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/docker.md)).
 
 :book: Documentation
 ----------------------------------------------------------------
 
-If you have a question, please try to find the answer in the [FAQ](https://github.com/Chocobozzz/PeerTube/blob/develop/FAQ.md) first.
+If you have a question, please try to find the answer in the [FAQ](https://joinpeertube.org/faq) first.
 
 ### User documentation
 


### PR DESCRIPTION
Apparently the FAQ has moved, see the [old URL](https://github.com/Chocobozzz/PeerTube/blob/develop/FAQ.md).
