### PR TITLE
Fix HLS playlist format

### DIFF
--- a/server/lib/hls.ts
+++ b/server/lib/hls.ts
@@ -50,13 +50,12 @@ async function updateMasterHLSPlaylist (video: MVideoWithFile) {
     let line = `#EXT-X-STREAM-INF:${bandwidth},${resolution}`
     if (file.fps) line += ',FRAME-RATE=' + file.fps
 
-    const videoCodec = await getVideoStreamCodec(videoFilePath)
-    line += `,CODECS="${videoCodec}`
+    const codecs = await Promise.all([
+      getVideoStreamCodec(videoFilePath),
+      getAudioStreamCodec(videoFilePath)
+    ])
 
-    const audioCodec = await getAudioStreamCodec(videoFilePath)
-    if (audioCodec) line += `,${audioCodec}`
-
-    line += '"'
+    line += `,CODECS="${codecs.filter(c => !!c).join(',')}"`
 
     masterPlaylists.push(line)
     masterPlaylists.push(VideoStreamingPlaylistModel.getHlsPlaylistFilename(file.resolution))


### PR DESCRIPTION
## Description
Remove prefixed comma when there's no video codec.

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:BANDWIDTH=2500677,RESOLUTION=1920x1080,FRAME-RATE=30,CODECS=",mp4a.40.2"
1080.m3u8
```

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough


1) Watch a video with both video and audio codec.
1) Watch a video with only audio codec.