### PR TITLE
throw on failed parameter checks instead of pure boolean checks

### DIFF
--- a/scripts/create-import-video-file-job.ts
+++ b/scripts/create-import-video-file-job.ts
@@ -6,7 +6,7 @@ import { resolve } from 'path'
 import { VideoModel } from '../server/models/video/video'
 import { initDatabaseModels } from '../server/initializers/database'
 import { JobQueue } from '../server/lib/job-queue'
-import { isUUIDValid } from '@server/helpers/custom-validators/misc'
+import { catchErrorAsBoolean, checkUUID } from '@server/helpers/custom-validators/misc'
 
 program
   .option('-v, --video [videoUUID]', 'Video UUID')
@@ -31,7 +31,7 @@ run()
 async function run () {
   await initDatabaseModels(true)
 
-  if (isUUIDValid(options.video) === false) {
+  if (catchErrorAsBoolean(checkUUID)(options.video) === false) {
     console.error('%s is not a valid video UUID.', options.video)
     return
   }

--- a/scripts/create-transcoding-job.ts
+++ b/scripts/create-transcoding-job.ts
@@ -8,7 +8,7 @@ import { JobQueue } from '../server/lib/job-queue'
 import { computeResolutionsToTranscode } from '@server/helpers/ffprobe-utils'
 import { VideoTranscodingPayload } from '@shared/models'
 import { CONFIG } from '@server/initializers/config'
-import { isUUIDValid } from '@server/helpers/custom-validators/misc'
+import { catchErrorAsBoolean, checkUUID } from '@server/helpers/custom-validators/misc'
 
 program
   .option('-v, --video [videoUUID]', 'Video UUID')
@@ -38,7 +38,7 @@ run()
 async function run () {
   await initDatabaseModels(true)
 
-  if (isUUIDValid(options.video) === false) {
+  if (catchErrorAsBoolean(checkUUID)(options.video) === false) {
     console.error('%s is not a valid video UUID.', options.video)
     return
   }

--- a/scripts/reset-password.ts
+++ b/scripts/reset-password.ts
@@ -4,7 +4,7 @@ registerTSPaths()
 import * as program from 'commander'
 import { initDatabaseModels } from '../server/initializers/database'
 import { UserModel } from '../server/models/user/user'
-import { isUserPasswordValid } from '../server/helpers/custom-validators/users'
+import { checkUserPassword } from '../server/helpers/custom-validators/users'
 
 program
   .option('-u, --user [user]', 'User')
@@ -42,7 +42,9 @@ initDatabaseModels(true)
 
     console.log('New password?')
     rl.on('line', function (password) {
-      if (!isUserPasswordValid(password)) {
+      try {
+        checkUserPassword(password)
+      } catch (error) {
         console.error('New password is invalid.')
         process.exit(-1)
       }

--- a/server/helpers/custom-validators/accounts.ts
+++ b/server/helpers/custom-validators/accounts.ts
@@ -1,8 +1,8 @@
 import { isUserDescriptionValid, isUserUsernameValid } from './users'
-import { EtoB, exists } from './misc'
+import { catchErrorAsBoolean, exists } from './misc'
 
 function isAccountNameValid (value: string) {
-  return EtoB(isUserUsernameValid)(value)
+  return catchErrorAsBoolean(isUserUsernameValid)(value)
 }
 
 function isAccountIdValid (value: string) {

--- a/server/helpers/custom-validators/accounts.ts
+++ b/server/helpers/custom-validators/accounts.ts
@@ -1,21 +1,15 @@
-import { checkUserDescription, isUserUsernameValid } from './users'
+import { checkUserDescription, checkUserUsername } from './users'
 import { exists } from './misc'
 
-/**
- * @throws {Error}
- */
 function checkAccountName (value: string) {
-  return isUserUsernameValid(value)
+  return checkUserUsername(value)
 }
 
 function isAccountIdValid (value: string) {
   return exists(value)
 }
 
-/**
- * @throws {Error}
- */
-function isAccountDescriptionValid (value: string) {
+function checkAccountDescription (value: string) {
   return checkUserDescription(value)
 }
 
@@ -23,6 +17,6 @@ function isAccountDescriptionValid (value: string) {
 
 export {
   isAccountIdValid,
-  isAccountDescriptionValid,
+  checkAccountDescription,
   checkAccountName
 }

--- a/server/helpers/custom-validators/accounts.ts
+++ b/server/helpers/custom-validators/accounts.ts
@@ -1,8 +1,8 @@
 import { isUserDescriptionValid, isUserUsernameValid } from './users'
-import { exists } from './misc'
+import { catchError, exists } from './misc'
 
 function isAccountNameValid (value: string) {
-  return isUserUsernameValid(value)
+  return catchError(isUserUsernameValid)(value)
 }
 
 function isAccountIdValid (value: string) {

--- a/server/helpers/custom-validators/accounts.ts
+++ b/server/helpers/custom-validators/accounts.ts
@@ -1,16 +1,22 @@
-import { isUserDescriptionValid, isUserUsernameValid } from './users'
-import { catchErrorAsBoolean, exists } from './misc'
+import { checkUserDescription, isUserUsernameValid } from './users'
+import { exists } from './misc'
 
-function isAccountNameValid (value: string) {
-  return catchErrorAsBoolean(isUserUsernameValid)(value)
+/**
+ * @throws {Error}
+ */
+function checkAccountName (value: string) {
+  return isUserUsernameValid(value)
 }
 
 function isAccountIdValid (value: string) {
   return exists(value)
 }
 
+/**
+ * @throws {Error}
+ */
 function isAccountDescriptionValid (value: string) {
-  return isUserDescriptionValid(value)
+  return checkUserDescription(value)
 }
 
 // ---------------------------------------------------------------------------
@@ -18,5 +24,5 @@ function isAccountDescriptionValid (value: string) {
 export {
   isAccountIdValid,
   isAccountDescriptionValid,
-  isAccountNameValid
+  checkAccountName
 }

--- a/server/helpers/custom-validators/accounts.ts
+++ b/server/helpers/custom-validators/accounts.ts
@@ -1,8 +1,8 @@
 import { isUserDescriptionValid, isUserUsernameValid } from './users'
-import { catchError, exists } from './misc'
+import { EtoB, exists } from './misc'
 
 function isAccountNameValid (value: string) {
-  return catchError(isUserUsernameValid)(value)
+  return EtoB(isUserUsernameValid)(value)
 }
 
 function isAccountIdValid (value: string) {

--- a/server/helpers/custom-validators/activitypub/actor.ts
+++ b/server/helpers/custom-validators/activitypub/actor.ts
@@ -1,6 +1,6 @@
 import validator from 'validator'
 import { CONSTRAINTS_FIELDS } from '../../../initializers/constants'
-import { exists, isArray, isDateValid } from '../misc'
+import { exists, isArray, checkDate } from '../misc'
 import { isActivityPubUrlValid, isBaseActivityValid, setValidAttributedTo } from './misc'
 import { isHostValid } from '../servers'
 import { peertubeTruncate } from '@server/helpers/core-utils'
@@ -91,7 +91,7 @@ function normalizeActor (actor: any) {
     actor.url = actor.url.href || actor.url.url
   }
 
-  if (!isDateValid(actor.published)) actor.published = undefined
+  if (!checkDate(actor.published)) actor.published = undefined
 
   if (actor.summary && typeof actor.summary === 'string') {
     actor.summary = peertubeTruncate(actor.summary, { length: CONSTRAINTS_FIELDS.USERS.DESCRIPTION.max })

--- a/server/helpers/custom-validators/activitypub/actor.ts
+++ b/server/helpers/custom-validators/activitypub/actor.ts
@@ -1,8 +1,8 @@
 import validator from 'validator'
 import { CONSTRAINTS_FIELDS } from '../../../initializers/constants'
-import { exists, isArray, checkDate } from '../misc'
+import { exists, isArray, checkDate, catchErrorAsBoolean } from '../misc'
 import { isActivityPubUrlValid, isBaseActivityValid, setValidAttributedTo } from './misc'
-import { isHostValid } from '../servers'
+import { checkHost } from '../servers'
 import { peertubeTruncate } from '@server/helpers/core-utils'
 
 function isActorEndpointsObjectValid (endpointObject: any) {
@@ -108,7 +108,7 @@ function isValidActorHandle (handle: string) {
   const parts = handle.split('@')
   if (parts.length !== 2) return false
 
-  return isHostValid(parts[1])
+  return catchErrorAsBoolean(checkHost)(parts[1])
 }
 
 function areValidActorHandles (handles: string[]) {

--- a/server/helpers/custom-validators/activitypub/cache-file.ts
+++ b/server/helpers/custom-validators/activitypub/cache-file.ts
@@ -1,12 +1,12 @@
 import { isActivityPubUrlValid } from './misc'
 import { isRemoteVideoUrlValid } from './videos'
-import { EtoB, exists, isDateValid } from '../misc'
+import { catchErrorAsBoolean, exists, checkDate } from '../misc'
 import { CacheFileObject } from '../../../../shared/models/activitypub/objects'
 
 function isCacheFileObjectValid (object: CacheFileObject) {
   return exists(object) &&
     object.type === 'CacheFile' &&
-    (object.expires === null || EtoB(isDateValid)(object.expires)) &&
+    (object.expires === null || catchErrorAsBoolean(checkDate)(object.expires)) &&
     isActivityPubUrlValid(object.object) &&
     (isRemoteVideoUrlValid(object.url) || isPlaylistRedundancyUrlValid(object.url))
 }

--- a/server/helpers/custom-validators/activitypub/cache-file.ts
+++ b/server/helpers/custom-validators/activitypub/cache-file.ts
@@ -1,12 +1,12 @@
 import { isActivityPubUrlValid } from './misc'
 import { isRemoteVideoUrlValid } from './videos'
-import { catchError, exists, isDateValid } from '../misc'
+import { EtoB, exists, isDateValid } from '../misc'
 import { CacheFileObject } from '../../../../shared/models/activitypub/objects'
 
 function isCacheFileObjectValid (object: CacheFileObject) {
   return exists(object) &&
     object.type === 'CacheFile' &&
-    (object.expires === null || catchError(isDateValid)(object.expires)) &&
+    (object.expires === null || EtoB(isDateValid)(object.expires)) &&
     isActivityPubUrlValid(object.object) &&
     (isRemoteVideoUrlValid(object.url) || isPlaylistRedundancyUrlValid(object.url))
 }

--- a/server/helpers/custom-validators/activitypub/cache-file.ts
+++ b/server/helpers/custom-validators/activitypub/cache-file.ts
@@ -1,12 +1,12 @@
 import { isActivityPubUrlValid } from './misc'
 import { isRemoteVideoUrlValid } from './videos'
-import { exists, isDateValid } from '../misc'
+import { catchError, exists, isDateValid } from '../misc'
 import { CacheFileObject } from '../../../../shared/models/activitypub/objects'
 
 function isCacheFileObjectValid (object: CacheFileObject) {
   return exists(object) &&
     object.type === 'CacheFile' &&
-    (object.expires === null || isDateValid(object.expires)) &&
+    (object.expires === null || catchError(isDateValid)(object.expires)) &&
     isActivityPubUrlValid(object.object) &&
     (isRemoteVideoUrlValid(object.url) || isPlaylistRedundancyUrlValid(object.url))
 }

--- a/server/helpers/custom-validators/activitypub/playlist.ts
+++ b/server/helpers/custom-validators/activitypub/playlist.ts
@@ -1,4 +1,4 @@
-import { exists, checkDate } from '../misc'
+import { exists, checkDate, catchErrorAsBoolean } from '../misc'
 import { PlaylistObject } from '../../../../shared/models/activitypub/objects/playlist-object'
 import validator from 'validator'
 import { PlaylistElementObject } from '../../../../shared/models/activitypub/objects/playlist-element-object'
@@ -8,8 +8,8 @@ function isPlaylistObjectValid (object: PlaylistObject) {
   return exists(object) &&
     object.type === 'Playlist' &&
     validator.isInt(object.totalItems + '') &&
-    checkDate(object.published) &&
-    checkDate(object.updated)
+    catchErrorAsBoolean(checkDate)(object.published) &&
+    catchErrorAsBoolean(checkDate)(object.updated)
 }
 
 function isPlaylistElementObjectValid (object: PlaylistElementObject) {

--- a/server/helpers/custom-validators/activitypub/playlist.ts
+++ b/server/helpers/custom-validators/activitypub/playlist.ts
@@ -1,4 +1,4 @@
-import { exists, isDateValid } from '../misc'
+import { exists, checkDate } from '../misc'
 import { PlaylistObject } from '../../../../shared/models/activitypub/objects/playlist-object'
 import validator from 'validator'
 import { PlaylistElementObject } from '../../../../shared/models/activitypub/objects/playlist-element-object'
@@ -8,8 +8,8 @@ function isPlaylistObjectValid (object: PlaylistObject) {
   return exists(object) &&
     object.type === 'Playlist' &&
     validator.isInt(object.totalItems + '') &&
-    isDateValid(object.published) &&
-    isDateValid(object.updated)
+    checkDate(object.published) &&
+    checkDate(object.updated)
 }
 
 function isPlaylistElementObjectValid (object: PlaylistElementObject) {

--- a/server/helpers/custom-validators/activitypub/signature.ts
+++ b/server/helpers/custom-validators/activitypub/signature.ts
@@ -1,22 +1,27 @@
 import { exists } from '../misc'
 import { isActivityPubUrlValid } from './misc'
 
-function isSignatureTypeValid (signatureType: string) {
-  return exists(signatureType) && signatureType === 'RsaSignature2017'
+function checkSignatureType (signatureType: string) {
+  if (signatureType !== 'RsaSignature2017') throw new Error('Should have a RsaSignature2017 signature')
+  return true
 }
 
-function isSignatureCreatorValid (signatureCreator: string) {
-  return exists(signatureCreator) && isActivityPubUrlValid(signatureCreator)
+function checkSignatureCreator (signatureCreator: string) {
+  if (!exists(signatureCreator)) throw new Error('Should have a signature creator value')
+  if (!isActivityPubUrlValid(signatureCreator)) throw new Error('Should have a signature creator that is a valid ActivityPub URL')
+  return true
 }
 
-function isSignatureValueValid (signatureValue: string) {
-  return exists(signatureValue) && signatureValue.length > 0
+function checkSignatureValue (signatureValue: string) {
+  if (!exists(signatureValue)) throw new Error('Should have a signature value')
+  if (signatureValue.length === 0) throw new Error('Should have a signature of sufficient length')
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isSignatureTypeValid,
-  isSignatureCreatorValid,
-  isSignatureValueValid
+  checkSignatureType,
+  checkSignatureCreator,
+  checkSignatureValue
 }

--- a/server/helpers/custom-validators/activitypub/video-comments.ts
+++ b/server/helpers/custom-validators/activitypub/video-comments.ts
@@ -1,6 +1,6 @@
 import validator from 'validator'
 import { ACTIVITY_PUB } from '../../../initializers/constants'
-import { exists, isArray, checkDate } from '../misc'
+import { exists, isArray, checkDate, catchErrorAsBoolean } from '../misc'
 import { isActivityPubUrlValid } from './misc'
 
 function sanitizeAndCheckVideoCommentObject (comment: any) {
@@ -12,15 +12,15 @@ function sanitizeAndCheckVideoCommentObject (comment: any) {
 
   if (comment.type === 'Tombstone') {
     return isActivityPubUrlValid(comment.id) &&
-      checkDate(comment.published) &&
-      checkDate(comment.deleted) &&
+      catchErrorAsBoolean(checkDate)(comment.published) &&
+      catchErrorAsBoolean(checkDate)(comment.deleted) &&
       isActivityPubUrlValid(comment.url)
   }
 
   return isActivityPubUrlValid(comment.id) &&
     isCommentContentValid(comment.content) &&
     isActivityPubUrlValid(comment.inReplyTo) &&
-    checkDate(comment.published) &&
+    catchErrorAsBoolean(checkDate)(comment.published) &&
     isActivityPubUrlValid(comment.url) &&
     isArray(comment.to) &&
     (

--- a/server/helpers/custom-validators/activitypub/video-comments.ts
+++ b/server/helpers/custom-validators/activitypub/video-comments.ts
@@ -1,6 +1,6 @@
 import validator from 'validator'
 import { ACTIVITY_PUB } from '../../../initializers/constants'
-import { exists, isArray, isDateValid } from '../misc'
+import { exists, isArray, checkDate } from '../misc'
 import { isActivityPubUrlValid } from './misc'
 
 function sanitizeAndCheckVideoCommentObject (comment: any) {
@@ -12,15 +12,15 @@ function sanitizeAndCheckVideoCommentObject (comment: any) {
 
   if (comment.type === 'Tombstone') {
     return isActivityPubUrlValid(comment.id) &&
-      isDateValid(comment.published) &&
-      isDateValid(comment.deleted) &&
+      checkDate(comment.published) &&
+      checkDate(comment.deleted) &&
       isActivityPubUrlValid(comment.url)
   }
 
   return isActivityPubUrlValid(comment.id) &&
     isCommentContentValid(comment.content) &&
     isActivityPubUrlValid(comment.inReplyTo) &&
-    isDateValid(comment.published) &&
+    checkDate(comment.published) &&
     isActivityPubUrlValid(comment.url) &&
     isArray(comment.to) &&
     (

--- a/server/helpers/custom-validators/activitypub/videos.ts
+++ b/server/helpers/custom-validators/activitypub/videos.ts
@@ -4,7 +4,7 @@ import { ActivityTrackerUrlObject, ActivityVideoFileMetadataUrlObject } from '@s
 import { VideoState } from '../../../../shared/models/videos'
 import { ACTIVITY_PUB, CONSTRAINTS_FIELDS } from '../../../initializers/constants'
 import { peertubeTruncate } from '../../core-utils'
-import { catchError, exists, isArray, isBooleanValid, isDateValid, isUUIDValid } from '../misc'
+import { EtoB, exists, isArray, isBooleanValid, isDateValid, isUUIDValid } from '../misc'
 import {
   isVideoDurationValid,
   isVideoNameValid,
@@ -67,17 +67,17 @@ function sanitizeAndCheckVideoTorrentObject (video: any) {
   if (!isBooleanValid(video.permanentLive)) video.permanentLive = false
 
   return isActivityPubUrlValid(video.id) &&
-    catchError(isVideoNameValid)(video.name) &&
+    EtoB(isVideoNameValid)(video.name) &&
     isActivityPubVideoDurationValid(video.duration) &&
-    catchError(isUUIDValid)(video.uuid) &&
+    EtoB(isUUIDValid)(video.uuid) &&
     (!video.category || isRemoteNumberIdentifierValid(video.category)) &&
     (!video.licence || isRemoteNumberIdentifierValid(video.licence)) &&
     (!video.language || isRemoteStringIdentifierValid(video.language)) &&
     isVideoViewsValid(video.views) &&
     isBooleanValid(video.sensitive) &&
-    catchError(isDateValid)(video.published) &&
-    catchError(isDateValid)(video.updated) &&
-    (!video.originallyPublishedAt || catchError(isDateValid)(video.originallyPublishedAt)) &&
+    EtoB(isDateValid)(video.published) &&
+    EtoB(isDateValid)(video.updated) &&
+    (!video.originallyPublishedAt || EtoB(isDateValid)(video.originallyPublishedAt)) &&
     (!video.content || isRemoteVideoContentValid(video.mediaType, video.content)) &&
     video.attributedTo.length !== 0
 }
@@ -145,7 +145,7 @@ function setValidRemoteTags (video: any) {
 
   video.tag = video.tag.filter(t => {
     return t.type === 'Hashtag' &&
-      catchError(isVideoTagValid)(t.name)
+      EtoB(isVideoTagValid)(t.name)
   })
 
   return true

--- a/server/helpers/custom-validators/activitypub/videos.ts
+++ b/server/helpers/custom-validators/activitypub/videos.ts
@@ -8,10 +8,10 @@ import { catchErrorAsBoolean, exists, isArray, isBooleanValid, checkDate, checkU
 import {
   checkVideoDuration,
   checkVideoName,
-  isVideoStateValid,
+  checkVideoState,
   checkVideoTag,
   checkVideoTruncatedDescription,
-  isVideoViewsValid
+  checkVideoViews
 } from '../videos'
 import { isActivityPubUrlValid, isBaseActivityValid, setValidAttributedTo } from './misc'
 
@@ -26,7 +26,7 @@ function isActivityPubVideoDurationValid (value: string) {
     typeof value === 'string' &&
     value.startsWith('PT') &&
     value.endsWith('S') &&
-    checkVideoDuration(value.replace(/[^0-9]+/g, ''))
+    catchErrorAsBoolean(checkVideoDuration)(value.replace(/[^0-9]+/g, ''))
 }
 
 function sanitizeAndCheckVideoTorrentObject (video: any) {
@@ -58,7 +58,7 @@ function sanitizeAndCheckVideoTorrentObject (video: any) {
   }
 
   // Default attributes
-  if (!isVideoStateValid(video.state)) video.state = VideoState.PUBLISHED
+  if (!catchErrorAsBoolean(checkVideoState)(video.state)) video.state = VideoState.PUBLISHED
   if (!isBooleanValid(video.waitTranscoding)) video.waitTranscoding = false
   if (!isBooleanValid(video.downloadEnabled)) video.downloadEnabled = true
   if (!isBooleanValid(video.commentsEnabled)) video.commentsEnabled = false
@@ -73,7 +73,7 @@ function sanitizeAndCheckVideoTorrentObject (video: any) {
     (!video.category || isRemoteNumberIdentifierValid(video.category)) &&
     (!video.licence || isRemoteNumberIdentifierValid(video.licence)) &&
     (!video.language || isRemoteStringIdentifierValid(video.language)) &&
-    catchErrorAsBoolean(isVideoViewsValid)(video.views) &&
+    catchErrorAsBoolean(checkVideoViews)(video.views) &&
     isBooleanValid(video.sensitive) &&
     catchErrorAsBoolean(checkDate)(video.published) &&
     catchErrorAsBoolean(checkDate)(video.updated) &&
@@ -174,7 +174,7 @@ function isRemoteStringIdentifierValid (data: any) {
 }
 
 function isRemoteVideoContentValid (mediaType: string, content: string) {
-  return mediaType === 'text/markdown' && checkVideoTruncatedDescription(content)
+  return mediaType === 'text/markdown' && catchErrorAsBoolean(checkVideoTruncatedDescription)(content)
 }
 
 function setValidRemoteIcon (video: any) {

--- a/server/helpers/custom-validators/activitypub/videos.ts
+++ b/server/helpers/custom-validators/activitypub/videos.ts
@@ -73,12 +73,12 @@ function sanitizeAndCheckVideoTorrentObject (video: any) {
     (!video.category || isRemoteNumberIdentifierValid(video.category)) &&
     (!video.licence || isRemoteNumberIdentifierValid(video.licence)) &&
     (!video.language || isRemoteStringIdentifierValid(video.language)) &&
-    isVideoViewsValid(video.views) &&
+    catchErrorAsBoolean(isVideoViewsValid)(video.views) &&
     isBooleanValid(video.sensitive) &&
     catchErrorAsBoolean(checkDate)(video.published) &&
     catchErrorAsBoolean(checkDate)(video.updated) &&
     (!video.originallyPublishedAt || catchErrorAsBoolean(checkDate)(video.originallyPublishedAt)) &&
-    (!video.content || isRemoteVideoContentValid(video.mediaType, video.content)) &&
+    (!video.content || catchErrorAsBoolean(isRemoteVideoContentValid)(video.mediaType, video.content)) &&
     video.attributedTo.length !== 0
 }
 

--- a/server/helpers/custom-validators/activitypub/videos.ts
+++ b/server/helpers/custom-validators/activitypub/videos.ts
@@ -4,7 +4,7 @@ import { ActivityTrackerUrlObject, ActivityVideoFileMetadataUrlObject } from '@s
 import { VideoState } from '../../../../shared/models/videos'
 import { ACTIVITY_PUB, CONSTRAINTS_FIELDS } from '../../../initializers/constants'
 import { peertubeTruncate } from '../../core-utils'
-import { exists, isArray, isBooleanValid, isDateValid, isUUIDValid } from '../misc'
+import { catchError, exists, isArray, isBooleanValid, isDateValid, isUUIDValid } from '../misc'
 import {
   isVideoDurationValid,
   isVideoNameValid,
@@ -67,17 +67,17 @@ function sanitizeAndCheckVideoTorrentObject (video: any) {
   if (!isBooleanValid(video.permanentLive)) video.permanentLive = false
 
   return isActivityPubUrlValid(video.id) &&
-    isVideoNameValid(video.name) &&
+    catchError(isVideoNameValid)(video.name) &&
     isActivityPubVideoDurationValid(video.duration) &&
-    isUUIDValid(video.uuid) &&
+    catchError(isUUIDValid)(video.uuid) &&
     (!video.category || isRemoteNumberIdentifierValid(video.category)) &&
     (!video.licence || isRemoteNumberIdentifierValid(video.licence)) &&
     (!video.language || isRemoteStringIdentifierValid(video.language)) &&
     isVideoViewsValid(video.views) &&
     isBooleanValid(video.sensitive) &&
-    isDateValid(video.published) &&
-    isDateValid(video.updated) &&
-    (!video.originallyPublishedAt || isDateValid(video.originallyPublishedAt)) &&
+    catchError(isDateValid)(video.published) &&
+    catchError(isDateValid)(video.updated) &&
+    (!video.originallyPublishedAt || catchError(isDateValid)(video.originallyPublishedAt)) &&
     (!video.content || isRemoteVideoContentValid(video.mediaType, video.content)) &&
     video.attributedTo.length !== 0
 }
@@ -145,7 +145,7 @@ function setValidRemoteTags (video: any) {
 
   video.tag = video.tag.filter(t => {
     return t.type === 'Hashtag' &&
-      isVideoTagValid(t.name)
+      catchError(isVideoTagValid)(t.name)
   })
 
   return true

--- a/server/helpers/custom-validators/actor-images.ts
+++ b/server/helpers/custom-validators/actor-images.ts
@@ -1,17 +1,14 @@
 
 import { CONSTRAINTS_FIELDS } from '../../initializers/constants'
-import { isFileValid } from './misc'
+import { checkFileValid } from './misc'
 
 const imageMimeTypes = CONSTRAINTS_FIELDS.ACTORS.IMAGE.EXTNAME
   .map(v => v.replace('.', ''))
   .join('|')
 const imageMimeTypesRegex = `image/(${imageMimeTypes})`
 
-/**
- * @throws {Error}
- */
 function checkActorImageFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], fieldname: string) {
-  return isFileValid(files, imageMimeTypesRegex, fieldname, CONSTRAINTS_FIELDS.ACTORS.IMAGE.FILE_SIZE.max)
+  return checkFileValid(files, imageMimeTypesRegex, fieldname, CONSTRAINTS_FIELDS.ACTORS.IMAGE.FILE_SIZE.max)
 }
 
 // ---------------------------------------------------------------------------

--- a/server/helpers/custom-validators/actor-images.ts
+++ b/server/helpers/custom-validators/actor-images.ts
@@ -6,6 +6,10 @@ const imageMimeTypes = CONSTRAINTS_FIELDS.ACTORS.IMAGE.EXTNAME
   .map(v => v.replace('.', ''))
   .join('|')
 const imageMimeTypesRegex = `image/(${imageMimeTypes})`
+
+/**
+ * @throws {Error}
+ */
 function isActorImageFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], fieldname: string) {
   return isFileValid(files, imageMimeTypesRegex, fieldname, CONSTRAINTS_FIELDS.ACTORS.IMAGE.FILE_SIZE.max)
 }

--- a/server/helpers/custom-validators/actor-images.ts
+++ b/server/helpers/custom-validators/actor-images.ts
@@ -10,12 +10,12 @@ const imageMimeTypesRegex = `image/(${imageMimeTypes})`
 /**
  * @throws {Error}
  */
-function isActorImageFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], fieldname: string) {
+function checkActorImageFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], fieldname: string) {
   return isFileValid(files, imageMimeTypesRegex, fieldname, CONSTRAINTS_FIELDS.ACTORS.IMAGE.FILE_SIZE.max)
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isActorImageFile
+  checkActorImageFile
 }

--- a/server/helpers/custom-validators/bulk.ts
+++ b/server/helpers/custom-validators/bulk.ts
@@ -1,6 +1,3 @@
-/**
- * @throws {Error}
- */
 function checkBulkRemoveCommentsOfScope (value: string) {
   const possibleValues = [ 'my-videos', 'instance' ]
   if (!possibleValues.includes(value)) throw new Error('Should have a bulk removal scope among ' + possibleValues.join(', '))

--- a/server/helpers/custom-validators/bulk.ts
+++ b/server/helpers/custom-validators/bulk.ts
@@ -1,9 +1,14 @@
-function isBulkRemoveCommentsOfScopeValid (value: string) {
-  return value === 'my-videos' || value === 'instance'
+/**
+ * @throws {Error}
+ */
+function checkBulkRemoveCommentsOfScope (value: string) {
+  const possibleValues = [ 'my-videos', 'instance' ]
+  if (!possibleValues.includes(value)) throw new Error('Should have a bulk removal scope among ' + possibleValues.join(', '))
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isBulkRemoveCommentsOfScopeValid
+  checkBulkRemoveCommentsOfScope
 }

--- a/server/helpers/custom-validators/feeds.ts
+++ b/server/helpers/custom-validators/feeds.ts
@@ -1,8 +1,5 @@
 import { exists } from './misc'
 
-/**
- * @throws {Error}
- */
 function checkRSSFeedFormat (value: string) {
   if (!exists(value)) throw new Error('Should have a format')
 

--- a/server/helpers/custom-validators/feeds.ts
+++ b/server/helpers/custom-validators/feeds.ts
@@ -1,7 +1,10 @@
 import { exists } from './misc'
 
-function isValidRSSFeed (value: string) {
-  if (!exists(value)) return false
+/**
+ * @throws {Error}
+ */
+function checkRSSFeedFormat (value: string) {
+  if (!exists(value)) throw new Error('Should have a format')
 
   const feedExtensions = [
     'xml',
@@ -13,11 +16,12 @@ function isValidRSSFeed (value: string) {
     'atom1'
   ]
 
-  return feedExtensions.includes(value)
+  if (!feedExtensions.includes(value)) throw new Error('Should have a feed format among ' + feedExtensions.join(', '))
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isValidRSSFeed
+  checkRSSFeedFormat
 }

--- a/server/helpers/custom-validators/follows.ts
+++ b/server/helpers/custom-validators/follows.ts
@@ -1,14 +1,18 @@
 import { exists } from './misc'
 import { FollowState } from '@shared/models'
 
-function isFollowStateValid (value: FollowState) {
-  if (!exists(value)) return false
-
-  return value === 'pending' || value === 'accepted'
+/**
+ * @throws {Error}
+ */
+function checkFollowState (value: FollowState) {
+  if (!exists(value)) throw new Error('Should have a follow state')
+  const possibleValues = [ 'pending', 'accepted' ]
+  if (!possibleValues.includes(value)) throw new Error('Should have a follow state among ' + possibleValues.join(', '))
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isFollowStateValid
+  checkFollowState
 }

--- a/server/helpers/custom-validators/follows.ts
+++ b/server/helpers/custom-validators/follows.ts
@@ -1,9 +1,6 @@
 import { exists } from './misc'
 import { FollowState } from '@shared/models'
 
-/**
- * @throws {Error}
- */
 function checkFollowState (value: FollowState) {
   if (!exists(value)) throw new Error('Should have a follow state')
   const possibleValues = [ 'pending', 'accepted' ]

--- a/server/helpers/custom-validators/jobs.ts
+++ b/server/helpers/custom-validators/jobs.ts
@@ -4,18 +4,12 @@ import { jobTypes } from '@server/lib/job-queue/job-queue'
 
 const jobStates: JobState[] = [ 'active', 'completed', 'failed', 'waiting', 'delayed', 'paused' ]
 
-/**
- * @throws {Error}
- */
 function checkJobState (value: JobState) {
   if (!exists(value)) throw new Error('Should have a job state')
   if (!jobStates.includes(value)) throw new Error('Should have a job state among ' + jobStates.join(', '))
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkJobType (value: any) {
   if (!exists(value)) throw new Error('Should have a job type')
   if (!jobTypes.includes(value)) throw new Error('Should have a job type among ' + jobTypes.join(', '))

--- a/server/helpers/custom-validators/jobs.ts
+++ b/server/helpers/custom-validators/jobs.ts
@@ -4,18 +4,28 @@ import { jobTypes } from '@server/lib/job-queue/job-queue'
 
 const jobStates: JobState[] = [ 'active', 'completed', 'failed', 'waiting', 'delayed', 'paused' ]
 
-function isValidJobState (value: JobState) {
-  return exists(value) && jobStates.includes(value)
+/**
+ * @throws {Error}
+ */
+function checkJobState (value: JobState) {
+  if (!exists(value)) throw new Error('Should have a job state')
+  if (!jobStates.includes(value)) throw new Error('Should have a job state among ' + jobStates.join(', '))
+  return true
 }
 
-function isValidJobType (value: any) {
-  return exists(value) && jobTypes.includes(value)
+/**
+ * @throws {Error}
+ */
+function checkJobType (value: any) {
+  if (!exists(value)) throw new Error('Should have a job type')
+  if (!jobTypes.includes(value)) throw new Error('Should have a job type among ' + jobTypes.join(', '))
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
   jobStates,
-  isValidJobState,
-  isValidJobType
+  checkJobState,
+  checkJobType
 }

--- a/server/helpers/custom-validators/logs.ts
+++ b/server/helpers/custom-validators/logs.ts
@@ -3,12 +3,16 @@ import { LogLevel } from '../../../shared/models/server/log-level.type'
 
 const logLevels: LogLevel[] = [ 'debug', 'info', 'warn', 'error' ]
 
-function isValidLogLevel (value: any) {
-  return exists(value) && logLevels.includes(value)
+/**
+ * @throws {Error}
+ */
+function checkLogLevel (value: any) {
+  if (!exists(value)) throw new Error('Should have a log level')
+  if (!logLevels.includes(value)) throw new Error('Should have a log level among ' + logLevels.join(', '))
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isValidLogLevel
+  checkLogLevel
 }

--- a/server/helpers/custom-validators/logs.ts
+++ b/server/helpers/custom-validators/logs.ts
@@ -3,12 +3,10 @@ import { LogLevel } from '../../../shared/models/server/log-level.type'
 
 const logLevels: LogLevel[] = [ 'debug', 'info', 'warn', 'error' ]
 
-/**
- * @throws {Error}
- */
 function checkLogLevel (value: any) {
   if (!exists(value)) throw new Error('Should have a log level')
   if (!logLevels.includes(value)) throw new Error('Should have a log level among ' + logLevels.join(', '))
+  return true
 }
 
 // ---------------------------------------------------------------------------

--- a/server/helpers/custom-validators/misc.ts
+++ b/server/helpers/custom-validators/misc.ts
@@ -55,9 +55,6 @@ function isArrayOf (value: any, validator: (value: any) => boolean) {
 // ---------------------------------------------------------------------------
 // VALIDATORS - Throwables
 
-/**
- * @throws {Error}
- */
 function checkSafePath (value: string) {
   if (!exists(value)) throw new Error('Should have a path')
   if (
@@ -68,36 +65,24 @@ function checkSafePath (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkDate (value: string) {
   if (!exists(value)) throw new Error('Should have a date')
   if (!validator.isISO8601(value)) throw new Error('Should have a date conforming to ISO8601')
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkId (value: string) {
   if (!exists(value)) throw new Error('Should have an id')
   if (!validator.isInt('' + value)) throw new Error('Should have an integer id')
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkUUID (value: string) {
   if (!exists(value)) throw new Error('Should have a uuid')
   if (!validator.isUUID('' + value, 4)) throw new Error('Should have a v4 uuid')
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkIdOrUUID (value: string) {
   const errors = [
     catchErrorAsBoolean(checkId, true)(value)?.message,
@@ -115,10 +100,7 @@ function isIntOrNull (value: any) {
   return value === null || validator.isInt('' + value)
 }
 
-/**
- * @throws {Error}
- */
-function isFileFieldValid (
+function checkFileField (
   files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[],
   field: string,
   optional = false
@@ -144,10 +126,7 @@ function isFileFieldValid (
   throw new Error(res[1])
 }
 
-/**
- * @throws {Error}
- */
-function isFileMimeTypeValid (
+function checkFileMimeType (
   files: UploadFilesForCheck,
   mimeTypeRegex: string,
   field: string,
@@ -179,10 +158,7 @@ function isFileMimeTypeValid (
   throw new Error(res[1])
 }
 
-/**
- * @throws {Error}
- */
-function isFileValid (
+function checkFileValid (
   files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[],
   mimeTypeRegex: string,
   field: string,
@@ -279,7 +255,7 @@ export {
   toIntOrNull,
   toArray,
   toIntArray,
-  isFileFieldValid,
-  isFileMimeTypeValid,
-  isFileValid
+  checkFileField,
+  checkFileMimeType,
+  checkFileValid
 }

--- a/server/helpers/custom-validators/misc.ts
+++ b/server/helpers/custom-validators/misc.ts
@@ -44,16 +44,20 @@ function isArray (value: any): value is any[] {
   return Array.isArray(value)
 }
 
-function isNotEmptyIntArray (value: any) {
-  return Array.isArray(value) && value.every(v => validator.isInt('' + v)) && value.length !== 0
-}
-
-function isArrayOf (value: any, validator: (value: any) => boolean) {
-  return isArray(value) && value.every(v => validator(v))
-}
-
 // ---------------------------------------------------------------------------
 // VALIDATORS - Throwables
+
+function checkArrayWith (value: any, validator: (value: any) => boolean) {
+  if (!isArray(value)) throw new Error('Should be an array')
+  return value.every(v => validator(v))
+}
+
+function checkNotEmptyIntArray (value: any) {
+  if (!Array.isArray(value)) throw new Error('Should be an array')
+  if (value.length === 0) throw new Error('Should be a non-empty array')
+  if (!value.every(v => validator.isInt('' + v))) throw new Error('Should have every value of the array be an integer')
+  return true
+}
 
 function checkSafePath (value: string) {
   if (!exists(value)) throw new Error('Should have a path')
@@ -239,8 +243,8 @@ function toIntArray (value: any) {
 export {
   catchErrorAsBoolean,
   exists,
-  isArrayOf,
-  isNotEmptyIntArray,
+  checkArrayWith,
+  checkNotEmptyIntArray,
   isArray,
   isIntOrNull,
   isSafePath,

--- a/server/helpers/custom-validators/search.ts
+++ b/server/helpers/custom-validators/search.ts
@@ -11,20 +11,31 @@ function isStringArray (value: any) {
   return isArray(value) && value.every(v => typeof v === 'string')
 }
 
-function isBooleanBothQueryValid (value: any) {
-  return value === 'true' || value === 'false' || value === 'both'
+function checkBooleanBothQuery (value: any) {
+  const acceptableValues = [ 'true', 'false', 'both' ]
+  if (!acceptableValues.includes(value)) throw new Error('Should have the NSFW policy that is one of ' + acceptableValues.join(', '))
+  return true
 }
 
-function isSearchTargetValid (value: SearchTargetType) {
+function checkSearchTarget (value: SearchTargetType) {
   if (!exists(value)) return true
 
   const searchIndexConfig = CONFIG.SEARCH.SEARCH_INDEX
 
-  if (value === 'local' && (!searchIndexConfig.ENABLED || !searchIndexConfig.DISABLE_LOCAL_SEARCH)) return true
+  switch (value) {
+    case 'local':
+      if (searchIndexConfig.ENABLED && searchIndexConfig.DISABLE_LOCAL_SEARCH) {
+        throw new Error('Should target search-index since local search is disabled')
+      }
+      break
+    case 'search-index':
+      if (!searchIndexConfig.ENABLED) throw new Error('Should target local since search-index is disabled')
+      break
+    default:
+      throw new Error('Should have a known search target: local or search-index')
+  }
 
-  if (value === 'search-index' && searchIndexConfig.ENABLED) return true
-
-  return false
+  return true
 }
 
 // ---------------------------------------------------------------------------
@@ -32,6 +43,6 @@ function isSearchTargetValid (value: SearchTargetType) {
 export {
   isNumberArray,
   isStringArray,
-  isBooleanBothQueryValid,
-  isSearchTargetValid
+  checkBooleanBothQuery,
+  checkSearchTarget
 }

--- a/server/helpers/custom-validators/servers.ts
+++ b/server/helpers/custom-validators/servers.ts
@@ -3,9 +3,6 @@ import { catchErrorAsBoolean, exists, isArray } from './misc'
 import { isTestInstance } from '../core-utils'
 import { CONSTRAINTS_FIELDS } from '../../initializers/constants'
 
-/**
- * @throws {Error}
- */
 function checkHost (host: string) {
   const isURLOptions = {
     require_host: true,
@@ -33,9 +30,6 @@ function isEachUniqueHostValid (hosts: string[]) {
     })
 }
 
-/**
- * @throws {Error}
- */
 function checkContactBody (value: any) {
   if (!exists(value)) throw new Error('Should have a contact text')
   if (!validator.isLength(value, CONSTRAINTS_FIELDS.CONTACT_FORM.BODY)) {
@@ -46,9 +40,6 @@ function checkContactBody (value: any) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkContactFromName (value: any) {
   if (!exists(value)) throw new Error('Should have a contact From name')
   if (!validator.isLength(value, CONSTRAINTS_FIELDS.CONTACT_FORM.FROM_NAME)) {

--- a/server/helpers/custom-validators/users.ts
+++ b/server/helpers/custom-validators/users.ts
@@ -7,25 +7,6 @@ import { exists, isArray, isBooleanValid } from './misc'
 
 const USERS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.USERS
 
-function isUserPasswordValid (value: string) {
-  return validator.isLength(value, USERS_CONSTRAINTS_FIELDS.PASSWORD)
-}
-
-function isUserPasswordValidOrEmpty (value: string) {
-  // Empty password is only possible if emailing is enabled.
-  if (value === '') return isEmailEnabled()
-
-  return isUserPasswordValid(value)
-}
-
-function isUserVideoQuotaValid (value: string) {
-  return exists(value) && validator.isInt(value + '', USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA)
-}
-
-function isUserVideoQuotaDailyValid (value: string) {
-  return exists(value) && validator.isInt(value + '', USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA_DAILY)
-}
-
 function checkUserUsername (value: string) {
   if (!exists(value)) throw new Error('Should have a name')
   const max = USERS_CONSTRAINTS_FIELDS.USERNAME.max
@@ -58,6 +39,74 @@ function checkUserDescription (value: string) {
   return true
 }
 
+function checkUserVideoLanguages (value: any) {
+  if (value === null) return true
+  if (!isArray(value)) throw new Error('Should have an array of user video languages')
+  const maxLength = CONSTRAINTS_FIELDS.USERS.VIDEO_LANGUAGES.max
+  if (value.length >= maxLength) throw new Error(`Should have a array of user video languages not exceeding ${maxLength} languages`)
+  return true
+}
+
+function checkUserBlockedReason (value: any) {
+  if (value === null) return true
+  if (!exists(value)) throw new Error('Should have a reason to block the user')
+  const max = CONSTRAINTS_FIELDS.USERS.BLOCKED_REASON.max
+  const min = CONSTRAINTS_FIELDS.USERS.BLOCKED_REASON.min
+  if (!validator.isLength(value, CONSTRAINTS_FIELDS.USERS.BLOCKED_REASON)) {
+    throw new Error(`Should have a reason to block the user that is between ${min} and ${max} alphanumeric characters long`)
+  }
+  return true
+}
+
+function checkUserRole (value: any) {
+  if (!exists(value)) throw new Error('Should have a user role')
+  if (!validator.isInt('' + value)) throw new Error('Should have a user role that is an integer')
+  if (UserRole[value] === undefined) throw new Error('Should have a user role that is a known user role')
+  return true
+}
+
+function checkUserAdminFlags (value: any) {
+  if (!exists(value)) throw new Error('Should have an admin flag value')
+  if (!validator.isInt('' + value)) throw new Error('Should have an admin flag that is an integer')
+  return true
+}
+
+function checkUserPassword (value: string) {
+  const max = USERS_CONSTRAINTS_FIELDS.PASSWORD.max
+  const min = USERS_CONSTRAINTS_FIELDS.PASSWORD.min
+  if (!validator.isLength(value, USERS_CONSTRAINTS_FIELDS.PASSWORD)) {
+    throw new Error(`Should have a password that is between ${min} and ${max} alphanumeric characters long`)
+  }
+  return true
+}
+
+function checkUserPasswordValidOrEmpty (value: string) {
+  // Empty password is only possible if emailing is enabled.
+  if (value === '' && !isEmailEnabled()) throw new Error('Should have a password since emailing is not enabled')
+  if (value === '') return true
+
+  checkUserPassword(value)
+  return true
+}
+
+function checkUserVideoQuota (value: string) {
+  if (!exists(value)) throw new Error('Should have a user video quota value')
+  const min = USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA.min
+  if (!validator.isInt(value + '', USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA)) {
+    throw new Error(`Should have a user video quota that is at least ${min}`)
+  }
+  return true
+}
+
+function checkUserVideoQuotaDaily (value: string) {
+  if (!exists(value)) throw new Error('Should have a user daily video quota value')
+  const min = USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA_DAILY.min
+  if (!validator.isInt(value + '', USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA_DAILY)) {
+    throw new Error(`Should have a user daily video quota that is at least ${min}`)
+  }
+  return true
+}
+
 function isUserEmailVerifiedValid (value: any) {
   return isBooleanValid(value)
 }
@@ -77,14 +126,6 @@ function isUserVideosHistoryEnabledValid (value: any) {
 
 function isUserAutoPlayVideoValid (value: any) {
   return isBooleanValid(value)
-}
-
-function isUserVideoLanguages (value: any) {
-  return value === null || (isArray(value) && value.length < CONSTRAINTS_FIELDS.USERS.VIDEO_LANGUAGES.max)
-}
-
-function isUserAdminFlagsValid (value: any) {
-  return exists(value) && validator.isInt('' + value)
 }
 
 function isUserBlockedValid (value: any) {
@@ -107,28 +148,20 @@ function isNoWelcomeModal (value: any) {
   return isBooleanValid(value)
 }
 
-function isUserBlockedReasonValid (value: any) {
-  return value === null || (exists(value) && validator.isLength(value, CONSTRAINTS_FIELDS.USERS.BLOCKED_REASON))
-}
-
-function isUserRoleValid (value: any) {
-  return exists(value) && validator.isInt('' + value) && UserRole[value] !== undefined
-}
-
 // ---------------------------------------------------------------------------
 
 export {
   isUserVideosHistoryEnabledValid,
   isUserBlockedValid,
-  isUserPasswordValid,
-  isUserPasswordValidOrEmpty,
-  isUserVideoLanguages,
-  isUserBlockedReasonValid,
-  isUserRoleValid,
-  isUserVideoQuotaValid,
-  isUserVideoQuotaDailyValid,
+  checkUserPassword,
+  checkUserPasswordValidOrEmpty,
+  checkUserVideoLanguages,
+  checkUserBlockedReason,
+  checkUserRole,
+  checkUserVideoQuota,
+  checkUserVideoQuotaDaily,
   checkUserUsername,
-  isUserAdminFlagsValid,
+  checkUserAdminFlags,
   isUserEmailVerifiedValid,
   isUserNSFWPolicyValid,
   isUserWebTorrentEnabledValid,

--- a/server/helpers/custom-validators/users.ts
+++ b/server/helpers/custom-validators/users.ts
@@ -30,21 +30,41 @@ function isUserVideoQuotaDailyValid (value: string) {
  * @throws {Error}
  */
 function isUserUsernameValid (value: string) {
-  if (!exists(value)) throw new Error('Should have a username')
+  if (!exists(value)) throw new Error('Should have a name')
   const max = USERS_CONSTRAINTS_FIELDS.USERNAME.max
   const min = USERS_CONSTRAINTS_FIELDS.USERNAME.min
   if (!validator.matches(value, new RegExp(`^[a-z0-9._]{${min},${max}}$`))) {
-    throw new Error(`Should have a username between ${min} and ${max} alphanumeric characters long`)
+    throw new Error(`Should have a name between ${min} and ${max} alphanumeric characters long`)
   }
   return true
 }
 
-function isUserDisplayNameValid (value: string) {
-  return value === null || (exists(value) && validator.isLength(value, CONSTRAINTS_FIELDS.USERS.NAME))
+/**
+ * @throws {Error}
+ */
+function checkUserDisplayName (value: string) {
+  if (value === null) return true
+  if (!exists(value)) throw new Error('Should have a user display name')
+  if (!validator.isLength(value, CONSTRAINTS_FIELDS.USERS.NAME)) {
+    const min = CONSTRAINTS_FIELDS.USERS.DESCRIPTION.min
+    const max = CONSTRAINTS_FIELDS.USERS.DESCRIPTION.max
+    throw new Error(`Should have a user display name between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
-function isUserDescriptionValid (value: string) {
-  return value === null || (exists(value) && validator.isLength(value, CONSTRAINTS_FIELDS.USERS.DESCRIPTION))
+/**
+ * @throws {Error}
+ */
+function checkUserDescription (value: string) {
+  if (value === null) return true
+  if (!exists(value)) throw new Error('Should have a user description')
+  if (!validator.isLength(value, CONSTRAINTS_FIELDS.USERS.DESCRIPTION)) {
+    const min = CONSTRAINTS_FIELDS.USERS.DESCRIPTION.min
+    const max = CONSTRAINTS_FIELDS.USERS.DESCRIPTION.max
+    throw new Error(`Should have a user description between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
 function isUserEmailVerifiedValid (value: any) {
@@ -124,8 +144,8 @@ export {
   isUserAutoPlayVideoValid,
   isUserAutoPlayNextVideoValid,
   isUserAutoPlayNextVideoPlaylistValid,
-  isUserDisplayNameValid,
-  isUserDescriptionValid,
+  checkUserDisplayName,
+  checkUserDescription,
   isNoInstanceConfigWarningModal,
   isNoWelcomeModal
 }

--- a/server/helpers/custom-validators/users.ts
+++ b/server/helpers/custom-validators/users.ts
@@ -26,10 +26,7 @@ function isUserVideoQuotaDailyValid (value: string) {
   return exists(value) && validator.isInt(value + '', USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA_DAILY)
 }
 
-/**
- * @throws {Error}
- */
-function isUserUsernameValid (value: string) {
+function checkUserUsername (value: string) {
   if (!exists(value)) throw new Error('Should have a name')
   const max = USERS_CONSTRAINTS_FIELDS.USERNAME.max
   const min = USERS_CONSTRAINTS_FIELDS.USERNAME.min
@@ -39,9 +36,6 @@ function isUserUsernameValid (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkUserDisplayName (value: string) {
   if (value === null) return true
   if (!exists(value)) throw new Error('Should have a user display name')
@@ -53,9 +47,6 @@ function checkUserDisplayName (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkUserDescription (value: string) {
   if (value === null) return true
   if (!exists(value)) throw new Error('Should have a user description')
@@ -136,7 +127,7 @@ export {
   isUserRoleValid,
   isUserVideoQuotaValid,
   isUserVideoQuotaDailyValid,
-  isUserUsernameValid,
+  checkUserUsername,
   isUserAdminFlagsValid,
   isUserEmailVerifiedValid,
   isUserNSFWPolicyValid,

--- a/server/helpers/custom-validators/users.ts
+++ b/server/helpers/custom-validators/users.ts
@@ -26,10 +26,17 @@ function isUserVideoQuotaDailyValid (value: string) {
   return exists(value) && validator.isInt(value + '', USERS_CONSTRAINTS_FIELDS.VIDEO_QUOTA_DAILY)
 }
 
+/**
+ * @throws {Error}
+ */
 function isUserUsernameValid (value: string) {
+  if (!exists(value)) throw new Error('Should have a username')
   const max = USERS_CONSTRAINTS_FIELDS.USERNAME.max
   const min = USERS_CONSTRAINTS_FIELDS.USERNAME.min
-  return exists(value) && validator.matches(value, new RegExp(`^[a-z0-9._]{${min},${max}}$`))
+  if (!validator.matches(value, new RegExp(`^[a-z0-9._]{${min},${max}}$`))) {
+    throw new Error(`Should have a username between ${min} and ${max} alphanumeric characters long`)
+  }
+  return true
 }
 
 function isUserDisplayNameValid (value: string) {

--- a/server/helpers/custom-validators/video-blacklist.ts
+++ b/server/helpers/custom-validators/video-blacklist.ts
@@ -5,9 +5,6 @@ import { VideoBlacklistType } from '../../../shared/models/videos'
 
 const VIDEO_BLACKLIST_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEO_BLACKLIST
 
-/**
- * @throws {Error}
- */
 function checkVideoBlacklistReason (value: string) {
   if (value === null) return true
   if (!validator.isLength(value, VIDEO_BLACKLIST_CONSTRAINTS_FIELDS.REASON)) {

--- a/server/helpers/custom-validators/video-blacklist.ts
+++ b/server/helpers/custom-validators/video-blacklist.ts
@@ -5,8 +5,17 @@ import { VideoBlacklistType } from '../../../shared/models/videos'
 
 const VIDEO_BLACKLIST_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEO_BLACKLIST
 
-function isVideoBlacklistReasonValid (value: string) {
-  return value === null || validator.isLength(value, VIDEO_BLACKLIST_CONSTRAINTS_FIELDS.REASON)
+/**
+ * @throws {Error}
+ */
+function checkVideoBlacklistReason (value: string) {
+  if (value === null) return true
+  if (!validator.isLength(value, VIDEO_BLACKLIST_CONSTRAINTS_FIELDS.REASON)) {
+    const min = VIDEO_BLACKLIST_CONSTRAINTS_FIELDS.REASON.min
+    const max = VIDEO_BLACKLIST_CONSTRAINTS_FIELDS.REASON.max
+    throw new Error(`Should have a video blacklist reason between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
 function isVideoBlacklistTypeValid (value: any) {
@@ -17,6 +26,6 @@ function isVideoBlacklistTypeValid (value: any) {
 // ---------------------------------------------------------------------------
 
 export {
-  isVideoBlacklistReasonValid,
+  checkVideoBlacklistReason,
   isVideoBlacklistTypeValid
 }

--- a/server/helpers/custom-validators/video-captions.ts
+++ b/server/helpers/custom-validators/video-captions.ts
@@ -1,8 +1,13 @@
 import { CONSTRAINTS_FIELDS, MIMETYPES, VIDEO_LANGUAGES } from '../../initializers/constants'
 import { exists, isFileValid } from './misc'
 
-function isVideoCaptionLanguageValid (value: any) {
-  return exists(value) && VIDEO_LANGUAGES[value] !== undefined
+/**
+ * @throws {Error}
+ */
+function checkVideoCaptionLanguage (value: any) {
+  if (!exists(value)) throw new Error('Should have a video caption language')
+  if (VIDEO_LANGUAGES[value] === undefined) throw new Error('Should have a known video caption language')
+  return true
 }
 
 const videoCaptionTypesRegex = Object.keys(MIMETYPES.VIDEO_CAPTIONS.MIMETYPE_EXT)
@@ -21,5 +26,5 @@ function isVideoCaptionFile (files: { [ fieldname: string ]: Express.Multer.File
 
 export {
   isVideoCaptionFile,
-  isVideoCaptionLanguageValid
+  checkVideoCaptionLanguage
 }

--- a/server/helpers/custom-validators/video-captions.ts
+++ b/server/helpers/custom-validators/video-captions.ts
@@ -9,6 +9,10 @@ const videoCaptionTypesRegex = Object.keys(MIMETYPES.VIDEO_CAPTIONS.MIMETYPE_EXT
                                 .concat([ 'application/octet-stream' ]) // MacOS sends application/octet-stream
                                 .map(m => `(${m})`)
                                 .join('|')
+
+/**
+ * @throws {Error}
+ */
 function isVideoCaptionFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], field: string) {
   return isFileValid(files, videoCaptionTypesRegex, field, CONSTRAINTS_FIELDS.VIDEO_CAPTIONS.CAPTION_FILE.FILE_SIZE.max)
 }

--- a/server/helpers/custom-validators/video-captions.ts
+++ b/server/helpers/custom-validators/video-captions.ts
@@ -1,9 +1,6 @@
 import { CONSTRAINTS_FIELDS, MIMETYPES, VIDEO_LANGUAGES } from '../../initializers/constants'
-import { exists, isFileValid } from './misc'
+import { exists, checkFileValid } from './misc'
 
-/**
- * @throws {Error}
- */
 function checkVideoCaptionLanguage (value: any) {
   if (!exists(value)) throw new Error('Should have a video caption language')
   if (VIDEO_LANGUAGES[value] === undefined) throw new Error('Should have a known video caption language')
@@ -15,11 +12,8 @@ const videoCaptionTypesRegex = Object.keys(MIMETYPES.VIDEO_CAPTIONS.MIMETYPE_EXT
                                 .map(m => `(${m})`)
                                 .join('|')
 
-/**
- * @throws {Error}
- */
 function isVideoCaptionFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], field: string) {
-  return isFileValid(files, videoCaptionTypesRegex, field, CONSTRAINTS_FIELDS.VIDEO_CAPTIONS.CAPTION_FILE.FILE_SIZE.max)
+  return checkFileValid(files, videoCaptionTypesRegex, field, CONSTRAINTS_FIELDS.VIDEO_CAPTIONS.CAPTION_FILE.FILE_SIZE.max)
 }
 
 // ---------------------------------------------------------------------------

--- a/server/helpers/custom-validators/video-channels.ts
+++ b/server/helpers/custom-validators/video-channels.ts
@@ -4,22 +4,47 @@ import { exists } from './misc'
 
 const VIDEO_CHANNELS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEO_CHANNELS
 
-function isVideoChannelDescriptionValid (value: string) {
-  return value === null || validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.DESCRIPTION)
+/**
+ * @throws {Error}
+ */
+function checkVideoChannelDescription (value: string) {
+  if (value === null) return true
+  if (!validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.DESCRIPTION)) {
+    const min = VIDEO_CHANNELS_CONSTRAINTS_FIELDS.DESCRIPTION.min
+    const max = VIDEO_CHANNELS_CONSTRAINTS_FIELDS.DESCRIPTION.max
+    throw new Error(`Should have a video channel description text between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
 function isVideoChannelNameValid (value: string) {
-  return exists(value) && validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.NAME)
+  if (!exists(value)) throw new Error('Should have a video channel name')
+  if (!validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.NAME)) {
+    const min = VIDEO_CHANNELS_CONSTRAINTS_FIELDS.NAME.min
+    const max = VIDEO_CHANNELS_CONSTRAINTS_FIELDS.NAME.max
+    throw new Error(`Should have a video channel name between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoChannelSupportValid (value: string) {
-  return value === null || (exists(value) && validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.SUPPORT))
+  if (value === null) return true
+  if (!exists(value)) throw new Error('Should have a video channel support')
+  if (!validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.SUPPORT)) {
+    const min = VIDEO_CHANNELS_CONSTRAINTS_FIELDS.SUPPORT.min
+    const max = VIDEO_CHANNELS_CONSTRAINTS_FIELDS.SUPPORT.max
+    throw new Error(`Should have a video channel support text between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isVideoChannelDescriptionValid,
+  checkVideoChannelDescription,
   isVideoChannelNameValid,
   isVideoChannelSupportValid
 }

--- a/server/helpers/custom-validators/video-channels.ts
+++ b/server/helpers/custom-validators/video-channels.ts
@@ -4,9 +4,6 @@ import { exists } from './misc'
 
 const VIDEO_CHANNELS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEO_CHANNELS
 
-/**
- * @throws {Error}
- */
 function checkVideoChannelDescription (value: string) {
   if (value === null) return true
   if (!validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.DESCRIPTION)) {
@@ -17,7 +14,7 @@ function checkVideoChannelDescription (value: string) {
   return true
 }
 
-function isVideoChannelNameValid (value: string) {
+function checkVideoChannelName (value: string) {
   if (!exists(value)) throw new Error('Should have a video channel name')
   if (!validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.NAME)) {
     const min = VIDEO_CHANNELS_CONSTRAINTS_FIELDS.NAME.min
@@ -27,10 +24,7 @@ function isVideoChannelNameValid (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoChannelSupportValid (value: string) {
+function checkVideoChannelSupport (value: string) {
   if (value === null) return true
   if (!exists(value)) throw new Error('Should have a video channel support')
   if (!validator.isLength(value, VIDEO_CHANNELS_CONSTRAINTS_FIELDS.SUPPORT)) {
@@ -45,6 +39,6 @@ function isVideoChannelSupportValid (value: string) {
 
 export {
   checkVideoChannelDescription,
-  isVideoChannelNameValid,
-  isVideoChannelSupportValid
+  checkVideoChannelName,
+  checkVideoChannelSupport
 }

--- a/server/helpers/custom-validators/video-comments.ts
+++ b/server/helpers/custom-validators/video-comments.ts
@@ -7,9 +7,6 @@ import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-code
 
 const VIDEO_COMMENTS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEO_COMMENTS
 
-/**
- * @throws {Error}
- */
 function checkVideoCommentText (value: string) {
   if (value === null) return true
   if (!validator.isLength(value, VIDEO_COMMENTS_CONSTRAINTS_FIELDS.TEXT)) {

--- a/server/helpers/custom-validators/video-comments.ts
+++ b/server/helpers/custom-validators/video-comments.ts
@@ -7,8 +7,17 @@ import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-code
 
 const VIDEO_COMMENTS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEO_COMMENTS
 
-function isValidVideoCommentText (value: string) {
-  return value === null || validator.isLength(value, VIDEO_COMMENTS_CONSTRAINTS_FIELDS.TEXT)
+/**
+ * @throws {Error}
+ */
+function checkVideoCommentText (value: string) {
+  if (value === null) return true
+  if (!validator.isLength(value, VIDEO_COMMENTS_CONSTRAINTS_FIELDS.TEXT)) {
+    const min = VIDEO_COMMENTS_CONSTRAINTS_FIELDS.TEXT.min
+    const max = VIDEO_COMMENTS_CONSTRAINTS_FIELDS.TEXT.max
+    throw new Error(`Should have a video comment text between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
 async function doesVideoCommentThreadExist (idArg: number | string, video: MVideoId, res: express.Response) {
@@ -86,7 +95,7 @@ async function doesCommentIdExist (idArg: number | string, res: express.Response
 // ---------------------------------------------------------------------------
 
 export {
-  isValidVideoCommentText,
+  checkVideoCommentText,
   doesVideoCommentThreadExist,
   doesVideoCommentExist,
   doesCommentIdExist

--- a/server/helpers/custom-validators/video-imports.ts
+++ b/server/helpers/custom-validators/video-imports.ts
@@ -28,6 +28,10 @@ const videoTorrentImportRegex = Object.keys(MIMETYPES.TORRENT.MIMETYPE_EXT)
                                       .concat([ 'application/octet-stream' ]) // MacOS sends application/octet-stream
                                       .map(m => `(${m})`)
                                       .join('|')
+
+/**
+ * @throws {Error}
+ */
 function isVideoImportTorrentFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[]) {
   return isFileValid(files, videoTorrentImportRegex, 'torrentfile', CONSTRAINTS_FIELDS.VIDEO_IMPORTS.TORRENT_FILE.FILE_SIZE.max, true)
 }

--- a/server/helpers/custom-validators/video-imports.ts
+++ b/server/helpers/custom-validators/video-imports.ts
@@ -1,14 +1,11 @@
 import 'multer'
 import validator from 'validator'
 import { CONSTRAINTS_FIELDS, MIMETYPES, VIDEO_IMPORT_STATES } from '../../initializers/constants'
-import { exists, isFileValid } from './misc'
+import { exists, checkFileValid } from './misc'
 import * as express from 'express'
 import { VideoImportModel } from '../../models/video/video-import'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 
-/**
- * @throws {Error}
- */
 function checkVideoImportTargetUrl (url: string) {
   const isURLOptions = {
     require_host: true,
@@ -30,9 +27,6 @@ function checkVideoImportTargetUrl (url: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoImportState (value: any) {
   if (!exists(value)) throw new Error('Should have a video import state')
   if (VIDEO_IMPORT_STATES[value] === undefined) throw new Error('Should have a known video import')
@@ -44,11 +38,8 @@ const videoTorrentImportRegex = Object.keys(MIMETYPES.TORRENT.MIMETYPE_EXT)
                                       .map(m => `(${m})`)
                                       .join('|')
 
-/**
- * @throws {Error}
- */
 function checkVideoImportTorrentFile (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[]) {
-  return isFileValid(files, videoTorrentImportRegex, 'torrentfile', CONSTRAINTS_FIELDS.VIDEO_IMPORTS.TORRENT_FILE.FILE_SIZE.max, true)
+  return checkFileValid(files, videoTorrentImportRegex, 'torrentfile', CONSTRAINTS_FIELDS.VIDEO_IMPORTS.TORRENT_FILE.FILE_SIZE.max, true)
 }
 
 async function doesVideoImportExist (id: number, res: express.Response) {

--- a/server/helpers/custom-validators/video-playlists.ts
+++ b/server/helpers/custom-validators/video-playlists.ts
@@ -4,9 +4,6 @@ import { CONSTRAINTS_FIELDS, VIDEO_PLAYLIST_PRIVACIES, VIDEO_PLAYLIST_TYPES } fr
 
 const PLAYLISTS_CONSTRAINT_FIELDS = CONSTRAINTS_FIELDS.VIDEO_PLAYLISTS
 
-/**
- * @throws {Error}
- */
 function checkVideoPlaylistName (value: any) {
   if (!exists(value)) throw new Error('Should have a non-null playlist name')
   if (!validator.isLength(value, PLAYLISTS_CONSTRAINT_FIELDS.NAME)) {
@@ -17,9 +14,6 @@ function checkVideoPlaylistName (value: any) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoPlaylistDescription (value: any) {
   if (value === null) return true
   if (!exists(value)) throw new Error('Should have a non-null playlist description')
@@ -31,18 +25,12 @@ function checkVideoPlaylistDescription (value: any) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoPlaylistPrivacy (value: number) {
   if (!validator.isInt(value + '')) throw new Error('Should have a privacy policy that is an integer')
   if (VIDEO_PLAYLIST_PRIVACIES[value] === undefined) throw new Error('Should have a privacy policy that corresponds to a known value')
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoPlaylistTimestamp (value: any) {
   if (value === null) return true
   if (!exists(value)) throw new Error('Should have a non-null timestamp')
@@ -50,9 +38,6 @@ function checkVideoPlaylistTimestamp (value: any) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoPlaylistType (value: any) {
   if (!exists(value)) throw new Error('Should have a non-null type')
   if (VIDEO_PLAYLIST_TYPES[value] === undefined) throw new Error('Should have a known playlist type')

--- a/server/helpers/custom-validators/video-playlists.ts
+++ b/server/helpers/custom-validators/video-playlists.ts
@@ -1,4 +1,4 @@
-import { exists } from './misc'
+import { catchError, exists, isArrayOf, isIdValid } from './misc'
 import validator from 'validator'
 import { CONSTRAINTS_FIELDS, VIDEO_PLAYLIST_PRIVACIES, VIDEO_PLAYLIST_TYPES } from '../../initializers/constants'
 
@@ -24,6 +24,10 @@ function isVideoPlaylistTypeValid (value: any) {
   return exists(value) && VIDEO_PLAYLIST_TYPES[value] !== undefined
 }
 
+function isVideoPlaylistVideoIdsValid (value: any) {
+  return isArrayOf(value, catchError(isIdValid))
+}
+
 // ---------------------------------------------------------------------------
 
 export {
@@ -31,5 +35,6 @@ export {
   isVideoPlaylistDescriptionValid,
   isVideoPlaylistPrivacyValid,
   isVideoPlaylistTimestampValid,
-  isVideoPlaylistTypeValid
+  isVideoPlaylistTypeValid,
+  isVideoPlaylistVideoIdsValid
 }

--- a/server/helpers/custom-validators/video-playlists.ts
+++ b/server/helpers/custom-validators/video-playlists.ts
@@ -1,4 +1,4 @@
-import { catchErrorAsBoolean, exists, isArrayOf, checkId } from './misc'
+import { exists, checkArrayWith, checkId } from './misc'
 import validator from 'validator'
 import { CONSTRAINTS_FIELDS, VIDEO_PLAYLIST_PRIVACIES, VIDEO_PLAYLIST_TYPES } from '../../initializers/constants'
 
@@ -44,8 +44,8 @@ function checkVideoPlaylistType (value: any) {
   return true
 }
 
-function isVideoPlaylistVideoIdsValid (value: any) {
-  return isArrayOf(value, catchErrorAsBoolean(checkId))
+function checkVideoPlaylistVideoIds (value: any) {
+  return checkArrayWith(value, checkId)
 }
 
 // ---------------------------------------------------------------------------
@@ -56,5 +56,5 @@ export {
   checkVideoPlaylistPrivacy,
   checkVideoPlaylistTimestamp,
   checkVideoPlaylistType,
-  isVideoPlaylistVideoIdsValid
+  checkVideoPlaylistVideoIds
 }

--- a/server/helpers/custom-validators/video-playlists.ts
+++ b/server/helpers/custom-validators/video-playlists.ts
@@ -1,4 +1,4 @@
-import { catchError, exists, isArrayOf, isIdValid } from './misc'
+import { EtoB, exists, isArrayOf, isIdValid } from './misc'
 import validator from 'validator'
 import { CONSTRAINTS_FIELDS, VIDEO_PLAYLIST_PRIVACIES, VIDEO_PLAYLIST_TYPES } from '../../initializers/constants'
 
@@ -25,7 +25,7 @@ function isVideoPlaylistTypeValid (value: any) {
 }
 
 function isVideoPlaylistVideoIdsValid (value: any) {
-  return isArrayOf(value, catchError(isIdValid))
+  return isArrayOf(value, EtoB(isIdValid))
 }
 
 // ---------------------------------------------------------------------------

--- a/server/helpers/custom-validators/video-playlists.ts
+++ b/server/helpers/custom-validators/video-playlists.ts
@@ -1,40 +1,75 @@
-import { EtoB, exists, isArrayOf, isIdValid } from './misc'
+import { catchErrorAsBoolean, exists, isArrayOf, checkId } from './misc'
 import validator from 'validator'
 import { CONSTRAINTS_FIELDS, VIDEO_PLAYLIST_PRIVACIES, VIDEO_PLAYLIST_TYPES } from '../../initializers/constants'
 
 const PLAYLISTS_CONSTRAINT_FIELDS = CONSTRAINTS_FIELDS.VIDEO_PLAYLISTS
 
-function isVideoPlaylistNameValid (value: any) {
-  return exists(value) && validator.isLength(value, PLAYLISTS_CONSTRAINT_FIELDS.NAME)
+/**
+ * @throws {Error}
+ */
+function checkVideoPlaylistName (value: any) {
+  if (!exists(value)) throw new Error('Should have a non-null playlist name')
+  if (!validator.isLength(value, PLAYLISTS_CONSTRAINT_FIELDS.NAME)) {
+    const min = PLAYLISTS_CONSTRAINT_FIELDS.NAME.min
+    const max = PLAYLISTS_CONSTRAINT_FIELDS.NAME.max
+    throw new Error(`Should have a video playlist name between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
-function isVideoPlaylistDescriptionValid (value: any) {
-  return value === null || (exists(value) && validator.isLength(value, PLAYLISTS_CONSTRAINT_FIELDS.DESCRIPTION))
+/**
+ * @throws {Error}
+ */
+function checkVideoPlaylistDescription (value: any) {
+  if (value === null) return true
+  if (!exists(value)) throw new Error('Should have a non-null playlist description')
+  if (!validator.isLength(value, PLAYLISTS_CONSTRAINT_FIELDS.DESCRIPTION)) {
+    const min = PLAYLISTS_CONSTRAINT_FIELDS.DESCRIPTION.min
+    const max = PLAYLISTS_CONSTRAINT_FIELDS.DESCRIPTION.max
+    throw new Error(`Should have a video playlist description text between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
-function isVideoPlaylistPrivacyValid (value: number) {
-  return validator.isInt(value + '') && VIDEO_PLAYLIST_PRIVACIES[value] !== undefined
+/**
+ * @throws {Error}
+ */
+function checkVideoPlaylistPrivacy (value: number) {
+  if (!validator.isInt(value + '')) throw new Error('Should have a privacy policy that is an integer')
+  if (VIDEO_PLAYLIST_PRIVACIES[value] === undefined) throw new Error('Should have a privacy policy that corresponds to a known value')
+  return true
 }
 
-function isVideoPlaylistTimestampValid (value: any) {
-  return value === null || (exists(value) && validator.isInt('' + value, { min: 0 }))
+/**
+ * @throws {Error}
+ */
+function checkVideoPlaylistTimestamp (value: any) {
+  if (value === null) return true
+  if (!exists(value)) throw new Error('Should have a non-null timestamp')
+  if (!validator.isInt('' + value, { min: 0 })) throw new Error('Should have a timestamp that is a positive integer')
+  return true
 }
 
-function isVideoPlaylistTypeValid (value: any) {
-  return exists(value) && VIDEO_PLAYLIST_TYPES[value] !== undefined
+/**
+ * @throws {Error}
+ */
+function checkVideoPlaylistType (value: any) {
+  if (!exists(value)) throw new Error('Should have a non-null type')
+  if (VIDEO_PLAYLIST_TYPES[value] === undefined) throw new Error('Should have a known playlist type')
+  return true
 }
 
 function isVideoPlaylistVideoIdsValid (value: any) {
-  return isArrayOf(value, EtoB(isIdValid))
+  return isArrayOf(value, catchErrorAsBoolean(checkId))
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isVideoPlaylistNameValid,
-  isVideoPlaylistDescriptionValid,
-  isVideoPlaylistPrivacyValid,
-  isVideoPlaylistTimestampValid,
-  isVideoPlaylistTypeValid,
+  checkVideoPlaylistName,
+  checkVideoPlaylistDescription,
+  checkVideoPlaylistPrivacy,
+  checkVideoPlaylistTimestamp,
+  checkVideoPlaylistType,
   isVideoPlaylistVideoIdsValid
 }

--- a/server/helpers/custom-validators/video-rates.ts
+++ b/server/helpers/custom-validators/video-rates.ts
@@ -1,5 +1,9 @@
-function isRatingValid (value: any) {
-  return value === 'like' || value === 'dislike'
+/**
+ * @throws {Error}
+ */
+function checkVideoRating (value: any) {
+  if (![ 'like', 'dislike' ].includes(value)) throw new Error('Should have rating value be either "like" or "dislike"')
+  return true
 }
 
-export { isRatingValid }
+export { checkVideoRating }

--- a/server/helpers/custom-validators/video-rates.ts
+++ b/server/helpers/custom-validators/video-rates.ts
@@ -1,6 +1,3 @@
-/**
- * @throws {Error}
- */
 function checkVideoRating (value: any) {
   if (![ 'like', 'dislike' ].includes(value)) throw new Error('Should have rating value be either "like" or "dislike"')
   return true

--- a/server/helpers/custom-validators/video-redundancies.ts
+++ b/server/helpers/custom-validators/video-redundancies.ts
@@ -1,12 +1,16 @@
 import { exists } from './misc'
 
-function isVideoRedundancyTarget (value: any) {
-  return exists(value) &&
-    (value === 'my-videos' || value === 'remote-videos')
+/**
+ * @throws {Error}
+ */
+function checkVideoRedundancyTarget (value: any) {
+  if (!exists(value)) throw new Error('Should have a video redundancy target')
+  if (![ 'my-videos', 'remote-videos' ].includes(value)) throw new Error('Should have a known video redundancy target')
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isVideoRedundancyTarget
+  checkVideoRedundancyTarget
 }

--- a/server/helpers/custom-validators/video-redundancies.ts
+++ b/server/helpers/custom-validators/video-redundancies.ts
@@ -1,8 +1,5 @@
 import { exists } from './misc'
 
-/**
- * @throws {Error}
- */
 function checkVideoRedundancyTarget (value: any) {
   if (!exists(value)) throw new Error('Should have a video redundancy target')
   if (![ 'my-videos', 'remote-videos' ].includes(value)) throw new Error('Should have a known video redundancy target')

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -38,36 +38,84 @@ function isVideoLanguageValid (value: any) {
     (typeof value === 'string' && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.LANGUAGE))
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoDurationValid (value: string) {
-  return exists(value) && validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.DURATION)
+  if (!exists(value)) throw new Error('Should have a video duration')
+  if (!validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.DURATION)) throw new Error('Should have an integer video duration')
+  return true
 }
 
 function isVideoTruncatedDescriptionValid (value: string) {
   return exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.TRUNCATED_DESCRIPTION)
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoDescriptionValid (value: string) {
-  return value === null || (exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.DESCRIPTION))
+  if (value === null) return true
+  if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.DESCRIPTION)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.DESCRIPTION.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.DESCRIPTION.max
+    throw new Error(`Should have a video description between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoSupportValid (value: string) {
-  return value === null || (exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.SUPPORT))
+  if (value === null) return true
+  if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.SUPPORT)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.SUPPORT.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.SUPPORT.max
+    throw new Error(`Should have a video support text between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoNameValid (value: string) {
-  return exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.NAME)
+  if (!exists(value)) throw new Error('Should have a video name')
+  if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.NAME)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.NAME.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.NAME.max
+    throw new Error(`Should have a video name between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoTagValid (tag: string) {
-  return exists(tag) && validator.isLength(tag, VIDEOS_CONSTRAINTS_FIELDS.TAG)
+  if (!exists(tag)) throw new Error('Should have a video tag value')
+  if (!validator.isLength(tag, VIDEOS_CONSTRAINTS_FIELDS.TAG)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.TAG.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.TAG.max
+    throw new Error(`Should have a video tag between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoTagsValid (tags: string[]) {
-  return tags === null || (
-    isArray(tags) &&
-    validator.isInt(tags.length.toString(), VIDEOS_CONSTRAINTS_FIELDS.TAGS) &&
-    tags.every(tag => isVideoTagValid(tag))
-  )
+  if (tags === null) return true
+  if (!isArray(tags)) throw new Error('Should have an array of tags')
+  if (!validator.isInt(tags.length.toString(), VIDEOS_CONSTRAINTS_FIELDS.TAGS)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.TAGS.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.TAGS.max
+    throw new Error(`Should have between ${min} and ${max} tags`)
+  }
+  tags.forEach(tag => isVideoTagValid(tag)) // will throw with proper message
+  return true
 }
 
 function isVideoViewsValid (value: string) {
@@ -99,16 +147,30 @@ function isVideoPrivacyValid (value: number) {
   return VIDEO_PRIVACIES[value] !== undefined
 }
 
+/**
+ * @throws {Error}
+ */
 function isScheduleVideoUpdatePrivacyValid (value: number) {
-  return value === VideoPrivacy.UNLISTED || value === VideoPrivacy.PUBLIC || value === VideoPrivacy.INTERNAL
+  const valid = value === VideoPrivacy.UNLISTED || value === VideoPrivacy.PUBLIC || value === VideoPrivacy.INTERNAL
+  if (!valid) throw new Error(`Should have a valid privacy: ${VideoPrivacy.UNLISTED}, ${VideoPrivacy.PUBLIC} or ${VideoPrivacy.INTERNAL}`)
+  return true
 }
 
 function isVideoOriginallyPublishedAtValid (value: string | null) {
   return value === null || isDateValid(value)
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoFileInfoHashValid (value: string | null | undefined) {
-  return exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH)
+  if (!exists(value)) throw new Error('Should have a video file infohash')
+  if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH.max
+    throw new Error(`Should have a video file infohash between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
 function isVideoFileResolutionValid (value: string) {

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -13,49 +13,34 @@ import {
   VIDEO_RATE_TYPES,
   VIDEO_STATES
 } from '../../initializers/constants'
-import { exists, isArray, checkDate, isFileMimeTypeValid, isFileValid } from './misc'
+import { exists, isArray, checkDate, checkFileMimeType, checkFileValid } from './misc'
 
 const VIDEOS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEOS
 
-/**
- * @throws {Error}
- */
-function isVideoFilterValid (filter: VideoFilter) {
+function checkVideoFilter (filter: VideoFilter) {
   if (![ 'local', 'all-local', 'all' ].includes(filter)) throw new Error('Should have a known video filter')
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoCategoryValid (value: any) {
+function checkVideoCategory (value: any) {
   if (value === null) return true
   if (VIDEO_CATEGORIES[value] === undefined) throw new Error('Should have a known video category')
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoStateValid (value: any) {
+function checkVideoState (value: any) {
   if (!exists(value)) throw new Error('Should have a video state')
   if (VIDEO_STATES[value] === undefined) throw new Error('Should have a known video state')
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoLicenceValid (value: any) {
+function checkVideoLicence (value: any) {
   if (value === null) return true
   if (VIDEO_LICENCES[value] === undefined) throw new Error('Should have a known video licence')
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoLanguageValid (value: any) {
+function checkVideoLanguage (value: any) {
   if (value === null) return true
   if (typeof value !== 'string') throw new Error('Should have a video language that is a string')
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.LANGUAGE)) {
@@ -66,18 +51,12 @@ function isVideoLanguageValid (value: any) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoDuration (value: string) {
   if (!exists(value)) throw new Error('Should have a video duration')
   if (!validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.DURATION)) throw new Error('Should have an integer video duration')
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoTruncatedDescription (value: string) {
   if (!exists(value)) throw new Error('Should have a video truncated description')
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.TRUNCATED_DESCRIPTION)) {
@@ -88,9 +67,6 @@ function checkVideoTruncatedDescription (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoDescription (value: string) {
   if (value === null) return true
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.DESCRIPTION)) {
@@ -101,9 +77,6 @@ function checkVideoDescription (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoSupport (value: string) {
   if (value === null) return true
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.SUPPORT)) {
@@ -114,9 +87,6 @@ function checkVideoSupport (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoName (value: string) {
   if (!exists(value)) throw new Error('Should have a video name')
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.NAME)) {
@@ -127,9 +97,6 @@ function checkVideoName (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoTag (tag: string) {
   if (!exists(tag)) throw new Error('Should have a video tag value')
   if (!validator.isLength(tag, VIDEOS_CONSTRAINTS_FIELDS.TAG)) {
@@ -140,9 +107,6 @@ function checkVideoTag (tag: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoTags (tags: string[]) {
   if (tags === null) return true
   if (!isArray(tags)) throw new Error('Should have an array of tags')
@@ -155,10 +119,7 @@ function checkVideoTags (tags: string[]) {
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoViewsValid (value: string) {
+function checkVideoViews (value: string) {
   if (!exists(value)) throw new Error('Should have a video views count')
   if (!validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.VIEWS)) {
     throw new Error(`Should have a positive video view count`)
@@ -166,11 +127,8 @@ function isVideoViewsValid (value: string) {
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoRatingTypeValid (value: string) {
-  if (value === 'none') return true
+function checkVideoRatingType (value: string) {
+  if (value === 'none') return
   if (!values(VIDEO_RATE_TYPES).includes(value as VideoRateType)) throw new Error('Should have a known video rate')
   return true
 }
@@ -179,11 +137,8 @@ function isVideoFileExtnameValid (value: string) {
   return exists(value) && (value === VIDEO_LIVE.EXTENSION || MIMETYPES.VIDEO.EXT_MIMETYPE[value] !== undefined)
 }
 
-/**
- * @throws {Error}
- */
 function isVideoFileMimeTypeValid (files: UploadFilesForCheck) {
-  return isFileMimeTypeValid(files, MIMETYPES.VIDEO.MIMETYPES_REGEX, 'videofile')
+  return checkFileMimeType(files, MIMETYPES.VIDEO.MIMETYPES_REGEX, 'videofile')
 }
 
 const videoImageTypes = CONSTRAINTS_FIELDS.VIDEOS.IMAGE.EXTNAME
@@ -191,40 +146,27 @@ const videoImageTypes = CONSTRAINTS_FIELDS.VIDEOS.IMAGE.EXTNAME
                                           .join('|')
 const videoImageTypesRegex = `image/(${videoImageTypes})`
 
-/**
- * @throws {Error}
- */
 function checkVideoImage (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], field: string) {
-  return isFileValid(files, videoImageTypesRegex, field, CONSTRAINTS_FIELDS.VIDEOS.IMAGE.FILE_SIZE.max, true)
+  return checkFileValid(files, videoImageTypesRegex, field, CONSTRAINTS_FIELDS.VIDEOS.IMAGE.FILE_SIZE.max, true)
 }
 
-/**
- * @throws {Error}
- */
-function isVideoPrivacyValid (value: number) {
+function checkVideoPrivacy (value: number) {
   if (VIDEO_PRIVACIES[value] === undefined) throw new Error('Should have a known video privacy policy')
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkScheduleVideoUpdatePrivacy (value: number) {
   const valid = value === VideoPrivacy.UNLISTED || value === VideoPrivacy.PUBLIC || value === VideoPrivacy.INTERNAL
   if (!valid) throw new Error(`Should have a valid privacy: ${VideoPrivacy.UNLISTED}, ${VideoPrivacy.PUBLIC} or ${VideoPrivacy.INTERNAL}`)
   return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoOriginallyPublishedAt (value: string | null) {
-  return value === null || checkDate(value)
+  if (value === null) return true
+  checkDate(value)
+  return true
 }
 
-/**
- * @throws {Error}
- */
 function checkVideoFileInfoHash (value: string | null | undefined) {
   if (!exists(value)) throw new Error('Should have a video file infohash')
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH)) {
@@ -235,73 +177,62 @@ function checkVideoFileInfoHash (value: string | null | undefined) {
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoFileResolutionValid (value: string) {
+function checkVideoFileResolution (value: string) {
   if (!exists(value)) throw new Error('Should have a video file resolution')
   if (!validator.isInt(value + '')) throw new Error('Should have a video file resolution that is an integer')
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoFPSResolutionValid (value: string) {
+function checkVideoFPSResolution (value: string) {
   if (value === null) return true
   if (!validator.isInt(value + '')) throw new Error('Should have a video file resolution that is an integer')
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoFileSizeValid (value: string) {
-  if (!exists(value)) throw new Error('')
+function checkVideoFileSize (value: string) {
+  if (!exists(value)) throw new Error('Should have a video file size')
   if (!validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.FILE_SIZE)) {
     throw new Error('This file is too large. It exceeds the maximum file size authorized.')
   }
   return true
 }
 
-/**
- * @throws {Error}
- */
-function isVideoMagnetUriValid (value: string) {
+function checkVideoMagnetUri (value: string) {
   if (!exists(value)) throw new Error('Should have a video magnetUri')
 
   const parsed = magnetUtil.decode(value)
-  if (parsed && checkVideoFileInfoHash(parsed.infoHash)) {
-    return true
-  }
+  if (!parsed) throw new Error('Should have a parsed infohash')
+
+  checkVideoFileInfoHash(parsed.infoHash)
+  return true
 }
 
 // ---------------------------------------------------------------------------
 
 export {
-  isVideoCategoryValid,
-  isVideoLicenceValid,
-  isVideoLanguageValid,
+  checkVideoCategory,
+  checkVideoLicence,
+  checkVideoLanguage,
   checkVideoTruncatedDescription,
   checkVideoDescription,
   checkVideoFileInfoHash,
   checkVideoName,
   checkVideoTags,
-  isVideoFPSResolutionValid,
+  checkVideoFPSResolution,
   checkScheduleVideoUpdatePrivacy,
   checkVideoOriginallyPublishedAt,
-  isVideoMagnetUriValid,
-  isVideoStateValid,
-  isVideoViewsValid,
-  isVideoRatingTypeValid,
+  checkVideoMagnetUri,
+  checkVideoState,
+  checkVideoViews,
+  checkVideoRatingType,
   isVideoFileExtnameValid,
   isVideoFileMimeTypeValid,
   checkVideoDuration,
   checkVideoTag,
-  isVideoPrivacyValid,
-  isVideoFileResolutionValid,
-  isVideoFileSizeValid,
+  checkVideoPrivacy,
+  checkVideoFileResolution,
+  checkVideoFileSize,
   checkVideoImage,
   checkVideoSupport,
-  isVideoFilterValid
+  checkVideoFilter
 }

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -13,49 +13,76 @@ import {
   VIDEO_RATE_TYPES,
   VIDEO_STATES
 } from '../../initializers/constants'
-import { EtoB, exists, isArray, isDateValid, isFileMimeTypeValid, isFileValid } from './misc'
-import * as magnetUtil from 'magnet-uri'
+import { exists, isArray, checkDate, isFileMimeTypeValid, isFileValid } from './misc'
 
 const VIDEOS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEOS
 
+/**
+ * @throws {Error}
+ */
 function isVideoFilterValid (filter: VideoFilter) {
-  return filter === 'local' || filter === 'all-local' || filter === 'all'
-}
-
-function isVideoCategoryValid (value: any) {
-  return value === null || VIDEO_CATEGORIES[value] !== undefined
-}
-
-function isVideoStateValid (value: any) {
-  return exists(value) && VIDEO_STATES[value] !== undefined
-}
-
-function isVideoLicenceValid (value: any) {
-  return value === null || VIDEO_LICENCES[value] !== undefined
-}
-
-function isVideoLanguageValid (value: any) {
-  return value === null ||
-    (typeof value === 'string' && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.LANGUAGE))
+  if (![ 'local', 'all-local', 'all' ].includes(filter)) throw new Error('Should have a known video filter')
+  return true
 }
 
 /**
  * @throws {Error}
  */
-function isVideoDurationValid (value: string) {
+function isVideoCategoryValid (value: any) {
+  if (value === null) return true
+  if (VIDEO_CATEGORIES[value] === undefined) throw new Error('Should have a known video category')
+  return true
+}
+
+/**
+ * @throws {Error}
+ */
+function isVideoStateValid (value: any) {
+  if (!exists(value)) throw new Error('Should have a video state')
+  if (VIDEO_STATES[value] === undefined) throw new Error('Should have a known video state')
+  return true
+}
+
+/**
+ * @throws {Error}
+ */
+function isVideoLicenceValid (value: any) {
+  if (value === null) return true
+  if (VIDEO_LICENCES[value] === undefined) throw new Error('Should have a known video licence')
+  return true
+}
+
+/**
+ * @throws {Error}
+ */
+function isVideoLanguageValid (value: any) {
+  if (value === null) return true
+  if (typeof value !== 'string') throw new Error('Should have a video language that is a string')
+  if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.LANGUAGE)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.LANGUAGE.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.LANGUAGE.max
+    throw new Error(`Should have a video language between ${min} and ${max} characters long`)
+  }
+  return true
+}
+
+/**
+ * @throws {Error}
+ */
+function checkVideoDuration (value: string) {
   if (!exists(value)) throw new Error('Should have a video duration')
   if (!validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.DURATION)) throw new Error('Should have an integer video duration')
   return true
 }
 
-function isVideoTruncatedDescriptionValid (value: string) {
+function checkVideoTruncatedDescription (value: string) {
   return exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.TRUNCATED_DESCRIPTION)
 }
 
 /**
  * @throws {Error}
  */
-function isVideoDescriptionValid (value: string) {
+function checkVideoDescription (value: string) {
   if (value === null) return true
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.DESCRIPTION)) {
     const min = VIDEOS_CONSTRAINTS_FIELDS.DESCRIPTION.min
@@ -68,7 +95,7 @@ function isVideoDescriptionValid (value: string) {
 /**
  * @throws {Error}
  */
-function isVideoSupportValid (value: string) {
+function checkVideoSupport (value: string) {
   if (value === null) return true
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.SUPPORT)) {
     const min = VIDEOS_CONSTRAINTS_FIELDS.SUPPORT.min
@@ -81,7 +108,7 @@ function isVideoSupportValid (value: string) {
 /**
  * @throws {Error}
  */
-function isVideoNameValid (value: string) {
+function checkVideoName (value: string) {
   if (!exists(value)) throw new Error('Should have a video name')
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.NAME)) {
     const min = VIDEOS_CONSTRAINTS_FIELDS.NAME.min
@@ -94,7 +121,7 @@ function isVideoNameValid (value: string) {
 /**
  * @throws {Error}
  */
-function isVideoTagValid (tag: string) {
+function checkVideoTag (tag: string) {
   if (!exists(tag)) throw new Error('Should have a video tag value')
   if (!validator.isLength(tag, VIDEOS_CONSTRAINTS_FIELDS.TAG)) {
     const min = VIDEOS_CONSTRAINTS_FIELDS.TAG.min
@@ -107,7 +134,7 @@ function isVideoTagValid (tag: string) {
 /**
  * @throws {Error}
  */
-function isVideoTagsValid (tags: string[]) {
+function checkVideoTags (tags: string[]) {
   if (tags === null) return true
   if (!isArray(tags)) throw new Error('Should have an array of tags')
   if (!validator.isInt(tags.length.toString(), VIDEOS_CONSTRAINTS_FIELDS.TAGS)) {
@@ -115,7 +142,7 @@ function isVideoTagsValid (tags: string[]) {
     const max = VIDEOS_CONSTRAINTS_FIELDS.TAGS.max
     throw new Error(`Should have between ${min} and ${max} tags`)
   }
-  tags.forEach(tag => isVideoTagValid(tag)) // will throw with proper message
+  tags.forEach(tag => checkVideoTag(tag)) // will throw with proper message
   return true
 }
 
@@ -123,16 +150,24 @@ function isVideoViewsValid (value: string) {
   return exists(value) && validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.VIEWS)
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoRatingTypeValid (value: string) {
-  return value === 'none' || values(VIDEO_RATE_TYPES).includes(value as VideoRateType)
+  if (value === 'none') return true
+  if (!values(VIDEO_RATE_TYPES).includes(value as VideoRateType)) throw new Error('Should have a known video rate')
+  return true
 }
 
 function isVideoFileExtnameValid (value: string) {
   return exists(value) && (value === VIDEO_LIVE.EXTENSION || MIMETYPES.VIDEO.EXT_MIMETYPE[value] !== undefined)
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoFileMimeTypeValid (files: UploadFilesForCheck) {
-  return EtoB(isFileMimeTypeValid)(files, MIMETYPES.VIDEO.MIMETYPES_REGEX, 'videofile')
+  return isFileMimeTypeValid(files, MIMETYPES.VIDEO.MIMETYPES_REGEX, 'videofile')
 }
 
 const videoImageTypes = CONSTRAINTS_FIELDS.VIDEOS.IMAGE.EXTNAME
@@ -143,31 +178,38 @@ const videoImageTypesRegex = `image/(${videoImageTypes})`
 /**
  * @throws {Error}
  */
-function isVideoImage (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], field: string) {
+function checkVideoImage (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], field: string) {
   return isFileValid(files, videoImageTypesRegex, field, CONSTRAINTS_FIELDS.VIDEOS.IMAGE.FILE_SIZE.max, true)
-}
-
-function isVideoPrivacyValid (value: number) {
-  return VIDEO_PRIVACIES[value] !== undefined
 }
 
 /**
  * @throws {Error}
  */
-function isScheduleVideoUpdatePrivacyValid (value: number) {
+function isVideoPrivacyValid (value: number) {
+  if (VIDEO_PRIVACIES[value] === undefined) throw new Error('Should have a known video privacy policy')
+  return true
+}
+
+/**
+ * @throws {Error}
+ */
+function checkScheduleVideoUpdatePrivacy (value: number) {
   const valid = value === VideoPrivacy.UNLISTED || value === VideoPrivacy.PUBLIC || value === VideoPrivacy.INTERNAL
   if (!valid) throw new Error(`Should have a valid privacy: ${VideoPrivacy.UNLISTED}, ${VideoPrivacy.PUBLIC} or ${VideoPrivacy.INTERNAL}`)
   return true
 }
 
-function isVideoOriginallyPublishedAtValid (value: string | null) {
-  return value === null || isDateValid(value)
+/**
+ * @throws {Error}
+ */
+function checkVideoOriginallyPublishedAt (value: string | null) {
+  return value === null || checkDate(value)
 }
 
 /**
  * @throws {Error}
  */
-function isVideoFileInfoHashValid (value: string | null | undefined) {
+function checkVideoFileInfoHash (value: string | null | undefined) {
   if (!exists(value)) throw new Error('Should have a video file infohash')
   if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH)) {
     const min = VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH.min
@@ -185,15 +227,22 @@ function isVideoFPSResolutionValid (value: string) {
   return value === null || validator.isInt(value + '')
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoFileSizeValid (value: string) {
-  return exists(value) && validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.FILE_SIZE)
+  if (!exists(value)) throw new Error('')
+  if (!validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.FILE_SIZE)) {
+    throw new Error('This file is too large. It exceeds the maximum file size authorized.')
+  }
+  return true
 }
 
 function isVideoMagnetUriValid (value: string) {
   if (!exists(value)) return false
 
   const parsed = magnetUtil.decode(value)
-  return parsed && isVideoFileInfoHashValid(parsed.infoHash)
+  return parsed && checkVideoFileInfoHash(parsed.infoHash)
 }
 
 // ---------------------------------------------------------------------------
@@ -202,26 +251,26 @@ export {
   isVideoCategoryValid,
   isVideoLicenceValid,
   isVideoLanguageValid,
-  isVideoTruncatedDescriptionValid,
-  isVideoDescriptionValid,
-  isVideoFileInfoHashValid,
-  isVideoNameValid,
-  isVideoTagsValid,
+  checkVideoTruncatedDescription,
+  checkVideoDescription,
+  checkVideoFileInfoHash,
+  checkVideoName,
+  checkVideoTags,
   isVideoFPSResolutionValid,
-  isScheduleVideoUpdatePrivacyValid,
-  isVideoOriginallyPublishedAtValid,
+  checkScheduleVideoUpdatePrivacy,
+  checkVideoOriginallyPublishedAt,
   isVideoMagnetUriValid,
   isVideoStateValid,
   isVideoViewsValid,
   isVideoRatingTypeValid,
   isVideoFileExtnameValid,
   isVideoFileMimeTypeValid,
-  isVideoDurationValid,
-  isVideoTagValid,
+  checkVideoDuration,
+  checkVideoTag,
   isVideoPrivacyValid,
   isVideoFileResolutionValid,
   isVideoFileSizeValid,
-  isVideoImage,
-  isVideoSupportValid,
+  checkVideoImage,
+  checkVideoSupport,
   isVideoFilterValid
 }

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -13,7 +13,8 @@ import {
   VIDEO_RATE_TYPES,
   VIDEO_STATES
 } from '../../initializers/constants'
-import { exists, isArray, isDateValid, isFileMimeTypeValid, isFileValid } from './misc'
+import { EtoB, exists, isArray, isDateValid, isFileMimeTypeValid, isFileValid } from './misc'
+import * as magnetUtil from 'magnet-uri'
 
 const VIDEOS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.VIDEOS
 
@@ -131,7 +132,7 @@ function isVideoFileExtnameValid (value: string) {
 }
 
 function isVideoFileMimeTypeValid (files: UploadFilesForCheck) {
-  return isFileMimeTypeValid(files, MIMETYPES.VIDEO.MIMETYPES_REGEX, 'videofile')
+  return EtoB(isFileMimeTypeValid)(files, MIMETYPES.VIDEO.MIMETYPES_REGEX, 'videofile')
 }
 
 const videoImageTypes = CONSTRAINTS_FIELDS.VIDEOS.IMAGE.EXTNAME
@@ -139,6 +140,9 @@ const videoImageTypes = CONSTRAINTS_FIELDS.VIDEOS.IMAGE.EXTNAME
                                           .join('|')
 const videoImageTypesRegex = `image/(${videoImageTypes})`
 
+/**
+ * @throws {Error}
+ */
 function isVideoImage (files: { [ fieldname: string ]: Express.Multer.File[] } | Express.Multer.File[], field: string) {
   return isFileValid(files, videoImageTypesRegex, field, CONSTRAINTS_FIELDS.VIDEOS.IMAGE.FILE_SIZE.max, true)
 }

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -75,8 +75,17 @@ function checkVideoDuration (value: string) {
   return true
 }
 
+/**
+ * @throws {Error}
+ */
 function checkVideoTruncatedDescription (value: string) {
-  return exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.TRUNCATED_DESCRIPTION)
+  if (!exists(value)) throw new Error('Should have a video truncated description')
+  if (!validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.TRUNCATED_DESCRIPTION)) {
+    const min = VIDEOS_CONSTRAINTS_FIELDS.TRUNCATED_DESCRIPTION.min
+    const max = VIDEOS_CONSTRAINTS_FIELDS.TRUNCATED_DESCRIPTION.max
+    throw new Error(`Should have a video truncated description between ${min} and ${max} characters long`)
+  }
+  return true
 }
 
 /**
@@ -146,8 +155,15 @@ function checkVideoTags (tags: string[]) {
   return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoViewsValid (value: string) {
-  return exists(value) && validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.VIEWS)
+  if (!exists(value)) throw new Error('Should have a video views count')
+  if (!validator.isInt(value + '', VIDEOS_CONSTRAINTS_FIELDS.VIEWS)) {
+    throw new Error(`Should have a positive video view count`)
+  }
+  return true
 }
 
 /**
@@ -219,12 +235,22 @@ function checkVideoFileInfoHash (value: string | null | undefined) {
   return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoFileResolutionValid (value: string) {
-  return exists(value) && validator.isInt(value + '')
+  if (!exists(value)) throw new Error('Should have a video file resolution')
+  if (!validator.isInt(value + '')) throw new Error('Should have a video file resolution that is an integer')
+  return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoFPSResolutionValid (value: string) {
-  return value === null || validator.isInt(value + '')
+  if (value === null) return true
+  if (!validator.isInt(value + '')) throw new Error('Should have a video file resolution that is an integer')
+  return true
 }
 
 /**
@@ -238,11 +264,16 @@ function isVideoFileSizeValid (value: string) {
   return true
 }
 
+/**
+ * @throws {Error}
+ */
 function isVideoMagnetUriValid (value: string) {
-  if (!exists(value)) return false
+  if (!exists(value)) throw new Error('Should have a video magnetUri')
 
   const parsed = magnetUtil.decode(value)
-  return parsed && checkVideoFileInfoHash(parsed.infoHash)
+  if (parsed && checkVideoFileInfoHash(parsed.infoHash)) {
+    return true
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -128,16 +128,23 @@ function checkVideoViews (value: string) {
 }
 
 function checkVideoRatingType (value: string) {
-  if (value === 'none') return
+  if (value === 'none') return true
   if (!values(VIDEO_RATE_TYPES).includes(value as VideoRateType)) throw new Error('Should have a known video rate')
   return true
 }
 
-function isVideoFileExtnameValid (value: string) {
-  return exists(value) && (value === VIDEO_LIVE.EXTENSION || MIMETYPES.VIDEO.EXT_MIMETYPE[value] !== undefined)
+function checkVideoFileExtname (value: string) {
+  if (!exists(value)) throw new Error('Should have a video file extension')
+  if (value !== VIDEO_LIVE.EXTENSION && MIMETYPES.VIDEO.EXT_MIMETYPE[value] === undefined) {
+    throw new Error(
+      `Should have a ${values(MIMETYPES.VIDEO.EXT_MIMETYPE).join(',')} extension for regular videos ` +
+      `or a ${VIDEO_LIVE.EXTENSION} extension for lives`
+    )
+  }
+  return true
 }
 
-function isVideoFileMimeTypeValid (files: UploadFilesForCheck) {
+function checkVideoFileMimeType (files: UploadFilesForCheck) {
   return checkFileMimeType(files, MIMETYPES.VIDEO.MIMETYPES_REGEX, 'videofile')
 }
 
@@ -225,8 +232,8 @@ export {
   checkVideoState,
   checkVideoViews,
   checkVideoRatingType,
-  isVideoFileExtnameValid,
-  isVideoFileMimeTypeValid,
+  checkVideoFileExtname,
+  checkVideoFileMimeType,
   checkVideoDuration,
   checkVideoTag,
   checkVideoPrivacy,

--- a/server/helpers/youtube-dl.ts
+++ b/server/helpers/youtube-dl.ts
@@ -7,7 +7,7 @@ import { HttpStatusCode } from '../../shared/core-utils/miscs/http-error-codes'
 import { VideoResolution } from '../../shared/models/videos'
 import { CONSTRAINTS_FIELDS, VIDEO_CATEGORIES, VIDEO_LANGUAGES, VIDEO_LICENCES } from '../initializers/constants'
 import { peertubeTruncate, pipelinePromise, root } from './core-utils'
-import { isVideoFileExtnameValid } from './custom-validators/videos'
+import { checkVideoFileExtname } from './custom-validators/videos'
 import { logger } from './logger'
 import { generateVideoImportTmpPath } from './utils'
 
@@ -207,9 +207,7 @@ class YoutubeDL {
   }
 
   private async guessVideoPathWithExtension (tmpPath: string, sourceExt: string) {
-    if (!isVideoFileExtnameValid(sourceExt)) {
-      throw new Error('Invalid video extension ' + sourceExt)
-    }
+    checkVideoFileExtname(sourceExt)
 
     const extensions = [ sourceExt, '.mp4', '.mkv', '.webm' ]
 

--- a/server/lib/activitypub/videos.ts
+++ b/server/lib/activitypub/videos.ts
@@ -27,7 +27,7 @@ import {
   sanitizeAndCheckVideoTorrentObject
 } from '../../helpers/custom-validators/activitypub/videos'
 import { isArray } from '../../helpers/custom-validators/misc'
-import { isVideoFileInfoHashValid } from '../../helpers/custom-validators/videos'
+import { checkVideoFileInfoHash } from '../../helpers/custom-validators/videos'
 import { deleteNonExistingModels, resetSequelizeInstance, retryTransactionWrapper } from '../../helpers/database-utils'
 import { logger } from '../../helpers/logger'
 import { doJSONRequest, PeerTubeRequestError } from '../../helpers/requests'
@@ -804,7 +804,7 @@ function videoFileActivityUrlToDBAttributes (
     if (!magnet) throw new Error('Cannot find associated magnet uri for file ' + fileUrl.href)
 
     const parsed = magnetUtil.decode(magnet.href)
-    if (!parsed || isVideoFileInfoHashValid(parsed.infoHash) === false) {
+    if (!parsed || checkVideoFileInfoHash(parsed.infoHash) === false) {
       throw new Error('Cannot parse magnet URI ' + magnet.href)
     }
 

--- a/server/lib/activitypub/videos.ts
+++ b/server/lib/activitypub/videos.ts
@@ -26,7 +26,7 @@ import {
   isAPVideoTrackerUrlObject,
   sanitizeAndCheckVideoTorrentObject
 } from '../../helpers/custom-validators/activitypub/videos'
-import { isArray } from '../../helpers/custom-validators/misc'
+import { catchErrorAsBoolean, isArray } from '../../helpers/custom-validators/misc'
 import { checkVideoFileInfoHash } from '../../helpers/custom-validators/videos'
 import { deleteNonExistingModels, resetSequelizeInstance, retryTransactionWrapper } from '../../helpers/database-utils'
 import { logger } from '../../helpers/logger'
@@ -804,7 +804,7 @@ function videoFileActivityUrlToDBAttributes (
     if (!magnet) throw new Error('Cannot find associated magnet uri for file ' + fileUrl.href)
 
     const parsed = magnetUtil.decode(magnet.href)
-    if (!parsed || checkVideoFileInfoHash(parsed.infoHash) === false) {
+    if (!parsed || catchErrorAsBoolean(checkVideoFileInfoHash)(parsed.infoHash) === false) {
       throw new Error('Cannot parse magnet URI ' + magnet.href)
     }
 

--- a/server/lib/auth/external-auth.ts
+++ b/server/lib/auth/external-auth.ts
@@ -1,5 +1,5 @@
 
-import { catchError } from '@server/helpers/custom-validators/misc'
+import { EtoB } from '@server/helpers/custom-validators/misc'
 import { isUserDisplayNameValid, isUserRoleValid, isUserUsernameValid } from '@server/helpers/custom-validators/users'
 import { logger } from '@server/helpers/logger'
 import { generateRandomString } from '@server/helpers/utils'
@@ -173,7 +173,7 @@ function getBypassFromExternalAuth (username: string, externalAuthToken: string)
 }
 
 function isAuthResultValid (npmName: string, authName: string, result: RegisterServerAuthenticatedResult) {
-  if (!catchError(isUserUsernameValid)(result.username)) {
+  if (!EtoB(isUserUsernameValid)(result.username)) {
     logger.error('Auth method %s of plugin %s did not provide a valid username.', authName, npmName, { username: result.username })
     return false
   }

--- a/server/lib/auth/external-auth.ts
+++ b/server/lib/auth/external-auth.ts
@@ -1,5 +1,5 @@
 
-import { EtoB } from '@server/helpers/custom-validators/misc'
+import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
 import { isUserDisplayNameValid, isUserRoleValid, isUserUsernameValid } from '@server/helpers/custom-validators/users'
 import { logger } from '@server/helpers/logger'
 import { generateRandomString } from '@server/helpers/utils'
@@ -173,7 +173,7 @@ function getBypassFromExternalAuth (username: string, externalAuthToken: string)
 }
 
 function isAuthResultValid (npmName: string, authName: string, result: RegisterServerAuthenticatedResult) {
-  if (!EtoB(isUserUsernameValid)(result.username)) {
+  if (!catchErrorAsBoolean(isUserUsernameValid)(result.username)) {
     logger.error('Auth method %s of plugin %s did not provide a valid username.', authName, npmName, { username: result.username })
     return false
   }

--- a/server/lib/auth/external-auth.ts
+++ b/server/lib/auth/external-auth.ts
@@ -1,6 +1,6 @@
 
 import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
-import { checkUserDisplayName, isUserRoleValid, isUserUsernameValid } from '@server/helpers/custom-validators/users'
+import { checkUserDisplayName, isUserRoleValid, checkUserUsername } from '@server/helpers/custom-validators/users'
 import { logger } from '@server/helpers/logger'
 import { generateRandomString } from '@server/helpers/utils'
 import { PLUGIN_EXTERNAL_AUTH_TOKEN_LIFETIME } from '@server/initializers/constants'
@@ -173,7 +173,7 @@ function getBypassFromExternalAuth (username: string, externalAuthToken: string)
 }
 
 function isAuthResultValid (npmName: string, authName: string, result: RegisterServerAuthenticatedResult) {
-  if (!catchErrorAsBoolean(isUserUsernameValid)(result.username)) {
+  if (!catchErrorAsBoolean(checkUserUsername)(result.username)) {
     logger.error('Auth method %s of plugin %s did not provide a valid username.', authName, npmName, { username: result.username })
     return false
   }

--- a/server/lib/auth/external-auth.ts
+++ b/server/lib/auth/external-auth.ts
@@ -1,6 +1,6 @@
 
 import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
-import { checkUserDisplayName, isUserRoleValid, checkUserUsername } from '@server/helpers/custom-validators/users'
+import { checkUserDisplayName, checkUserRole, checkUserUsername } from '@server/helpers/custom-validators/users'
 import { logger } from '@server/helpers/logger'
 import { generateRandomString } from '@server/helpers/utils'
 import { PLUGIN_EXTERNAL_AUTH_TOKEN_LIFETIME } from '@server/initializers/constants'
@@ -184,7 +184,7 @@ function isAuthResultValid (npmName: string, authName: string, result: RegisterS
   }
 
   // role is optional
-  if (result.role && !isUserRoleValid(result.role)) {
+  if (result.role && !catchErrorAsBoolean(checkUserRole)(result.role)) {
     logger.error('Auth method %s of plugin %s did not provide a valid role.', authName, npmName, { role: result.role })
     return false
   }

--- a/server/lib/auth/external-auth.ts
+++ b/server/lib/auth/external-auth.ts
@@ -1,6 +1,6 @@
 
 import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
-import { isUserDisplayNameValid, isUserRoleValid, isUserUsernameValid } from '@server/helpers/custom-validators/users'
+import { checkUserDisplayName, isUserRoleValid, isUserUsernameValid } from '@server/helpers/custom-validators/users'
 import { logger } from '@server/helpers/logger'
 import { generateRandomString } from '@server/helpers/utils'
 import { PLUGIN_EXTERNAL_AUTH_TOKEN_LIFETIME } from '@server/initializers/constants'
@@ -190,7 +190,7 @@ function isAuthResultValid (npmName: string, authName: string, result: RegisterS
   }
 
   // display name is optional
-  if (result.displayName && !isUserDisplayNameValid(result.displayName)) {
+  if (result.displayName && !catchErrorAsBoolean(checkUserDisplayName)(result.displayName)) {
     logger.error(
       'Auth method %s of plugin %s did not provide a valid display name.',
       authName, npmName, { displayName: result.displayName }

--- a/server/lib/auth/external-auth.ts
+++ b/server/lib/auth/external-auth.ts
@@ -1,4 +1,5 @@
 
+import { catchError } from '@server/helpers/custom-validators/misc'
 import { isUserDisplayNameValid, isUserRoleValid, isUserUsernameValid } from '@server/helpers/custom-validators/users'
 import { logger } from '@server/helpers/logger'
 import { generateRandomString } from '@server/helpers/utils'
@@ -172,7 +173,7 @@ function getBypassFromExternalAuth (username: string, externalAuthToken: string)
 }
 
 function isAuthResultValid (npmName: string, authName: string, result: RegisterServerAuthenticatedResult) {
-  if (!isUserUsernameValid(result.username)) {
+  if (!catchError(isUserUsernameValid)(result.username)) {
     logger.error('Auth method %s of plugin %s did not provide a valid username.', authName, npmName, { username: result.username })
     return false
   }

--- a/server/lib/peertube-socket.ts
+++ b/server/lib/peertube-socket.ts
@@ -5,7 +5,7 @@ import { UserNotificationModelForApi } from '@server/types/models/user'
 import { LiveVideoEventPayload, LiveVideoEventType } from '@shared/models'
 import { logger } from '../helpers/logger'
 import { authenticateSocket } from '../middlewares'
-import { isIdValid } from '@server/helpers/custom-validators/misc'
+import { checkId } from '@server/helpers/custom-validators/misc'
 
 class PeerTubeSocket {
 
@@ -41,7 +41,7 @@ class PeerTubeSocket {
       .on('connection', socket => {
         socket.on('subscribe', ({ videoId }) => {
           try {
-            isIdValid(videoId)
+            checkId(videoId)
           } catch {
             return
           }
@@ -52,7 +52,7 @@ class PeerTubeSocket {
 
         socket.on('unsubscribe', ({ videoId }) => {
           try {
-            isIdValid(videoId)
+            checkId(videoId)
           } catch {
             return
           }

--- a/server/lib/peertube-socket.ts
+++ b/server/lib/peertube-socket.ts
@@ -40,14 +40,22 @@ class PeerTubeSocket {
     this.liveVideosNamespace = io.of('/live-videos')
       .on('connection', socket => {
         socket.on('subscribe', ({ videoId }) => {
-          if (!isIdValid(videoId)) return
+          try {
+            isIdValid(videoId)
+          } catch {
+            return
+          }
 
           /* eslint-disable @typescript-eslint/no-floating-promises */
           socket.join(videoId)
         })
 
         socket.on('unsubscribe', ({ videoId }) => {
-          if (!isIdValid(videoId)) return
+          try {
+            isIdValid(videoId)
+          } catch {
+            return
+          }
 
           /* eslint-disable @typescript-eslint/no-floating-promises */
           socket.leave(videoId)

--- a/server/lib/plugins/plugin-helpers-builder.ts
+++ b/server/lib/plugins/plugin-helpers-builder.ts
@@ -104,8 +104,8 @@ function buildModerationHelpers () {
       await removeServerFromBlocklist(serverBlock)
     },
 
-    blockAccount: async (options: { byAccountId: number, handleToBlock: string }) => {
-      const accountToBlock = await AccountModel.loadByNameWithHost(options.handleToBlock)
+    blockAccount: async (options: { byAccountId: number, handlcatchErrorAsBooleanlock: string }) => {
+      const accountToBlock = await AccountModel.loadByNameWithHost(options.handlcatchErrorAsBooleanlock)
       if (!accountToBlock) return
 
       await addAccountInBlocklist(options.byAccountId, accountToBlock.id)

--- a/server/lib/redis.ts
+++ b/server/lib/redis.ts
@@ -143,7 +143,7 @@ class Redis {
   /* ************ API cache ************ */
 
   async getCachedRoute (req: express.Request) {
-    const cached = await this.getObject(this.generateCachedRouteKey(req))
+    const cached = await this.gcatchErrorAsBooleanject(this.generateCachedRouteKey(req))
 
     return cached as CachedRoute
   }
@@ -156,7 +156,7 @@ class Redis {
       (statusCode) ? { statusCode: statusCode.toString() } : null
     )
 
-    return this.setObject(this.generateCachedRouteKey(req), cached, lifetime)
+    return this.scatchErrorAsBooleanject(this.generateCachedRouteKey(req), cached, lifetime)
   }
 
   /* ************ Video views ************ */
@@ -308,7 +308,7 @@ class Redis {
     })
   }
 
-  private setObject (key: string, obj: { [id: string]: string }, expirationMilliseconds: number) {
+  private scatchErrorAsBooleanject (key: string, obj: { [id: string]: string }, expirationMilliseconds: number) {
     return new Promise<void>((res, rej) => {
       this.client.hmset(this.prefix + key, obj, (err, ok) => {
         if (err) return rej(err)
@@ -324,7 +324,7 @@ class Redis {
     })
   }
 
-  private getObject (key: string) {
+  private gcatchErrorAsBooleanject (key: string) {
     return new Promise<{ [id: string]: string }>((res, rej) => {
       this.client.hgetall(this.prefix + key, (err, value) => {
         if (err) return rej(err)

--- a/server/middlewares/validators/abuse.ts
+++ b/server/middlewares/validators/abuse.ts
@@ -12,7 +12,7 @@ import {
   isAbuseTimestampValid,
   isAbuseVideoIsValid
 } from '@server/helpers/custom-validators/abuses'
-import { exists, isIdOrUUIDValid, isIdValid, toIntOrNull } from '@server/helpers/custom-validators/misc'
+import { exists, checkIdOrUUID, checkId, toIntOrNull } from '@server/helpers/custom-validators/misc'
 import { doesCommentIdExist } from '@server/helpers/custom-validators/video-comments'
 import { logger } from '@server/helpers/logger'
 import { doesAbuseExist, doesAccountIdExist, doesVideoExist } from '@server/helpers/middlewares'
@@ -24,11 +24,11 @@ import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-code
 const abuseReportValidator = [
   body('account.id')
     .optional()
-    .custom(isIdValid),
+    .custom(checkId),
 
   body('video.id')
     .optional()
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   body('video.startAt')
     .optional()
     .customSanitizer(toIntOrNull)
@@ -45,7 +45,7 @@ const abuseReportValidator = [
 
   body('comment.id')
     .optional()
-    .custom(isIdValid),
+    .custom(checkId),
   body('reason')
     .custom(isAbuseReasonValid)
     .withMessage('Should have a valid reason'),
@@ -79,7 +79,7 @@ const abuseReportValidator = [
 
 const abuseGetValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking abuseGetValidator parameters', { parameters: req.body })
@@ -93,7 +93,7 @@ const abuseGetValidator = [
 
 const abuseUpdateValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   body('state')
     .optional()
@@ -115,7 +115,7 @@ const abuseUpdateValidator = [
 const abuseListForAdminsValidator = [
   query('id')
     .optional()
-    .custom(isIdValid),
+    .custom(checkId),
   query('filter')
     .optional()
     .custom(isAbuseFilterValid)
@@ -158,7 +158,7 @@ const abuseListForAdminsValidator = [
 const abuseListForUserValidator = [
   query('id')
     .optional()
-    .custom(isIdValid),
+    .custom(checkId),
   query('search')
     .optional()
     .custom(exists).withMessage('Should have a valid search'),
@@ -177,7 +177,7 @@ const abuseListForUserValidator = [
 
 const getAbuseValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking getAbuseValidator parameters', { parameters: req.body })
@@ -230,7 +230,7 @@ const addAbuseMessageValidator = [
 
 const deleteAbuseMessageValidator = [
   param('messageId')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking deleteAbuseMessageValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/abuse.ts
+++ b/server/middlewares/validators/abuse.ts
@@ -24,13 +24,11 @@ import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-code
 const abuseReportValidator = [
   body('account.id')
     .optional()
-    .custom(isIdValid)
-    .withMessage('Should have a valid accountId'),
+    .custom(isIdValid),
 
   body('video.id')
     .optional()
-    .custom(isIdOrUUIDValid)
-    .withMessage('Should have a valid videoId'),
+    .custom(isIdOrUUIDValid),
   body('video.startAt')
     .optional()
     .customSanitizer(toIntOrNull)
@@ -47,9 +45,7 @@ const abuseReportValidator = [
 
   body('comment.id')
     .optional()
-    .custom(isIdValid)
-    .withMessage('Should have a valid commentId'),
-
+    .custom(isIdValid),
   body('reason')
     .custom(isAbuseReasonValid)
     .withMessage('Should have a valid reason'),
@@ -82,7 +78,8 @@ const abuseReportValidator = [
 ]
 
 const abuseGetValidator = [
-  param('id').custom(isIdValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking abuseGetValidator parameters', { parameters: req.body })
@@ -95,7 +92,8 @@ const abuseGetValidator = [
 ]
 
 const abuseUpdateValidator = [
-  param('id').custom(isIdValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdValid),
 
   body('state')
     .optional()
@@ -117,7 +115,7 @@ const abuseUpdateValidator = [
 const abuseListForAdminsValidator = [
   query('id')
     .optional()
-    .custom(isIdValid).withMessage('Should have a valid id'),
+    .custom(isIdValid),
   query('filter')
     .optional()
     .custom(isAbuseFilterValid)
@@ -160,12 +158,10 @@ const abuseListForAdminsValidator = [
 const abuseListForUserValidator = [
   query('id')
     .optional()
-    .custom(isIdValid).withMessage('Should have a valid id'),
-
+    .custom(isIdValid),
   query('search')
     .optional()
     .custom(exists).withMessage('Should have a valid search'),
-
   query('state')
     .optional()
     .custom(isAbuseStateValid).withMessage('Should have a valid abuse state'),
@@ -180,7 +176,8 @@ const abuseListForUserValidator = [
 ]
 
 const getAbuseValidator = [
-  param('id').custom(isIdValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking getAbuseValidator parameters', { parameters: req.body })
@@ -232,7 +229,8 @@ const addAbuseMessageValidator = [
 ]
 
 const deleteAbuseMessageValidator = [
-  param('messageId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid message id'),
+  param('messageId')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking deleteAbuseMessageValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/account.ts
+++ b/server/middlewares/validators/account.ts
@@ -6,7 +6,8 @@ import { areValidationErrors } from './utils'
 import { doesAccountNameWithHostExist, doesLocalAccountNameExist } from '../../helpers/middlewares'
 
 const localAccountValidator = [
-  param('name').custom(isAccountNameValid).withMessage('Should have a valid account name'),
+  param('name')
+    .custom(isAccountNameValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking localAccountValidator parameters', { parameters: req.params })

--- a/server/middlewares/validators/account.ts
+++ b/server/middlewares/validators/account.ts
@@ -1,13 +1,13 @@
 import * as express from 'express'
 import { param } from 'express-validator'
-import { isAccountNameValid } from '../../helpers/custom-validators/accounts'
+import { checkAccountName } from '../../helpers/custom-validators/accounts'
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 import { doesAccountNameWithHostExist, doesLocalAccountNameExist } from '../../helpers/middlewares'
 
 const localAccountValidator = [
   param('name')
-    .custom(isAccountNameValid),
+    .custom(checkAccountName),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking localAccountValidator parameters', { parameters: req.params })
@@ -20,7 +20,8 @@ const localAccountValidator = [
 ]
 
 const accountNameWithHostGetValidator = [
-  param('accountName').exists().withMessage('Should have an account name with host'),
+  param('accountName')
+    .exists().withMessage('Should have an account name with host'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking accountsNameWithHostGetValidator parameters', { parameters: req.params })

--- a/server/middlewares/validators/activitypub/signature.ts
+++ b/server/middlewares/validators/activitypub/signature.ts
@@ -1,8 +1,8 @@
 import * as express from 'express'
 import { body } from 'express-validator'
 import {
-  isSignatureCreatorValid, isSignatureTypeValid,
-  isSignatureValueValid
+  checkSignatureCreator, checkSignatureType,
+  checkSignatureValue
 } from '../../../helpers/custom-validators/activitypub/signature'
 import { checkDate } from '../../../helpers/custom-validators/misc'
 import { logger } from '../../../helpers/logger'
@@ -11,16 +11,16 @@ import { areValidationErrors } from '../utils'
 const signatureValidator = [
   body('signature.type')
     .optional()
-    .custom(isSignatureTypeValid).withMessage('Should have a valid signature type'),
+    .custom(checkSignatureType),
   body('signature.created')
     .optional()
-    .custom(checkDate).withMessage('Should have a valid signature created date'),
+    .custom(checkDate),
   body('signature.creator')
     .optional()
-    .custom(isSignatureCreatorValid).withMessage('Should have a valid signature creator'),
+    .custom(checkSignatureCreator),
   body('signature.signatureValue')
     .optional()
-    .custom(isSignatureValueValid).withMessage('Should have a valid signature value'),
+    .custom(checkSignatureValue),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking Linked Data Signature parameter', { parameters: { signature: req.body.signature } })

--- a/server/middlewares/validators/activitypub/signature.ts
+++ b/server/middlewares/validators/activitypub/signature.ts
@@ -4,7 +4,7 @@ import {
   isSignatureCreatorValid, isSignatureTypeValid,
   isSignatureValueValid
 } from '../../../helpers/custom-validators/activitypub/signature'
-import { isDateValid } from '../../../helpers/custom-validators/misc'
+import { checkDate } from '../../../helpers/custom-validators/misc'
 import { logger } from '../../../helpers/logger'
 import { areValidationErrors } from '../utils'
 
@@ -14,7 +14,7 @@ const signatureValidator = [
     .custom(isSignatureTypeValid).withMessage('Should have a valid signature type'),
   body('signature.created')
     .optional()
-    .custom(isDateValid).withMessage('Should have a valid signature created date'),
+    .custom(checkDate).withMessage('Should have a valid signature created date'),
   body('signature.creator')
     .optional()
     .custom(isSignatureCreatorValid).withMessage('Should have a valid signature creator'),

--- a/server/middlewares/validators/actor-image.ts
+++ b/server/middlewares/validators/actor-image.ts
@@ -3,14 +3,11 @@ import { body } from 'express-validator'
 import { checkActorImageFile } from '@server/helpers/custom-validators/actor-images'
 import { cleanUpReqFiles } from '../../helpers/express-utils'
 import { logger } from '../../helpers/logger'
-import { CONSTRAINTS_FIELDS } from '../../initializers/constants'
 import { areValidationErrors } from './utils'
 
 const updateActorImageValidatorFactory = (fieldname: string) => ([
-  body(fieldname).custom((value, { req }) => checkActorImageFile(req.files, fieldname)).withMessage(
-    'This file is not supported or too large. Please, make sure it is of the following type : ' +
-    CONSTRAINTS_FIELDS.ACTORS.IMAGE.EXTNAME.join(', ')
-  ),
+  body(fieldname)
+    .custom((value, { req }) => checkActorImageFile(req.files, fieldname)),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking updateActorImageValidator parameters', { files: req.files })

--- a/server/middlewares/validators/actor-image.ts
+++ b/server/middlewares/validators/actor-image.ts
@@ -1,13 +1,13 @@
 import * as express from 'express'
 import { body } from 'express-validator'
-import { isActorImageFile } from '@server/helpers/custom-validators/actor-images'
+import { checkActorImageFile } from '@server/helpers/custom-validators/actor-images'
 import { cleanUpReqFiles } from '../../helpers/express-utils'
 import { logger } from '../../helpers/logger'
 import { CONSTRAINTS_FIELDS } from '../../initializers/constants'
 import { areValidationErrors } from './utils'
 
 const updateActorImageValidatorFactory = (fieldname: string) => ([
-  body(fieldname).custom((value, { req }) => isActorImageFile(req.files, fieldname)).withMessage(
+  body(fieldname).custom((value, { req }) => checkActorImageFile(req.files, fieldname)).withMessage(
     'This file is not supported or too large. Please, make sure it is of the following type : ' +
     CONSTRAINTS_FIELDS.ACTORS.IMAGE.EXTNAME.join(', ')
   ),

--- a/server/middlewares/validators/blocklist.ts
+++ b/server/middlewares/validators/blocklist.ts
@@ -3,7 +3,7 @@ import * as express from 'express'
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 import { AccountBlocklistModel } from '../../models/account/account-blocklist'
-import { isHostValid } from '../../helpers/custom-validators/servers'
+import { checkHost } from '../../helpers/custom-validators/servers'
 import { ServerBlocklistModel } from '../../models/server/server-blocklist'
 import { ServerModel } from '../../models/server/server'
 import { WEBSERVER } from '../../initializers/constants'
@@ -69,7 +69,8 @@ const unblockAccountByServerValidator = [
 ]
 
 const blockServerValidator = [
-  body('host').custom(isHostValid).withMessage('Should have a valid host'),
+  body('host')
+    .custom(checkHost),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking serverGetValidator parameters', { parameters: req.body })
@@ -92,7 +93,8 @@ const blockServerValidator = [
 ]
 
 const unblockServerByAccountValidator = [
-  param('host').custom(isHostValid).withMessage('Should have an account name with host'),
+  param('host')
+    .custom(checkHost),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking unblockServerByAccountValidator parameters', { parameters: req.params })
@@ -107,7 +109,8 @@ const unblockServerByAccountValidator = [
 ]
 
 const unblockServerByServerValidator = [
-  param('host').custom(isHostValid).withMessage('Should have an account name with host'),
+  param('host')
+    .custom(checkHost),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking unblockServerByServerValidator parameters', { parameters: req.params })

--- a/server/middlewares/validators/bulk.ts
+++ b/server/middlewares/validators/bulk.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { body } from 'express-validator'
-import { isBulkRemoveCommentsOfScopeValid } from '@server/helpers/custom-validators/bulk'
+import { checkBulkRemoveCommentsOfScope } from '@server/helpers/custom-validators/bulk'
 import { doesAccountNameWithHostExist } from '@server/helpers/middlewares'
 import { UserRight } from '@shared/models'
 import { BulkRemoveCommentsOfBody } from '@shared/models/bulk/bulk-remove-comments-of-body.model'
@@ -9,9 +9,10 @@ import { areValidationErrors } from './utils'
 import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
 
 const bulkRemoveCommentsOfValidator = [
-  body('accountName').exists().withMessage('Should have an account name with host'),
+  body('accountName')
+    .exists().withMessage('Should have an account name with host'),
   body('scope')
-    .custom(isBulkRemoveCommentsOfScopeValid).withMessage('Should have a valid scope'),
+    .custom(checkBulkRemoveCommentsOfScope),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking bulkRemoveCommentsOfValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/config.ts
+++ b/server/middlewares/validators/config.ts
@@ -5,7 +5,7 @@ import { isEmailEnabled } from '@server/initializers/config'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 import { CustomConfig } from '../../../shared/models/server/custom-config.model'
 import { isThemeNameValid } from '../../helpers/custom-validators/plugins'
-import { isUserNSFWPolicyValid, isUserVideoQuotaDailyValid, isUserVideoQuotaValid } from '../../helpers/custom-validators/users'
+import { isUserNSFWPolicyValid, checkUserVideoQuotaDaily, checkUserVideoQuota } from '../../helpers/custom-validators/users'
 import { logger } from '../../helpers/logger'
 import { isThemeRegistered } from '../../lib/plugins/theme-utils'
 import { areValidationErrors } from './utils'
@@ -34,8 +34,8 @@ const customConfigUpdateValidator = [
   body('admin.email').isEmail().withMessage('Should have a valid administrator email'),
   body('contactForm.enabled').isBoolean().withMessage('Should have a valid contact form enabled boolean'),
 
-  body('user.videoQuota').custom(isUserVideoQuotaValid).withMessage('Should have a valid video quota'),
-  body('user.videoQuotaDaily').custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily video quota'),
+  body('user.videoQuota').custom(checkUserVideoQuota),
+  body('user.videoQuotaDaily').custom(checkUserVideoQuotaDaily),
 
   body('transcoding.enabled').isBoolean().withMessage('Should have a valid transcoding enabled boolean'),
   body('transcoding.allowAdditionalExtensions').isBoolean().withMessage('Should have a valid additional extensions boolean'),

--- a/server/middlewares/validators/feeds.ts
+++ b/server/middlewares/validators/feeds.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { param, query } from 'express-validator'
-import { isValidRSSFeed } from '../../helpers/custom-validators/feeds'
+import { checkRSSFeedFormat } from '../../helpers/custom-validators/feeds'
 import { exists, checkIdOrUUID, checkId } from '../../helpers/custom-validators/misc'
 import { logger } from '../../helpers/logger'
 import {
@@ -15,8 +15,10 @@ import { areValidationErrors } from './utils'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 
 const feedsFormatValidator = [
-  param('format').optional().custom(isValidRSSFeed).withMessage('Should have a valid format (rss, atom, json)'),
-  query('format').optional().custom(isValidRSSFeed).withMessage('Should have a valid format (rss, atom, json)')
+  param('format')
+    .optional().custom(checkRSSFeedFormat),
+  query('format')
+    .optional().custom(checkRSSFeedFormat)
 ]
 
 function setFeedFormatContentType (req: express.Request, res: express.Response, next: express.NextFunction) {

--- a/server/middlewares/validators/feeds.ts
+++ b/server/middlewares/validators/feeds.ts
@@ -48,17 +48,12 @@ function setFeedFormatContentType (req: express.Request, res: express.Response, 
 const videoFeedsValidator = [
   query('accountId')
     .optional()
-    .custom(isIdValid)
-    .withMessage('Should have a valid account id'),
-
+    .custom(isIdValid),
   query('accountName')
     .optional(),
-
   query('videoChannelId')
     .optional()
-    .custom(isIdValid)
-    .withMessage('Should have a valid channel id'),
-
+    .custom(isIdValid),
   query('videoChannelName')
     .optional(),
 
@@ -78,9 +73,7 @@ const videoFeedsValidator = [
 
 const videoSubscriptionFeedsValidator = [
   query('accountId')
-    .custom(isIdValid)
-    .withMessage('Should have a valid account id'),
-
+    .custom(isIdValid),
   query('token')
     .custom(exists)
     .withMessage('Should have a token'),
@@ -98,7 +91,9 @@ const videoSubscriptionFeedsValidator = [
 ]
 
 const videoCommentsFeedsValidator = [
-  query('videoId').optional().custom(isIdOrUUIDValid),
+  query('videoId')
+    .optional()
+    .custom(isIdOrUUIDValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking feeds parameters', { parameters: req.query })

--- a/server/middlewares/validators/feeds.ts
+++ b/server/middlewares/validators/feeds.ts
@@ -1,7 +1,7 @@
 import * as express from 'express'
 import { param, query } from 'express-validator'
 import { isValidRSSFeed } from '../../helpers/custom-validators/feeds'
-import { exists, isIdOrUUIDValid, isIdValid } from '../../helpers/custom-validators/misc'
+import { exists, checkIdOrUUID, checkId } from '../../helpers/custom-validators/misc'
 import { logger } from '../../helpers/logger'
 import {
   doesAccountIdExist,
@@ -48,12 +48,12 @@ function setFeedFormatContentType (req: express.Request, res: express.Response, 
 const videoFeedsValidator = [
   query('accountId')
     .optional()
-    .custom(isIdValid),
+    .custom(checkId),
   query('accountName')
     .optional(),
   query('videoChannelId')
     .optional()
-    .custom(isIdValid),
+    .custom(checkId),
   query('videoChannelName')
     .optional(),
 
@@ -73,7 +73,7 @@ const videoFeedsValidator = [
 
 const videoSubscriptionFeedsValidator = [
   query('accountId')
-    .custom(isIdValid),
+    .custom(checkId),
   query('token')
     .custom(exists)
     .withMessage('Should have a token'),
@@ -93,7 +93,7 @@ const videoSubscriptionFeedsValidator = [
 const videoCommentsFeedsValidator = [
   query('videoId')
     .optional()
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking feeds parameters', { parameters: req.query })

--- a/server/middlewares/validators/follows.ts
+++ b/server/middlewares/validators/follows.ts
@@ -1,12 +1,12 @@
 import * as express from 'express'
 import { body, param, query } from 'express-validator'
-import { isFollowStateValid } from '@server/helpers/custom-validators/follows'
+import { checkFollowState } from '@server/helpers/custom-validators/follows'
 import { getServerActor } from '@server/models/application/application'
 import { MActorFollowActorsDefault } from '@server/types/models'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 import { isTestInstance } from '../../helpers/core-utils'
 import { isActorTypeValid, isValidActorHandle } from '../../helpers/custom-validators/activitypub/actor'
-import { isEachUniqueHostValid, isHostValid } from '../../helpers/custom-validators/servers'
+import { isEachUniqueHostValid, checkHost } from '../../helpers/custom-validators/servers'
 import { logger } from '../../helpers/logger'
 import { loadActorUrlOrGetFromWebfinger } from '../../helpers/webfinger'
 import { SERVER_ACTOR_NAME, WEBSERVER } from '../../initializers/constants'
@@ -17,7 +17,7 @@ import { areValidationErrors } from './utils'
 const listFollowsValidator = [
   query('state')
     .optional()
-    .custom(isFollowStateValid).withMessage('Should have a valid follow state'),
+    .custom(checkFollowState),
   query('actorType')
     .optional()
     .custom(isActorTypeValid).withMessage('Should have a valid actor type'),
@@ -52,7 +52,8 @@ const followValidator = [
 ]
 
 const removeFollowingValidator = [
-  param('host').custom(isHostValid).withMessage('Should have a valid host'),
+  param('host')
+    .custom(checkHost),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking unfollowing parameters', { parameters: req.params })

--- a/server/middlewares/validators/jobs.ts
+++ b/server/middlewares/validators/jobs.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { param, query } from 'express-validator'
-import { isValidJobState, isValidJobType } from '../../helpers/custom-validators/jobs'
+import { checkJobState, checkJobType } from '../../helpers/custom-validators/jobs'
 import { logger, loggerTagsFactory } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 
@@ -9,11 +9,11 @@ const lTags = loggerTagsFactory('validators', 'jobs')
 const listJobsValidator = [
   param('state')
   .optional()
-  .custom(isValidJobState).not().isEmpty().withMessage('Should have a valid job state'),
+  .custom(checkJobState),
 
   query('jobType')
     .optional()
-    .custom(isValidJobType).withMessage('Should have a valid job state'),
+    .custom(checkJobType),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listJobsValidator parameters.', { parameters: req.params, ...lTags() })

--- a/server/middlewares/validators/logs.ts
+++ b/server/middlewares/validators/logs.ts
@@ -1,19 +1,19 @@
 import * as express from 'express'
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
-import { isDateValid } from '../../helpers/custom-validators/misc'
+import { checkDate } from '../../helpers/custom-validators/misc'
 import { query } from 'express-validator'
 import { isValidLogLevel } from '../../helpers/custom-validators/logs'
 
 const getLogsValidator = [
   query('startDate')
-    .custom(isDateValid).withMessage('Should have a valid start date'),
+    .custom(checkDate).withMessage('Should have a valid start date'),
   query('level')
     .optional()
     .custom(isValidLogLevel).withMessage('Should have a valid level'),
   query('endDate')
     .optional()
-    .custom(isDateValid).withMessage('Should have a valid end date'),
+    .custom(checkDate).withMessage('Should have a valid end date'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking getLogsValidator parameters.', { parameters: req.query })
@@ -26,10 +26,10 @@ const getLogsValidator = [
 
 const getAuditLogsValidator = [
   query('startDate')
-    .custom(isDateValid).withMessage('Should have a valid start date'),
+    .custom(checkDate).withMessage('Should have a valid start date'),
   query('endDate')
     .optional()
-    .custom(isDateValid).withMessage('Should have a valid end date'),
+    .custom(checkDate).withMessage('Should have a valid end date'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking getAuditLogsValidator parameters.', { parameters: req.query })

--- a/server/middlewares/validators/logs.ts
+++ b/server/middlewares/validators/logs.ts
@@ -3,14 +3,14 @@ import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 import { checkDate } from '../../helpers/custom-validators/misc'
 import { query } from 'express-validator'
-import { isValidLogLevel } from '../../helpers/custom-validators/logs'
+import { checkLogLevel } from '../../helpers/custom-validators/logs'
 
 const getLogsValidator = [
   query('startDate')
-    .custom(checkDate).withMessage('Should have a valid start date'),
+    .custom(checkDate),
   query('level')
     .optional()
-    .custom(isValidLogLevel).withMessage('Should have a valid level'),
+    .custom(checkLogLevel),
   query('endDate')
     .optional()
     .custom(checkDate).withMessage('Should have a valid end date'),

--- a/server/middlewares/validators/oembed.ts
+++ b/server/middlewares/validators/oembed.ts
@@ -26,10 +26,17 @@ if (isTestInstance()) {
 }
 
 const oembedValidator = [
-  query('url').isURL(isURLOptions).withMessage('Should have a valid url'),
-  query('maxwidth').optional().isInt().withMessage('Should have a valid max width'),
-  query('maxheight').optional().isInt().withMessage('Should have a valid max height'),
-  query('format').optional().isIn([ 'xml', 'json' ]).withMessage('Should have a valid format'),
+  query('url')
+    .isURL(isURLOptions).withMessage('Should have a valid url'),
+  query('maxwidth')
+    .optional()
+    .isInt().withMessage('Should have a valid max width'),
+  query('maxheight')
+    .optional()
+    .isInt().withMessage('Should have a valid max height'),
+  query('format')
+    .optional()
+    .isIn([ 'xml', 'json' ]).withMessage('Should have a valid format'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking oembed parameters', { parameters: req.query })
@@ -56,9 +63,10 @@ const oembedValidator = [
     }
 
     const elementId = matches[1]
-    if (isIdOrUUIDValid(elementId) === false) {
-      return res.status(HttpStatusCode.BAD_REQUEST_400)
-        .json({ error: 'Invalid video or playlist id.' })
+    try {
+      isIdOrUUIDValid(elementId)
+    } catch (error) {
+      return res.status(HttpStatusCode.BAD_REQUEST_400).json({ error })
     }
 
     if (isVideo) {

--- a/server/middlewares/validators/oembed.ts
+++ b/server/middlewares/validators/oembed.ts
@@ -5,7 +5,7 @@ import { fetchVideo } from '@server/helpers/video'
 import { VideoPlaylistModel } from '@server/models/video/video-playlist'
 import { VideoPlaylistPrivacy, VideoPrivacy } from '@shared/models'
 import { isTestInstance } from '../../helpers/core-utils'
-import { isIdOrUUIDValid } from '../../helpers/custom-validators/misc'
+import { checkIdOrUUID } from '../../helpers/custom-validators/misc'
 import { logger } from '../../helpers/logger'
 import { WEBSERVER } from '../../initializers/constants'
 import { areValidationErrors } from './utils'
@@ -64,7 +64,7 @@ const oembedValidator = [
 
     const elementId = matches[1]
     try {
-      isIdOrUUIDValid(elementId)
+      checkIdOrUUID(elementId)
     } catch (error) {
       return res.status(HttpStatusCode.BAD_REQUEST_400).json({ error })
     }

--- a/server/middlewares/validators/plugins.ts
+++ b/server/middlewares/validators/plugins.ts
@@ -3,7 +3,7 @@ import { body, param, query, ValidationChain } from 'express-validator'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 import { PluginType } from '../../../shared/models/plugins/plugin.type'
 import { InstallOrUpdatePlugin } from '../../../shared/models/plugins/server/api/install-plugin.model'
-import { exists, isBooleanValid, isSafePath, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
+import { exists, isBooleanValid, checkSafePath, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
 import { isNpmPluginNameValid, isPluginNameValid, isPluginTypeValid, isPluginVersionValid } from '../../helpers/custom-validators/plugins'
 import { logger } from '../../helpers/logger'
 import { CONFIG } from '../../initializers/config'
@@ -62,7 +62,7 @@ const getExternalAuthValidator = [
 ]
 
 const pluginStaticDirectoryValidator = [
-  param('staticEndpoint').custom(isSafePath).withMessage('Should have a valid static endpoint'),
+  param('staticEndpoint').custom(checkSafePath).withMessage('Should have a valid static endpoint'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking pluginStaticDirectoryValidator parameters', { parameters: req.params })
@@ -98,7 +98,7 @@ const installOrUpdatePluginValidator = [
     .custom(isNpmPluginNameValid).withMessage('Should have a valid npm name'),
   body('path')
     .optional()
-    .custom(isSafePath).withMessage('Should have a valid safe path'),
+    .custom(checkSafePath).withMessage('Should have a valid safe path'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking installOrUpdatePluginValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/redundancy.ts
+++ b/server/middlewares/validators/redundancy.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { body, param, query } from 'express-validator'
-import { exists, isBooleanValid, isIdOrUUIDValid, isIdValid, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
+import { exists, isBooleanValid, checkIdOrUUID, checkId, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 import { VideoRedundancyModel } from '../../models/redundancy/video-redundancy'
@@ -12,7 +12,7 @@ import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-code
 
 const videoFileRedundancyGetValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   param('resolution')
     .customSanitizer(toIntOrNull)
     .custom(exists).withMessage('Should have a valid resolution'),
@@ -49,7 +49,7 @@ const videoFileRedundancyGetValidator = [
 
 const videoPlaylistRedundancyGetValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   param('streamingPlaylistType')
     .customSanitizer(toIntOrNull)
     .custom(exists).withMessage('Should have a valid streaming playlist type'),
@@ -118,7 +118,7 @@ const listVideoRedundanciesValidator = [
 
 const addVideoRedundancyValidator = [
   body('videoId')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking addVideoRedundancyValidator parameters', { parameters: req.query })
@@ -149,7 +149,7 @@ const addVideoRedundancyValidator = [
 
 const removeVideoRedundancyValidator = [
   param('redundancyId')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking removeVideoRedundancyValidator parameters', { parameters: req.query })

--- a/server/middlewares/validators/redundancy.ts
+++ b/server/middlewares/validators/redundancy.ts
@@ -11,7 +11,8 @@ import { isVideoRedundancyTarget } from '@server/helpers/custom-validators/video
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 
 const videoFileRedundancyGetValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid video id'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
   param('resolution')
     .customSanitizer(toIntOrNull)
     .custom(exists).withMessage('Should have a valid resolution'),
@@ -48,8 +49,7 @@ const videoFileRedundancyGetValidator = [
 
 const videoPlaylistRedundancyGetValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid)
-    .not().isEmpty().withMessage('Should have a valid video id'),
+    .custom(isIdOrUUIDValid),
   param('streamingPlaylistType')
     .customSanitizer(toIntOrNull)
     .custom(exists).withMessage('Should have a valid streaming playlist type'),
@@ -118,8 +118,7 @@ const listVideoRedundanciesValidator = [
 
 const addVideoRedundancyValidator = [
   body('videoId')
-    .custom(isIdValid)
-    .withMessage('Should have a valid video id'),
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking addVideoRedundancyValidator parameters', { parameters: req.query })
@@ -150,8 +149,7 @@ const addVideoRedundancyValidator = [
 
 const removeVideoRedundancyValidator = [
   param('redundancyId')
-    .custom(isIdValid)
-    .withMessage('Should have a valid redundancy id'),
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking removeVideoRedundancyValidator parameters', { parameters: req.query })

--- a/server/middlewares/validators/redundancy.ts
+++ b/server/middlewares/validators/redundancy.ts
@@ -4,10 +4,10 @@ import { exists, isBooleanValid, checkIdOrUUID, checkId, toBooleanOrNull, toIntO
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 import { VideoRedundancyModel } from '../../models/redundancy/video-redundancy'
-import { isHostValid } from '../../helpers/custom-validators/servers'
+import { checkHost } from '../../helpers/custom-validators/servers'
 import { ServerModel } from '../../models/server/server'
 import { doesVideoExist } from '../../helpers/middlewares'
-import { isVideoRedundancyTarget } from '@server/helpers/custom-validators/video-redundancies'
+import { checkVideoRedundancyTarget } from '@server/helpers/custom-validators/video-redundancies'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 
 const videoFileRedundancyGetValidator = [
@@ -77,7 +77,8 @@ const videoPlaylistRedundancyGetValidator = [
 ]
 
 const updateServerRedundancyValidator = [
-  param('host').custom(isHostValid).withMessage('Should have a valid host'),
+  param('host')
+    .custom(checkHost),
   body('redundancyAllowed')
     .customSanitizer(toBooleanOrNull)
     .custom(isBooleanValid).withMessage('Should have a valid redundancyAllowed attribute'),
@@ -105,7 +106,7 @@ const updateServerRedundancyValidator = [
 
 const listVideoRedundanciesValidator = [
   query('target')
-    .custom(isVideoRedundancyTarget).withMessage('Should have a valid video redundancies target'),
+    .custom(checkVideoRedundancyTarget),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listVideoRedundanciesValidator parameters', { parameters: req.query })

--- a/server/middlewares/validators/search.ts
+++ b/server/middlewares/validators/search.ts
@@ -2,17 +2,17 @@ import * as express from 'express'
 import { areValidationErrors } from './utils'
 import { logger } from '../../helpers/logger'
 import { query } from 'express-validator'
-import { isDateValid } from '../../helpers/custom-validators/misc'
+import { checkDate } from '../../helpers/custom-validators/misc'
 import { isSearchTargetValid } from '@server/helpers/custom-validators/search'
 
 const videosSearchValidator = [
   query('search').optional().not().isEmpty().withMessage('Should have a valid search'),
 
-  query('startDate').optional().custom(isDateValid).withMessage('Should have a valid start date'),
-  query('endDate').optional().custom(isDateValid).withMessage('Should have a valid end date'),
+  query('startDate').optional().custom(checkDate).withMessage('Should have a valid start date'),
+  query('endDate').optional().custom(checkDate).withMessage('Should have a valid end date'),
 
-  query('originallyPublishedStartDate').optional().custom(isDateValid).withMessage('Should have a valid published start date'),
-  query('originallyPublishedEndDate').optional().custom(isDateValid).withMessage('Should have a valid published end date'),
+  query('originallyPublishedStartDate').optional().custom(checkDate).withMessage('Should have a valid published start date'),
+  query('originallyPublishedEndDate').optional().custom(checkDate).withMessage('Should have a valid published end date'),
 
   query('durationMin').optional().isInt().withMessage('Should have a valid min duration'),
   query('durationMax').optional().isInt().withMessage('Should have a valid max duration'),

--- a/server/middlewares/validators/search.ts
+++ b/server/middlewares/validators/search.ts
@@ -3,7 +3,7 @@ import { areValidationErrors } from './utils'
 import { logger } from '../../helpers/logger'
 import { query } from 'express-validator'
 import { checkDate } from '../../helpers/custom-validators/misc'
-import { isSearchTargetValid } from '@server/helpers/custom-validators/search'
+import { checkSearchTarget } from '@server/helpers/custom-validators/search'
 
 const videosSearchValidator = [
   query('search').optional().not().isEmpty().withMessage('Should have a valid search'),
@@ -17,7 +17,9 @@ const videosSearchValidator = [
   query('durationMin').optional().isInt().withMessage('Should have a valid min duration'),
   query('durationMax').optional().isInt().withMessage('Should have a valid max duration'),
 
-  query('searchTarget').optional().custom(isSearchTargetValid).withMessage('Should have a valid search target'),
+  query('searchTarget')
+    .optional()
+    .custom(checkSearchTarget),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videos search query', { parameters: req.query })
@@ -30,7 +32,9 @@ const videosSearchValidator = [
 
 const videoChannelsListSearchValidator = [
   query('search').not().isEmpty().withMessage('Should have a valid search'),
-  query('searchTarget').optional().custom(isSearchTargetValid).withMessage('Should have a valid search target'),
+  query('searchTarget')
+    .optional()
+    .custom(checkSearchTarget),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking video channels search query', { parameters: req.query })

--- a/server/middlewares/validators/server.ts
+++ b/server/middlewares/validators/server.ts
@@ -1,16 +1,16 @@
 import * as express from 'express'
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
-import { isHostValid, isValidContactBody } from '../../helpers/custom-validators/servers'
+import { checkHost, checkContactBody, checkContactFromName } from '../../helpers/custom-validators/servers'
 import { ServerModel } from '../../models/server/server'
 import { body } from 'express-validator'
-import { isUserDisplayNameValid } from '../../helpers/custom-validators/users'
 import { Redis } from '../../lib/redis'
 import { CONFIG, isEmailEnabled } from '../../initializers/config'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 
 const serverGetValidator = [
-  body('host').custom(isHostValid).withMessage('Should have a valid host'),
+  body('host')
+    .custom(checkHost),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking serverGetValidator parameters', { parameters: req.body })
@@ -32,11 +32,11 @@ const serverGetValidator = [
 
 const contactAdministratorValidator = [
   body('fromName')
-    .custom(isUserDisplayNameValid).withMessage('Should have a valid name'),
+    .custom(checkContactFromName).withMessage('Should have a valid name'),
   body('fromEmail')
     .isEmail().withMessage('Should have a valid email'),
   body('body')
-    .custom(isValidContactBody).withMessage('Should have a valid body'),
+    .custom(checkContactBody),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking contactAdministratorValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/themes.ts
+++ b/server/middlewares/validators/themes.ts
@@ -4,13 +4,13 @@ import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 import { isPluginNameValid, isPluginVersionValid } from '../../helpers/custom-validators/plugins'
 import { PluginManager } from '../../lib/plugins/plugin-manager'
-import { isSafePath } from '../../helpers/custom-validators/misc'
+import { checkSafePath } from '../../helpers/custom-validators/misc'
 import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
 
 const serveThemeCSSValidator = [
   param('themeName').custom(isPluginNameValid).withMessage('Should have a valid theme name'),
   param('themeVersion').custom(isPluginVersionValid).withMessage('Should have a valid theme version'),
-  param('staticEndpoint').custom(isSafePath).withMessage('Should have a valid static endpoint'),
+  param('staticEndpoint').custom(checkSafePath).withMessage('Should have a valid static endpoint'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking serveThemeCSS parameters', { parameters: req.params })

--- a/server/middlewares/validators/user-history.ts
+++ b/server/middlewares/validators/user-history.ts
@@ -2,7 +2,7 @@ import * as express from 'express'
 import { body, query } from 'express-validator'
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
-import { exists, isDateValid } from '../../helpers/custom-validators/misc'
+import { exists, checkDate } from '../../helpers/custom-validators/misc'
 
 const userHistoryListValidator = [
   query('search')
@@ -21,7 +21,7 @@ const userHistoryListValidator = [
 const userHistoryRemoveValidator = [
   body('beforeDate')
     .optional()
-    .custom(isDateValid).withMessage('Should have a valid before date'),
+    .custom(checkDate).withMessage('Should have a valid before date'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking userHistoryRemoveValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/user-notifications.ts
+++ b/server/middlewares/validators/user-notifications.ts
@@ -3,7 +3,7 @@ import { body, query } from 'express-validator'
 import { logger } from '../../helpers/logger'
 import { areValidationErrors } from './utils'
 import { isUserNotificationSettingValid } from '../../helpers/custom-validators/user-notifications'
-import { isNotEmptyIntArray, toBooleanOrNull } from '../../helpers/custom-validators/misc'
+import { checkNotEmptyIntArray, toBooleanOrNull } from '../../helpers/custom-validators/misc'
 
 const listUserNotificationsValidator = [
   query('unread')
@@ -58,7 +58,7 @@ const updateNotificationSettingsValidator = [
 const markAsReadUserNotificationsValidator = [
   body('ids')
     .optional()
-    .custom(isNotEmptyIntArray).withMessage('Should have a valid notification ids to mark as read'),
+    .custom(checkNotEmptyIntArray),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking markAsReadUserNotificationsValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/user-subscriptions.ts
+++ b/server/middlewares/validators/user-subscriptions.ts
@@ -9,7 +9,9 @@ import { ActorFollowModel } from '../../models/actor/actor-follow'
 import { areValidationErrors } from './utils'
 
 const userSubscriptionListValidator = [
-  query('search').optional().not().isEmpty().withMessage('Should have a valid search'),
+  query('search')
+    .optional()
+    .not().isEmpty().withMessage('Should have a valid search'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking userSubscriptionListValidator parameters', { parameters: req.query })
@@ -21,7 +23,8 @@ const userSubscriptionListValidator = [
 ]
 
 const userSubscriptionAddValidator = [
-  body('uri').custom(isValidActorHandle).withMessage('Should have a valid URI to follow (username@domain)'),
+  body('uri')
+    .custom(isValidActorHandle).withMessage('Should have a valid URI to follow (username@domain)'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking userSubscriptionAddValidator parameters', { parameters: req.body })
@@ -47,7 +50,8 @@ const areSubscriptionsExistValidator = [
 ]
 
 const userSubscriptionGetValidator = [
-  param('uri').custom(isValidActorHandle).withMessage('Should have a valid URI to unfollow'),
+  param('uri')
+    .custom(isValidActorHandle).withMessage('Should have a valid URI to unfollow'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking userSubscriptionGetValidator parameters', { parameters: req.params })

--- a/server/middlewares/validators/users.ts
+++ b/server/middlewares/validators/users.ts
@@ -7,7 +7,7 @@ import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-code
 import { UserRole } from '../../../shared/models/users'
 import { UserRegister } from '../../../shared/models/users/user-register.model'
 import { isActorPreferredUsernameValid } from '../../helpers/custom-validators/activitypub/actor'
-import { isIdOrUUIDValid, isIdValid, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
+import { checkIdOrUUID, checkId, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
 import { isThemeNameValid } from '../../helpers/custom-validators/plugins'
 import {
   isNoInstanceConfigWarningModal,
@@ -155,7 +155,7 @@ const usersRegisterValidator = [
 
 const usersRemoveValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersRemove parameters', { parameters: req.params })
@@ -175,7 +175,7 @@ const usersRemoveValidator = [
 
 const usersBlockingValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   body('reason')
     .optional()
@@ -212,7 +212,7 @@ const deleteMeValidator = [
 
 const usersUpdateValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   body('password')
     .optional()
@@ -324,7 +324,7 @@ const usersUpdateMeValidator = [
 
 const usersGetValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
   query('withStats')
     .optional()
     .isBoolean().withMessage('Should have a valid stats flag'),
@@ -341,7 +341,7 @@ const usersGetValidator = [
 
 const usersVideoRatingValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersVideoRating parameters', { parameters: req.params })
@@ -410,7 +410,7 @@ const usersAskResetPasswordValidator = [
 
 const usersResetPasswordValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   body('verificationString')
     .not().isEmpty().withMessage('Should have a valid verification string'),
@@ -457,7 +457,7 @@ const usersAskSendVerifyEmailValidator = [
 
 const usersVerifyEmailValidator = [
   param('id')
-    .custom(isIdValid),
+    .custom(checkId),
 
   body('verificationString')
     .not().isEmpty().withMessage('Should have a valid verification string'),

--- a/server/middlewares/validators/users.ts
+++ b/server/middlewares/validators/users.ts
@@ -22,13 +22,13 @@ import {
   isUserPasswordValid,
   isUserPasswordValidOrEmpty,
   isUserRoleValid,
-  isUserUsernameValid,
+  checkUserUsername,
   isUserVideoLanguages,
   isUserVideoQuotaDailyValid,
   isUserVideoQuotaValid,
   isUserVideosHistoryEnabledValid
 } from '../../helpers/custom-validators/users'
-import { isVideoChannelNameValid } from '../../helpers/custom-validators/video-channels'
+import { checkVideoChannelName } from '../../helpers/custom-validators/video-channels'
 import { logger } from '../../helpers/logger'
 import { doesVideoExist } from '../../helpers/middlewares'
 import { isSignupAllowed, isSignupAllowedForCurrentIP } from '../../helpers/signup'
@@ -55,7 +55,7 @@ const usersListValidator = [
 
 const usersAddValidator = [
   body('username')
-    .custom(isUserUsernameValid),
+    .custom(checkUserUsername),
   body('password')
     .custom(isUserPasswordValidOrEmpty).withMessage('Should have a valid password'),
   body('email')
@@ -108,7 +108,7 @@ const usersAddValidator = [
 
 const usersRegisterValidator = [
   body('username')
-    .custom(isUserUsernameValid),
+    .custom(checkUserUsername),
   body('password')
     .custom(isUserPasswordValid).withMessage('Should have a valid password'),
   body('email')
@@ -121,7 +121,7 @@ const usersRegisterValidator = [
     .custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
   body('channel.displayName')
     .optional()
-    .custom(isVideoChannelNameValid),
+    .custom(checkVideoChannelName),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersRegister parameters', { parameters: omit(req.body, 'password') })

--- a/server/middlewares/validators/users.ts
+++ b/server/middlewares/validators/users.ts
@@ -7,7 +7,7 @@ import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-code
 import { UserRole } from '../../../shared/models/users'
 import { UserRegister } from '../../../shared/models/users/user-register.model'
 import { isActorPreferredUsernameValid } from '../../helpers/custom-validators/activitypub/actor'
-import { isIdOrUUIDValid, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
+import { isIdOrUUIDValid, isIdValid, toBooleanOrNull, toIntOrNull } from '../../helpers/custom-validators/misc'
 import { isThemeNameValid } from '../../helpers/custom-validators/plugins'
 import {
   isNoInstanceConfigWarningModal,
@@ -54,16 +54,25 @@ const usersListValidator = [
 ]
 
 const usersAddValidator = [
-  body('username').custom(isUserUsernameValid).withMessage('Should have a valid username (lowercase alphanumeric characters)'),
-  body('password').custom(isUserPasswordValidOrEmpty).withMessage('Should have a valid password'),
-  body('email').isEmail().withMessage('Should have a valid email'),
-  body('channelName').optional().custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
-  body('videoQuota').custom(isUserVideoQuotaValid).withMessage('Should have a valid user quota'),
-  body('videoQuotaDaily').custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily user quota'),
+  body('username')
+    .custom(isUserUsernameValid),
+  body('password')
+    .custom(isUserPasswordValidOrEmpty).withMessage('Should have a valid password'),
+  body('email')
+    .isEmail().withMessage('Should have a valid email'),
+  body('channelName')
+    .optional()
+    .custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
+  body('videoQuota')
+    .custom(isUserVideoQuotaValid).withMessage('Should have a valid user quota'),
+  body('videoQuotaDaily')
+    .custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily user quota'),
   body('role')
     .customSanitizer(toIntOrNull)
     .custom(isUserRoleValid).withMessage('Should have a valid role'),
-  body('adminFlags').optional().custom(isUserAdminFlagsValid).withMessage('Should have a valid admin flags'),
+  body('adminFlags')
+    .optional()
+    .custom(isUserAdminFlagsValid).withMessage('Should have a valid admin flags'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersAdd parameters', { parameters: omit(req.body, 'password') })
@@ -98,13 +107,15 @@ const usersAddValidator = [
 ]
 
 const usersRegisterValidator = [
-  body('username').custom(isUserUsernameValid).withMessage('Should have a valid username'),
-  body('password').custom(isUserPasswordValid).withMessage('Should have a valid password'),
-  body('email').isEmail().withMessage('Should have a valid email'),
+  body('username')
+    .custom(isUserUsernameValid),
+  body('password')
+    .custom(isUserPasswordValid).withMessage('Should have a valid password'),
+  body('email')
+    .isEmail().withMessage('Should have a valid email'),
   body('displayName')
     .optional()
     .custom(isUserDisplayNameValid).withMessage('Should have a valid display name'),
-
   body('channel.name')
     .optional()
     .custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
@@ -143,7 +154,8 @@ const usersRegisterValidator = [
 ]
 
 const usersRemoveValidator = [
-  param('id').isInt().not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersRemove parameters', { parameters: req.params })
@@ -162,8 +174,12 @@ const usersRemoveValidator = [
 ]
 
 const usersBlockingValidator = [
-  param('id').isInt().not().isEmpty().withMessage('Should have a valid id'),
-  body('reason').optional().custom(isUserBlockedReasonValid).withMessage('Should have a valid blocking reason'),
+  param('id')
+    .custom(isIdValid),
+
+  body('reason')
+    .optional()
+    .custom(isUserBlockedReasonValid).withMessage('Should have a valid blocking reason'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersBlocking parameters', { parameters: req.params })
@@ -195,14 +211,26 @@ const deleteMeValidator = [
 ]
 
 const usersUpdateValidator = [
-  param('id').isInt().not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdValid),
 
-  body('password').optional().custom(isUserPasswordValid).withMessage('Should have a valid password'),
-  body('email').optional().isEmail().withMessage('Should have a valid email attribute'),
-  body('emailVerified').optional().isBoolean().withMessage('Should have a valid email verified attribute'),
-  body('videoQuota').optional().custom(isUserVideoQuotaValid).withMessage('Should have a valid user quota'),
-  body('videoQuotaDaily').optional().custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily user quota'),
-  body('pluginAuth').optional(),
+  body('password')
+    .optional()
+    .custom(isUserPasswordValid).withMessage('Should have a valid password'),
+  body('email')
+    .optional()
+    .isEmail().withMessage('Should have a valid email attribute'),
+  body('emailVerified')
+    .optional()
+    .isBoolean().withMessage('Should have a valid email verified attribute'),
+  body('videoQuota')
+    .optional()
+    .custom(isUserVideoQuotaValid).withMessage('Should have a valid user quota'),
+  body('videoQuotaDaily')
+    .optional()
+    .custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily user quota'),
+  body('pluginAuth')
+    .optional(),
   body('role')
     .optional()
     .customSanitizer(toIntOrNull)
@@ -295,8 +323,11 @@ const usersUpdateMeValidator = [
 ]
 
 const usersGetValidator = [
-  param('id').isInt().not().isEmpty().withMessage('Should have a valid id'),
-  query('withStats').optional().isBoolean().withMessage('Should have a valid stats flag'),
+  param('id')
+    .custom(isIdValid),
+  query('withStats')
+    .optional()
+    .isBoolean().withMessage('Should have a valid stats flag'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersGet parameters', { parameters: req.params })
@@ -309,7 +340,8 @@ const usersGetValidator = [
 ]
 
 const usersVideoRatingValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid video id'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersVideoRating parameters', { parameters: req.params })
@@ -357,7 +389,8 @@ const ensureUserRegistrationAllowedForIP = [
 ]
 
 const usersAskResetPasswordValidator = [
-  body('email').isEmail().not().isEmpty().withMessage('Should have a valid email'),
+  body('email')
+    .isEmail().not().isEmpty().withMessage('Should have a valid email'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersAskResetPassword parameters', { parameters: req.body })
@@ -376,9 +409,13 @@ const usersAskResetPasswordValidator = [
 ]
 
 const usersResetPasswordValidator = [
-  param('id').isInt().not().isEmpty().withMessage('Should have a valid id'),
-  body('verificationString').not().isEmpty().withMessage('Should have a valid verification string'),
-  body('password').custom(isUserPasswordValid).withMessage('Should have a valid password'),
+  param('id')
+    .custom(isIdValid),
+
+  body('verificationString')
+    .not().isEmpty().withMessage('Should have a valid verification string'),
+  body('password')
+    .custom(isUserPasswordValid).withMessage('Should have a valid password'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersResetPassword parameters', { parameters: req.params })
@@ -400,7 +437,8 @@ const usersResetPasswordValidator = [
 ]
 
 const usersAskSendVerifyEmailValidator = [
-  body('email').isEmail().not().isEmpty().withMessage('Should have a valid email'),
+  body('email')
+    .isEmail().not().isEmpty().withMessage('Should have a valid email'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking askUsersSendVerifyEmail parameters', { parameters: req.body })
@@ -419,7 +457,7 @@ const usersAskSendVerifyEmailValidator = [
 
 const usersVerifyEmailValidator = [
   param('id')
-    .isInt().not().isEmpty().withMessage('Should have a valid id'),
+    .custom(isIdValid),
 
   body('verificationString')
     .not().isEmpty().withMessage('Should have a valid verification string'),
@@ -447,7 +485,8 @@ const usersVerifyEmailValidator = [
 ]
 
 const userAutocompleteValidator = [
-  param('search').isString().not().isEmpty().withMessage('Should have a search parameter')
+  param('search')
+    .isString().not().isEmpty().withMessage('Should have a search parameter')
 ]
 
 const ensureAuthUserOwnsAccountValidator = [

--- a/server/middlewares/validators/users.ts
+++ b/server/middlewares/validators/users.ts
@@ -16,8 +16,8 @@ import {
   isUserAutoPlayNextVideoValid,
   isUserAutoPlayVideoValid,
   isUserBlockedReasonValid,
-  isUserDescriptionValid,
-  isUserDisplayNameValid,
+  checkUserDescription,
+  checkUserDisplayName,
   isUserNSFWPolicyValid,
   isUserPasswordValid,
   isUserPasswordValidOrEmpty,
@@ -115,13 +115,13 @@ const usersRegisterValidator = [
     .isEmail().withMessage('Should have a valid email'),
   body('displayName')
     .optional()
-    .custom(isUserDisplayNameValid).withMessage('Should have a valid display name'),
+    .custom(checkUserDisplayName),
   body('channel.name')
     .optional()
     .custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
   body('channel.displayName')
     .optional()
-    .custom(isVideoChannelNameValid).withMessage('Should have a valid display name'),
+    .custom(isVideoChannelNameValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersRegister parameters', { parameters: omit(req.body, 'password') })
@@ -256,10 +256,10 @@ const usersUpdateValidator = [
 const usersUpdateMeValidator = [
   body('displayName')
     .optional()
-    .custom(isUserDisplayNameValid).withMessage('Should have a valid display name'),
+    .custom(checkUserDisplayName),
   body('description')
     .optional()
-    .custom(isUserDescriptionValid).withMessage('Should have a valid description'),
+    .custom(checkUserDescription),
   body('currentPassword')
     .optional()
     .custom(isUserPasswordValid).withMessage('Should have a valid current password'),

--- a/server/middlewares/validators/users.ts
+++ b/server/middlewares/validators/users.ts
@@ -12,20 +12,20 @@ import { isThemeNameValid } from '../../helpers/custom-validators/plugins'
 import {
   isNoInstanceConfigWarningModal,
   isNoWelcomeModal,
-  isUserAdminFlagsValid,
+  checkUserAdminFlags,
   isUserAutoPlayNextVideoValid,
   isUserAutoPlayVideoValid,
-  isUserBlockedReasonValid,
+  checkUserBlockedReason,
   checkUserDescription,
   checkUserDisplayName,
   isUserNSFWPolicyValid,
-  isUserPasswordValid,
-  isUserPasswordValidOrEmpty,
-  isUserRoleValid,
+  checkUserPassword,
+  checkUserPasswordValidOrEmpty,
+  checkUserRole,
   checkUserUsername,
-  isUserVideoLanguages,
-  isUserVideoQuotaDailyValid,
-  isUserVideoQuotaValid,
+  checkUserVideoLanguages,
+  checkUserVideoQuotaDaily,
+  checkUserVideoQuota,
   isUserVideosHistoryEnabledValid
 } from '../../helpers/custom-validators/users'
 import { checkVideoChannelName } from '../../helpers/custom-validators/video-channels'
@@ -57,22 +57,22 @@ const usersAddValidator = [
   body('username')
     .custom(checkUserUsername),
   body('password')
-    .custom(isUserPasswordValidOrEmpty).withMessage('Should have a valid password'),
+    .custom(checkUserPasswordValidOrEmpty),
   body('email')
     .isEmail().withMessage('Should have a valid email'),
   body('channelName')
     .optional()
     .custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
   body('videoQuota')
-    .custom(isUserVideoQuotaValid).withMessage('Should have a valid user quota'),
+    .custom(checkUserVideoQuota),
   body('videoQuotaDaily')
-    .custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily user quota'),
+    .custom(checkUserVideoQuotaDaily),
   body('role')
     .customSanitizer(toIntOrNull)
-    .custom(isUserRoleValid).withMessage('Should have a valid role'),
+    .custom(checkUserRole),
   body('adminFlags')
     .optional()
-    .custom(isUserAdminFlagsValid).withMessage('Should have a valid admin flags'),
+    .custom(checkUserAdminFlags),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersAdd parameters', { parameters: omit(req.body, 'password') })
@@ -110,7 +110,7 @@ const usersRegisterValidator = [
   body('username')
     .custom(checkUserUsername),
   body('password')
-    .custom(isUserPasswordValid).withMessage('Should have a valid password'),
+    .custom(checkUserPassword),
   body('email')
     .isEmail().withMessage('Should have a valid email'),
   body('displayName')
@@ -179,7 +179,7 @@ const usersBlockingValidator = [
 
   body('reason')
     .optional()
-    .custom(isUserBlockedReasonValid).withMessage('Should have a valid blocking reason'),
+    .custom(checkUserBlockedReason),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersBlocking parameters', { parameters: req.params })
@@ -216,7 +216,7 @@ const usersUpdateValidator = [
 
   body('password')
     .optional()
-    .custom(isUserPasswordValid).withMessage('Should have a valid password'),
+    .custom(checkUserPassword),
   body('email')
     .optional()
     .isEmail().withMessage('Should have a valid email attribute'),
@@ -225,17 +225,19 @@ const usersUpdateValidator = [
     .isBoolean().withMessage('Should have a valid email verified attribute'),
   body('videoQuota')
     .optional()
-    .custom(isUserVideoQuotaValid).withMessage('Should have a valid user quota'),
+    .custom(checkUserVideoQuota),
   body('videoQuotaDaily')
     .optional()
-    .custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily user quota'),
+    .custom(checkUserVideoQuotaDaily),
   body('pluginAuth')
     .optional(),
   body('role')
     .optional()
     .customSanitizer(toIntOrNull)
-    .custom(isUserRoleValid).withMessage('Should have a valid role'),
-  body('adminFlags').optional().custom(isUserAdminFlagsValid).withMessage('Should have a valid admin flags'),
+    .custom(checkUserRole),
+  body('adminFlags')
+    .optional()
+    .custom(checkUserAdminFlags),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersUpdate parameters', { parameters: req.body })
@@ -262,10 +264,10 @@ const usersUpdateMeValidator = [
     .custom(checkUserDescription),
   body('currentPassword')
     .optional()
-    .custom(isUserPasswordValid).withMessage('Should have a valid current password'),
+    .custom(checkUserPassword),
   body('password')
     .optional()
-    .custom(isUserPasswordValid).withMessage('Should have a valid password'),
+    .custom(checkUserPassword),
   body('email')
     .optional()
     .isEmail().withMessage('Should have a valid email attribute'),
@@ -277,7 +279,7 @@ const usersUpdateMeValidator = [
     .custom(isUserAutoPlayVideoValid).withMessage('Should have a valid automatically plays video attribute'),
   body('videoLanguages')
     .optional()
-    .custom(isUserVideoLanguages).withMessage('Should have a valid video languages attribute'),
+    .custom(checkUserVideoLanguages),
   body('videosHistoryEnabled')
     .optional()
     .custom(isUserVideosHistoryEnabledValid).withMessage('Should have a valid videos history enabled attribute'),
@@ -415,7 +417,7 @@ const usersResetPasswordValidator = [
   body('verificationString')
     .not().isEmpty().withMessage('Should have a valid verification string'),
   body('password')
-    .custom(isUserPasswordValid).withMessage('Should have a valid password'),
+    .custom(checkUserPassword),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking usersResetPassword parameters', { parameters: req.params })
@@ -460,7 +462,7 @@ const usersVerifyEmailValidator = [
     .custom(checkId),
 
   body('verificationString')
-    .not().isEmpty().withMessage('Should have a valid verification string'),
+    .not().isEmpty().withMessage('Should have a verification string'),
   body('isPendingEmail')
     .optional()
     .customSanitizer(toBooleanOrNull),

--- a/server/middlewares/validators/videos/video-blacklist.ts
+++ b/server/middlewares/validators/videos/video-blacklist.ts
@@ -1,7 +1,7 @@
 import * as express from 'express'
 import { body, param, query } from 'express-validator'
 import { isBooleanValid, checkIdOrUUID, toBooleanOrNull, toIntOrNull } from '../../../helpers/custom-validators/misc'
-import { isVideoBlacklistReasonValid, isVideoBlacklistTypeValid } from '../../../helpers/custom-validators/video-blacklist'
+import { checkVideoBlacklistReason, isVideoBlacklistTypeValid } from '../../../helpers/custom-validators/video-blacklist'
 import { logger } from '../../../helpers/logger'
 import { doesVideoBlacklistExist, doesVideoExist } from '../../../helpers/middlewares'
 import { areValidationErrors } from '../utils'
@@ -22,14 +22,15 @@ const videosBlacklistRemoveValidator = [
 ]
 
 const videosBlacklistAddValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId')
+    .custom(checkIdOrUUID).not().isEmpty(),
   body('unfederate')
     .optional()
     .customSanitizer(toBooleanOrNull)
     .custom(isBooleanValid).withMessage('Should have a valid unfederate boolean'),
   body('reason')
     .optional()
-    .custom(isVideoBlacklistReasonValid).withMessage('Should have a valid reason'),
+    .custom(checkVideoBlacklistReason),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videosBlacklistAdd parameters', { parameters: req.params })
@@ -50,10 +51,11 @@ const videosBlacklistAddValidator = [
 ]
 
 const videosBlacklistUpdateValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId')
+    .custom(checkIdOrUUID).not().isEmpty(),
   body('reason')
     .optional()
-    .custom(isVideoBlacklistReasonValid).withMessage('Should have a valid reason'),
+    .custom(checkVideoBlacklistReason),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videosBlacklistUpdate parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-blacklist.ts
+++ b/server/middlewares/validators/videos/video-blacklist.ts
@@ -8,7 +8,8 @@ import { areValidationErrors } from '../utils'
 import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-codes'
 
 const videosBlacklistRemoveValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId')
+    .custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking blacklistRemove parameters.', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-blacklist.ts
+++ b/server/middlewares/validators/videos/video-blacklist.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { body, param, query } from 'express-validator'
-import { isBooleanValid, isIdOrUUIDValid, toBooleanOrNull, toIntOrNull } from '../../../helpers/custom-validators/misc'
+import { isBooleanValid, checkIdOrUUID, toBooleanOrNull, toIntOrNull } from '../../../helpers/custom-validators/misc'
 import { isVideoBlacklistReasonValid, isVideoBlacklistTypeValid } from '../../../helpers/custom-validators/video-blacklist'
 import { logger } from '../../../helpers/logger'
 import { doesVideoBlacklistExist, doesVideoExist } from '../../../helpers/middlewares'
@@ -8,7 +8,7 @@ import { areValidationErrors } from '../utils'
 import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-codes'
 
 const videosBlacklistRemoveValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking blacklistRemove parameters.', { parameters: req.params })
@@ -22,7 +22,7 @@ const videosBlacklistRemoveValidator = [
 ]
 
 const videosBlacklistAddValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
   body('unfederate')
     .optional()
     .customSanitizer(toBooleanOrNull)
@@ -50,7 +50,7 @@ const videosBlacklistAddValidator = [
 ]
 
 const videosBlacklistUpdateValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
   body('reason')
     .optional()
     .custom(isVideoBlacklistReasonValid).withMessage('Should have a valid reason'),

--- a/server/middlewares/validators/videos/video-blacklist.ts
+++ b/server/middlewares/validators/videos/video-blacklist.ts
@@ -9,7 +9,7 @@ import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-c
 
 const videosBlacklistRemoveValidator = [
   param('videoId')
-    .custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
+    .custom(checkIdOrUUID),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking blacklistRemove parameters.', { parameters: req.params })
@@ -24,7 +24,7 @@ const videosBlacklistRemoveValidator = [
 
 const videosBlacklistAddValidator = [
   param('videoId')
-    .custom(checkIdOrUUID).not().isEmpty(),
+    .custom(checkIdOrUUID),
   body('unfederate')
     .optional()
     .customSanitizer(toBooleanOrNull)
@@ -53,7 +53,7 @@ const videosBlacklistAddValidator = [
 
 const videosBlacklistUpdateValidator = [
   param('videoId')
-    .custom(checkIdOrUUID).not().isEmpty(),
+    .custom(checkIdOrUUID),
   body('reason')
     .optional()
     .custom(checkVideoBlacklistReason),
@@ -76,8 +76,7 @@ const videosBlacklistFiltersValidator = [
     .custom(isVideoBlacklistTypeValid).withMessage('Should have a valid video blacklist type attribute'),
   query('search')
     .optional()
-    .not()
-    .isEmpty().withMessage('Should have a valid search'),
+    .not().isEmpty().withMessage('Should have a valid search'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videos blacklist filters query', { parameters: req.query })

--- a/server/middlewares/validators/videos/video-captions.ts
+++ b/server/middlewares/validators/videos/video-captions.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { areValidationErrors } from '../utils'
-import { isIdOrUUIDValid } from '../../../helpers/custom-validators/misc'
+import { checkIdOrUUID } from '../../../helpers/custom-validators/misc'
 import { body, param } from 'express-validator'
 import { CONSTRAINTS_FIELDS, MIMETYPES } from '../../../initializers/constants'
 import { UserRight } from '../../../../shared'
@@ -10,7 +10,7 @@ import { cleanUpReqFiles } from '../../../helpers/express-utils'
 import { checkUserCanManageVideo, doesVideoCaptionExist, doesVideoExist } from '../../../helpers/middlewares'
 
 const addVideoCaptionValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid video id'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid video id'),
   param('captionLanguage').custom(isVideoCaptionLanguageValid).not().isEmpty().withMessage('Should have a valid caption language'),
   body('captionfile')
     .custom((_, { req }) => isVideoCaptionFile(req.files, 'captionfile'))
@@ -35,7 +35,7 @@ const addVideoCaptionValidator = [
 ]
 
 const deleteVideoCaptionValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid video id'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid video id'),
   param('captionLanguage').custom(isVideoCaptionLanguageValid).not().isEmpty().withMessage('Should have a valid caption language'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -54,7 +54,7 @@ const deleteVideoCaptionValidator = [
 ]
 
 const listVideoCaptionsValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid video id'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid video id'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listVideoCaptions parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-captions.ts
+++ b/server/middlewares/validators/videos/video-captions.ts
@@ -11,7 +11,7 @@ import { checkUserCanManageVideo, doesVideoCaptionExist, doesVideoExist } from '
 
 const addVideoCaptionValidator = [
   param('videoId')
-    .custom(checkIdOrUUID).not().isEmpty(),
+    .custom(checkIdOrUUID),
   param('captionLanguage')
     .custom(checkVideoCaptionLanguage).not().isEmpty(),
   body('captionfile')
@@ -38,7 +38,7 @@ const addVideoCaptionValidator = [
 
 const deleteVideoCaptionValidator = [
   param('videoId')
-    .custom(checkIdOrUUID).not().isEmpty(),
+    .custom(checkIdOrUUID),
   param('captionLanguage')
     .custom(checkVideoCaptionLanguage).not().isEmpty(),
 
@@ -58,7 +58,8 @@ const deleteVideoCaptionValidator = [
 ]
 
 const listVideoCaptionsValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid video id'),
+  param('videoId')
+    .custom(checkIdOrUUID),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listVideoCaptions parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-captions.ts
+++ b/server/middlewares/validators/videos/video-captions.ts
@@ -5,13 +5,15 @@ import { body, param } from 'express-validator'
 import { CONSTRAINTS_FIELDS, MIMETYPES } from '../../../initializers/constants'
 import { UserRight } from '../../../../shared'
 import { logger } from '../../../helpers/logger'
-import { isVideoCaptionFile, isVideoCaptionLanguageValid } from '../../../helpers/custom-validators/video-captions'
+import { isVideoCaptionFile, checkVideoCaptionLanguage } from '../../../helpers/custom-validators/video-captions'
 import { cleanUpReqFiles } from '../../../helpers/express-utils'
 import { checkUserCanManageVideo, doesVideoCaptionExist, doesVideoExist } from '../../../helpers/middlewares'
 
 const addVideoCaptionValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid video id'),
-  param('captionLanguage').custom(isVideoCaptionLanguageValid).not().isEmpty().withMessage('Should have a valid caption language'),
+  param('videoId')
+    .custom(checkIdOrUUID).not().isEmpty(),
+  param('captionLanguage')
+    .custom(checkVideoCaptionLanguage).not().isEmpty(),
   body('captionfile')
     .custom((_, { req }) => isVideoCaptionFile(req.files, 'captionfile'))
     .withMessage(
@@ -35,8 +37,10 @@ const addVideoCaptionValidator = [
 ]
 
 const deleteVideoCaptionValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid video id'),
-  param('captionLanguage').custom(isVideoCaptionLanguageValid).not().isEmpty().withMessage('Should have a valid caption language'),
+  param('videoId')
+    .custom(checkIdOrUUID).not().isEmpty(),
+  param('captionLanguage')
+    .custom(checkVideoCaptionLanguage).not().isEmpty(),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking deleteVideoCaption parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-channels.ts
+++ b/server/middlewares/validators/videos/video-channels.ts
@@ -8,8 +8,8 @@ import { isActorPreferredUsernameValid } from '../../../helpers/custom-validator
 import { isBooleanValid, toBooleanOrNull } from '../../../helpers/custom-validators/misc'
 import {
   checkVideoChannelDescription,
-  isVideoChannelNameValid,
-  isVideoChannelSupportValid
+  checkVideoChannelName,
+  checkVideoChannelSupport
 } from '../../../helpers/custom-validators/video-channels'
 import { logger } from '../../../helpers/logger'
 import { doesLocalVideoChannelNameExist, doesVideoChannelNameWithHostExist } from '../../../helpers/middlewares'
@@ -21,13 +21,13 @@ const videoChannelsAddValidator = [
   body('name')
     .custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
   body('displayName')
-    .custom(isVideoChannelNameValid),
+    .custom(checkVideoChannelName),
   body('description')
     .optional()
     .custom(checkVideoChannelDescription),
   body('support')
     .optional()
-    .custom(isVideoChannelSupportValid),
+    .custom(checkVideoChannelSupport),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoChannelsAdd parameters', { parameters: req.body })
@@ -58,13 +58,13 @@ const videoChannelsUpdateValidator = [
   param('nameWithHost').exists().withMessage('Should have an video channel name with host'),
   body('displayName')
     .optional()
-    .custom(isVideoChannelNameValid),
+    .custom(checkVideoChannelName),
   body('description')
     .optional()
     .custom(checkVideoChannelDescription),
   body('support')
     .optional()
-    .custom(isVideoChannelSupportValid),
+    .custom(checkVideoChannelSupport),
   body('bulkVideosSupportUpdate')
     .optional()
     .custom(isBooleanValid).withMessage('Should have a valid bulkVideosSupportUpdate boolean field'),
@@ -122,7 +122,7 @@ const videoChannelsNameWithHostValidator = [
 
 const localVideoChannelValidator = [
   param('name')
-    .custom(isVideoChannelNameValid),
+    .custom(checkVideoChannelName),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking localVideoChannelValidator parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-channels.ts
+++ b/server/middlewares/validators/videos/video-channels.ts
@@ -7,7 +7,7 @@ import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-c
 import { isActorPreferredUsernameValid } from '../../../helpers/custom-validators/activitypub/actor'
 import { isBooleanValid, toBooleanOrNull } from '../../../helpers/custom-validators/misc'
 import {
-  isVideoChannelDescriptionValid,
+  checkVideoChannelDescription,
   isVideoChannelNameValid,
   isVideoChannelSupportValid
 } from '../../../helpers/custom-validators/video-channels'
@@ -18,10 +18,16 @@ import { VideoChannelModel } from '../../../models/video/video-channel'
 import { areValidationErrors } from '../utils'
 
 const videoChannelsAddValidator = [
-  body('name').custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
-  body('displayName').custom(isVideoChannelNameValid).withMessage('Should have a valid display name'),
-  body('description').optional().custom(isVideoChannelDescriptionValid).withMessage('Should have a valid description'),
-  body('support').optional().custom(isVideoChannelSupportValid).withMessage('Should have a valid support text'),
+  body('name')
+    .custom(isActorPreferredUsernameValid).withMessage('Should have a valid channel name'),
+  body('displayName')
+    .custom(isVideoChannelNameValid),
+  body('description')
+    .optional()
+    .custom(checkVideoChannelDescription),
+  body('support')
+    .optional()
+    .custom(isVideoChannelSupportValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoChannelsAdd parameters', { parameters: req.body })
@@ -52,13 +58,13 @@ const videoChannelsUpdateValidator = [
   param('nameWithHost').exists().withMessage('Should have an video channel name with host'),
   body('displayName')
     .optional()
-    .custom(isVideoChannelNameValid).withMessage('Should have a valid display name'),
+    .custom(isVideoChannelNameValid),
   body('description')
     .optional()
-    .custom(isVideoChannelDescriptionValid).withMessage('Should have a valid description'),
+    .custom(checkVideoChannelDescription),
   body('support')
     .optional()
-    .custom(isVideoChannelSupportValid).withMessage('Should have a valid support text'),
+    .custom(isVideoChannelSupportValid),
   body('bulkVideosSupportUpdate')
     .optional()
     .custom(isBooleanValid).withMessage('Should have a valid bulkVideosSupportUpdate boolean field'),
@@ -115,7 +121,8 @@ const videoChannelsNameWithHostValidator = [
 ]
 
 const localVideoChannelValidator = [
-  param('name').custom(isVideoChannelNameValid).withMessage('Should have a valid video channel name'),
+  param('name')
+    .custom(isVideoChannelNameValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking localVideoChannelValidator parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-channels.ts
+++ b/server/middlewares/validators/videos/video-channels.ts
@@ -55,7 +55,9 @@ const videoChannelsAddValidator = [
 ]
 
 const videoChannelsUpdateValidator = [
-  param('nameWithHost').exists().withMessage('Should have an video channel name with host'),
+  param('nameWithHost')
+    .exists().withMessage('Should have an video channel name with host'),
+
   body('displayName')
     .optional()
     .custom(checkVideoChannelName),
@@ -91,7 +93,8 @@ const videoChannelsUpdateValidator = [
 ]
 
 const videoChannelsRemoveValidator = [
-  param('nameWithHost').exists().withMessage('Should have an video channel name with host'),
+  param('nameWithHost')
+    .exists().withMessage('Should have an video channel name with host'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoChannelsRemove parameters', { parameters: req.params })
@@ -107,7 +110,8 @@ const videoChannelsRemoveValidator = [
 ]
 
 const videoChannelsNameWithHostValidator = [
-  param('nameWithHost').exists().withMessage('Should have an video channel name with host'),
+  param('nameWithHost')
+    .exists().withMessage('Should have an video channel name with host'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoChannelsNameWithHostValidator parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-comments.ts
+++ b/server/middlewares/validators/videos/video-comments.ts
@@ -2,7 +2,7 @@ import * as express from 'express'
 import { body, param, query } from 'express-validator'
 import { MUserAccountUrl } from '@server/types/models'
 import { UserRight } from '../../../../shared'
-import { exists, isBooleanValid, isIdOrUUIDValid, isIdValid, toBooleanOrNull } from '../../../helpers/custom-validators/misc'
+import { exists, isBooleanValid, checkIdOrUUID, checkId, toBooleanOrNull } from '../../../helpers/custom-validators/misc'
 import {
   doesVideoCommentExist,
   doesVideoCommentThreadExist,
@@ -45,7 +45,7 @@ const listVideoCommentsValidator = [
 ]
 
 const listVideoCommentThreadsValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listVideoCommentThreads parameters.', { parameters: req.params })
@@ -59,9 +59,9 @@ const listVideoCommentThreadsValidator = [
 
 const listVideoThreadCommentsValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   param('threadId')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listVideoThreadComments parameters.', { parameters: req.params })
@@ -75,7 +75,7 @@ const listVideoThreadCommentsValidator = [
 ]
 
 const addVideoCommentThreadValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
   body('text').custom(isValidVideoCommentText).not().isEmpty().withMessage('Should have a valid comment text'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -92,9 +92,9 @@ const addVideoCommentThreadValidator = [
 
 const addVideoCommentReplyValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   param('commentId')
-    .custom(isIdValid),
+    .custom(checkId),
   body('text').custom(isValidVideoCommentText).not().isEmpty().withMessage('Should have a valid comment text'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -112,9 +112,9 @@ const addVideoCommentReplyValidator = [
 
 const videoCommentGetValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   param('commentId')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoCommentGetValidator parameters.', { parameters: req.params })
@@ -129,9 +129,9 @@ const videoCommentGetValidator = [
 
 const removeVideoCommentValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   param('commentId')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking removeVideoCommentValidator parameters.', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-comments.ts
+++ b/server/middlewares/validators/videos/video-comments.ts
@@ -6,7 +6,7 @@ import { exists, isBooleanValid, checkIdOrUUID, checkId, toBooleanOrNull } from 
 import {
   doesVideoCommentExist,
   doesVideoCommentThreadExist,
-  isValidVideoCommentText
+  checkVideoCommentText
 } from '../../../helpers/custom-validators/video-comments'
 import { logger } from '../../../helpers/logger'
 import { doesVideoExist } from '../../../helpers/middlewares'
@@ -75,8 +75,10 @@ const listVideoThreadCommentsValidator = [
 ]
 
 const addVideoCommentThreadValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
-  body('text').custom(isValidVideoCommentText).not().isEmpty().withMessage('Should have a valid comment text'),
+  param('videoId')
+    .custom(checkIdOrUUID).not().isEmpty(),
+  body('text')
+    .custom(checkVideoCommentText).not().isEmpty(),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking addVideoCommentThread parameters.', { parameters: req.params, body: req.body })
@@ -95,7 +97,8 @@ const addVideoCommentReplyValidator = [
     .custom(checkIdOrUUID),
   param('commentId')
     .custom(checkId),
-  body('text').custom(isValidVideoCommentText).not().isEmpty().withMessage('Should have a valid comment text'),
+  body('text')
+    .custom(checkVideoCommentText).not().isEmpty(),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking addVideoCommentReply parameters.', { parameters: req.params, body: req.body })

--- a/server/middlewares/validators/videos/video-comments.ts
+++ b/server/middlewares/validators/videos/video-comments.ts
@@ -45,7 +45,7 @@ const listVideoCommentsValidator = [
 ]
 
 const listVideoCommentThreadsValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId').custom(checkIdOrUUID).withMessage('Should have a valid videoId'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listVideoCommentThreads parameters.', { parameters: req.params })
@@ -76,7 +76,7 @@ const listVideoThreadCommentsValidator = [
 
 const addVideoCommentThreadValidator = [
   param('videoId')
-    .custom(checkIdOrUUID).not().isEmpty(),
+    .custom(checkIdOrUUID),
   body('text')
     .custom(checkVideoCommentText).not().isEmpty(),
 

--- a/server/middlewares/validators/videos/video-comments.ts
+++ b/server/middlewares/validators/videos/video-comments.ts
@@ -58,8 +58,10 @@ const listVideoCommentThreadsValidator = [
 ]
 
 const listVideoThreadCommentsValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
-  param('threadId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid threadId'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
+  param('threadId')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking listVideoThreadComments parameters.', { parameters: req.params })
@@ -89,8 +91,10 @@ const addVideoCommentThreadValidator = [
 ]
 
 const addVideoCommentReplyValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
-  param('commentId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid commentId'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
+  param('commentId')
+    .custom(isIdValid),
   body('text').custom(isValidVideoCommentText).not().isEmpty().withMessage('Should have a valid comment text'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -107,8 +111,10 @@ const addVideoCommentReplyValidator = [
 ]
 
 const videoCommentGetValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
-  param('commentId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid commentId'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
+  param('commentId')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoCommentGetValidator parameters.', { parameters: req.params })
@@ -122,8 +128,10 @@ const videoCommentGetValidator = [
 ]
 
 const removeVideoCommentValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
-  param('commentId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid commentId'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
+  param('commentId')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking removeVideoCommentValidator parameters.', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-imports.ts
+++ b/server/middlewares/validators/videos/video-imports.ts
@@ -5,7 +5,7 @@ import { Hooks } from '@server/lib/plugins/hooks'
 import { VideoImportCreate } from '@shared/models/videos/import/video-import-create.model'
 import { checkId, toIntOrNull } from '../../../helpers/custom-validators/misc'
 import { checkVideoImportTargetUrl, checkVideoImportTorrentFile } from '../../../helpers/custom-validators/video-imports'
-import { isVideoMagnetUriValid, checkVideoName } from '../../../helpers/custom-validators/videos'
+import { checkVideoMagnetUri, checkVideoName } from '../../../helpers/custom-validators/videos'
 import { cleanUpReqFiles } from '../../../helpers/express-utils'
 import { logger } from '../../../helpers/logger'
 import { doesVideoChannelOfAccountExist } from '../../../helpers/middlewares'
@@ -23,7 +23,7 @@ const videoImportAddValidator = getCommonVideoEditAttributes().concat([
     .custom(checkVideoImportTargetUrl),
   body('magnetUri')
     .optional()
-    .custom(isVideoMagnetUriValid),
+    .custom(checkVideoMagnetUri),
   body('torrentfile')
     .custom((value, { req }) => checkVideoImportTorrentFile(req.files)),
   body('name')

--- a/server/middlewares/validators/videos/video-imports.ts
+++ b/server/middlewares/validators/videos/video-imports.ts
@@ -18,7 +18,7 @@ import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
 const videoImportAddValidator = getCommonVideoEditAttributes().concat([
   body('channelId')
     .customSanitizer(toIntOrNull)
-    .custom(isIdValid).withMessage('Should have correct video channel id'),
+    .custom(isIdValid),
   body('targetUrl')
     .optional()
     .custom(isVideoImportTargetUrlValid).withMessage('Should have a valid video import target URL'),
@@ -33,7 +33,7 @@ const videoImportAddValidator = getCommonVideoEditAttributes().concat([
     ),
   body('name')
     .optional()
-    .custom(isVideoNameValid).withMessage('Should have a valid name'),
+    .custom(isVideoNameValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoImportAddValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/videos/video-imports.ts
+++ b/server/middlewares/validators/videos/video-imports.ts
@@ -3,9 +3,9 @@ import { body } from 'express-validator'
 import { isPreImportVideoAccepted } from '@server/lib/moderation'
 import { Hooks } from '@server/lib/plugins/hooks'
 import { VideoImportCreate } from '@shared/models/videos/import/video-import-create.model'
-import { isIdValid, toIntOrNull } from '../../../helpers/custom-validators/misc'
+import { checkId, toIntOrNull } from '../../../helpers/custom-validators/misc'
 import { isVideoImportTargetUrlValid, isVideoImportTorrentFile } from '../../../helpers/custom-validators/video-imports'
-import { isVideoMagnetUriValid, isVideoNameValid } from '../../../helpers/custom-validators/videos'
+import { isVideoMagnetUriValid, checkVideoName } from '../../../helpers/custom-validators/videos'
 import { cleanUpReqFiles } from '../../../helpers/express-utils'
 import { logger } from '../../../helpers/logger'
 import { doesVideoChannelOfAccountExist } from '../../../helpers/middlewares'
@@ -18,7 +18,7 @@ import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
 const videoImportAddValidator = getCommonVideoEditAttributes().concat([
   body('channelId')
     .customSanitizer(toIntOrNull)
-    .custom(isIdValid),
+    .custom(checkId),
   body('targetUrl')
     .optional()
     .custom(isVideoImportTargetUrlValid).withMessage('Should have a valid video import target URL'),
@@ -33,7 +33,7 @@ const videoImportAddValidator = getCommonVideoEditAttributes().concat([
     ),
   body('name')
     .optional()
-    .custom(isVideoNameValid),
+    .custom(checkVideoName),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoImportAddValidator parameters', { parameters: req.body })

--- a/server/middlewares/validators/videos/video-imports.ts
+++ b/server/middlewares/validators/videos/video-imports.ts
@@ -4,13 +4,12 @@ import { isPreImportVideoAccepted } from '@server/lib/moderation'
 import { Hooks } from '@server/lib/plugins/hooks'
 import { VideoImportCreate } from '@shared/models/videos/import/video-import-create.model'
 import { checkId, toIntOrNull } from '../../../helpers/custom-validators/misc'
-import { isVideoImportTargetUrlValid, isVideoImportTorrentFile } from '../../../helpers/custom-validators/video-imports'
+import { checkVideoImportTargetUrl, checkVideoImportTorrentFile } from '../../../helpers/custom-validators/video-imports'
 import { isVideoMagnetUriValid, checkVideoName } from '../../../helpers/custom-validators/videos'
 import { cleanUpReqFiles } from '../../../helpers/express-utils'
 import { logger } from '../../../helpers/logger'
 import { doesVideoChannelOfAccountExist } from '../../../helpers/middlewares'
 import { CONFIG } from '../../../initializers/config'
-import { CONSTRAINTS_FIELDS } from '../../../initializers/constants'
 import { areValidationErrors } from '../utils'
 import { getCommonVideoEditAttributes } from './videos'
 import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
@@ -21,16 +20,12 @@ const videoImportAddValidator = getCommonVideoEditAttributes().concat([
     .custom(checkId),
   body('targetUrl')
     .optional()
-    .custom(isVideoImportTargetUrlValid).withMessage('Should have a valid video import target URL'),
+    .custom(checkVideoImportTargetUrl),
   body('magnetUri')
     .optional()
-    .custom(isVideoMagnetUriValid).withMessage('Should have a valid video magnet URI'),
+    .custom(isVideoMagnetUriValid),
   body('torrentfile')
-    .custom((value, { req }) => isVideoImportTorrentFile(req.files))
-    .withMessage(
-      'This torrent file is not supported or too large. Please, make sure it is of the following type: ' +
-      CONSTRAINTS_FIELDS.VIDEO_IMPORTS.TORRENT_FILE.EXTNAME.join(', ')
-    ),
+    .custom((value, { req }) => checkVideoImportTorrentFile(req.files)),
   body('name')
     .optional()
     .custom(checkVideoName),

--- a/server/middlewares/validators/videos/video-live.ts
+++ b/server/middlewares/validators/videos/video-live.ts
@@ -3,8 +3,8 @@ import { body, param } from 'express-validator'
 import { checkUserCanManageVideo, doesVideoChannelOfAccountExist, doesVideoExist } from '@server/helpers/middlewares/videos'
 import { VideoLiveModel } from '@server/models/video/video-live'
 import { ServerErrorCode, UserRight, VideoState } from '@shared/models'
-import { isBooleanValid, isIdOrUUIDValid, isIdValid, toBooleanOrNull, toIntOrNull } from '../../../helpers/custom-validators/misc'
-import { isVideoNameValid } from '../../../helpers/custom-validators/videos'
+import { isBooleanValid, checkIdOrUUID, checkId, toBooleanOrNull, toIntOrNull } from '../../../helpers/custom-validators/misc'
+import { checkVideoName } from '../../../helpers/custom-validators/videos'
 import { cleanUpReqFiles } from '../../../helpers/express-utils'
 import { logger } from '../../../helpers/logger'
 import { CONFIG } from '../../../initializers/config'
@@ -16,7 +16,7 @@ import { isLocalLiveVideoAccepted } from '@server/lib/moderation'
 import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
 
 const videoLiveGetValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoLiveGetValidator parameters', { parameters: req.params, user: res.locals.oauth.token.User.username })
@@ -40,9 +40,9 @@ const videoLiveGetValidator = [
 const videoLiveAddValidator = getCommonVideoEditAttributes().concat([
   body('channelId')
     .customSanitizer(toIntOrNull)
-    .custom(isIdValid),
+    .custom(checkId),
   body('name')
-    .custom(isVideoNameValid),
+    .custom(checkVideoName),
   body('saveReplay')
     .optional()
     .customSanitizer(toBooleanOrNull)

--- a/server/middlewares/validators/videos/video-live.ts
+++ b/server/middlewares/validators/videos/video-live.ts
@@ -16,7 +16,8 @@ import { isLocalLiveVideoAccepted } from '@server/lib/moderation'
 import { HttpStatusCode } from '@shared/core-utils/miscs/http-error-codes'
 
 const videoLiveGetValidator = [
-  param('videoId').custom(checkIdOrUUID).not().isEmpty().withMessage('Should have a valid videoId'),
+  param('videoId')
+    .custom(checkIdOrUUID),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoLiveGetValidator parameters', { parameters: req.params, user: res.locals.oauth.token.User.username })

--- a/server/middlewares/validators/videos/video-live.ts
+++ b/server/middlewares/validators/videos/video-live.ts
@@ -40,16 +40,13 @@ const videoLiveGetValidator = [
 const videoLiveAddValidator = getCommonVideoEditAttributes().concat([
   body('channelId')
     .customSanitizer(toIntOrNull)
-    .custom(isIdValid).withMessage('Should have correct video channel id'),
-
+    .custom(isIdValid),
   body('name')
-    .custom(isVideoNameValid).withMessage('Should have a valid name'),
-
+    .custom(isVideoNameValid),
   body('saveReplay')
     .optional()
     .customSanitizer(toBooleanOrNull)
     .custom(isBooleanValid).withMessage('Should have a valid saveReplay attribute'),
-
   body('permanentLive')
     .optional()
     .customSanitizer(toBooleanOrNull)

--- a/server/middlewares/validators/videos/video-playlists.ts
+++ b/server/middlewares/validators/videos/video-playlists.ts
@@ -7,7 +7,7 @@ import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-c
 import { VideoPlaylistPrivacy } from '../../../../shared/models/videos/playlist/video-playlist-privacy.model'
 import { VideoPlaylistType } from '../../../../shared/models/videos/playlist/video-playlist-type.model'
 import {
-  catchError,
+  EtoB,
   isIdOrUUIDValid,
   isIdValid,
   isUUIDValid,
@@ -143,7 +143,7 @@ const videoPlaylistsGetValidator = (fetchType: VideoPlaylistFetchType) => {
 
       // Video is unlisted, check we used the uuid to fetch it
       if (videoPlaylist.privacy === VideoPlaylistPrivacy.UNLISTED) {
-        if (catchError(isUUIDValid)(req.params.playlistId)) return next()
+        if (EtoB(isUUIDValid)(req.params.playlistId)) return next()
 
         return res.status(HttpStatusCode.NOT_FOUND_404).end()
       }

--- a/server/middlewares/validators/videos/video-playlists.ts
+++ b/server/middlewares/validators/videos/video-playlists.ts
@@ -20,7 +20,7 @@ import {
   checkVideoPlaylistPrivacy,
   checkVideoPlaylistTimestamp,
   checkVideoPlaylistType,
-  isVideoPlaylistVideoIdsValid
+  checkVideoPlaylistVideoIds
 } from '../../../helpers/custom-validators/video-playlists'
 import { checkVideoImage } from '../../../helpers/custom-validators/videos'
 import { cleanUpReqFiles } from '../../../helpers/express-utils'
@@ -347,7 +347,7 @@ const commonVideoPlaylistFiltersValidator = [
 const doVideosInPlaylistExistValidator = [
   query('videoIds')
     .customSanitizer(toIntArray)
-    .custom(isVideoPlaylistVideoIdsValid).withMessage('Should have a valid video ids array'),
+    .custom(checkVideoPlaylistVideoIds),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking areVideosInPlaylistExistValidator parameters', { parameters: req.query })

--- a/server/middlewares/validators/videos/video-rates.ts
+++ b/server/middlewares/validators/videos/video-rates.ts
@@ -12,8 +12,11 @@ import { doesVideoExist } from '../../../helpers/middlewares'
 import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-codes'
 
 const videoUpdateRateValidator = [
-  param('id').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
-  body('rating').custom(isVideoRatingTypeValid).withMessage('Should have a valid rate type'),
+  param('id')
+    .custom(isIdOrUUIDValid),
+
+  body('rating')
+    .custom(isVideoRatingTypeValid).withMessage('Should have a valid rate type'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoRate parameters', { parameters: req.body })
@@ -27,8 +30,10 @@ const videoUpdateRateValidator = [
 
 const getAccountVideoRateValidatorFactory = function (rateType: VideoRateType) {
   return [
-    param('name').custom(isAccountNameValid).withMessage('Should have a valid account name'),
-    param('videoId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid videoId'),
+    param('name')
+      .custom(isAccountNameValid),
+    param('videoId')
+      .custom(isIdValid),
 
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
       logger.debug('Checking videoCommentGetValidator parameters.', { parameters: req.params })
@@ -49,7 +54,9 @@ const getAccountVideoRateValidatorFactory = function (rateType: VideoRateType) {
 }
 
 const videoRatingValidator = [
-  query('rating').optional().custom(isRatingValid).withMessage('Value must be one of "like" or "dislike"'),
+  query('rating')
+    .optional()
+    .custom(isRatingValid).withMessage('Value must be one of "like" or "dislike"'),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking rating parameter', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-rates.ts
+++ b/server/middlewares/validators/videos/video-rates.ts
@@ -2,7 +2,7 @@ import * as express from 'express'
 import { body, param, query } from 'express-validator'
 import { checkIdOrUUID, checkId } from '../../../helpers/custom-validators/misc'
 import { checkVideoRating } from '../../../helpers/custom-validators/video-rates'
-import { isVideoRatingTypeValid } from '../../../helpers/custom-validators/videos'
+import { checkVideoRatingType } from '../../../helpers/custom-validators/videos'
 import { logger } from '../../../helpers/logger'
 import { areValidationErrors } from '../utils'
 import { AccountVideoRateModel } from '../../../models/account/account-video-rate'
@@ -16,7 +16,7 @@ const videoUpdateRateValidator = [
     .custom(checkIdOrUUID),
 
   body('rating')
-    .custom(isVideoRatingTypeValid),
+    .custom(checkVideoRatingType),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoRate parameters', { parameters: req.body })

--- a/server/middlewares/validators/videos/video-rates.ts
+++ b/server/middlewares/validators/videos/video-rates.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { body, param, query } from 'express-validator'
-import { isIdOrUUIDValid, isIdValid } from '../../../helpers/custom-validators/misc'
+import { checkIdOrUUID, checkId } from '../../../helpers/custom-validators/misc'
 import { isRatingValid } from '../../../helpers/custom-validators/video-rates'
 import { isVideoRatingTypeValid } from '../../../helpers/custom-validators/videos'
 import { logger } from '../../../helpers/logger'
@@ -13,10 +13,10 @@ import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-c
 
 const videoUpdateRateValidator = [
   param('id')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
 
   body('rating')
-    .custom(isVideoRatingTypeValid).withMessage('Should have a valid rate type'),
+    .custom(isVideoRatingTypeValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoRate parameters', { parameters: req.body })
@@ -33,7 +33,7 @@ const getAccountVideoRateValidatorFactory = function (rateType: VideoRateType) {
     param('name')
       .custom(isAccountNameValid),
     param('videoId')
-      .custom(isIdValid),
+      .custom(checkId),
 
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
       logger.debug('Checking videoCommentGetValidator parameters.', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-rates.ts
+++ b/server/middlewares/validators/videos/video-rates.ts
@@ -1,13 +1,13 @@
 import * as express from 'express'
 import { body, param, query } from 'express-validator'
 import { checkIdOrUUID, checkId } from '../../../helpers/custom-validators/misc'
-import { isRatingValid } from '../../../helpers/custom-validators/video-rates'
+import { checkVideoRating } from '../../../helpers/custom-validators/video-rates'
 import { isVideoRatingTypeValid } from '../../../helpers/custom-validators/videos'
 import { logger } from '../../../helpers/logger'
 import { areValidationErrors } from '../utils'
 import { AccountVideoRateModel } from '../../../models/account/account-video-rate'
 import { VideoRateType } from '../../../../shared/models/videos'
-import { isAccountNameValid } from '../../../helpers/custom-validators/accounts'
+import { checkAccountName } from '../../../helpers/custom-validators/accounts'
 import { doesVideoExist } from '../../../helpers/middlewares'
 import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-codes'
 
@@ -31,7 +31,7 @@ const videoUpdateRateValidator = [
 const getAccountVideoRateValidatorFactory = function (rateType: VideoRateType) {
   return [
     param('name')
-      .custom(isAccountNameValid),
+      .custom(checkAccountName),
     param('videoId')
       .custom(checkId),
 
@@ -56,7 +56,7 @@ const getAccountVideoRateValidatorFactory = function (rateType: VideoRateType) {
 const videoRatingValidator = [
   query('rating')
     .optional()
-    .custom(isRatingValid).withMessage('Value must be one of "like" or "dislike"'),
+    .custom(checkVideoRating),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking rating parameter', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-shares.ts
+++ b/server/middlewares/validators/videos/video-shares.ts
@@ -8,8 +8,10 @@ import { doesVideoExist } from '../../../helpers/middlewares'
 import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-codes'
 
 const videosShareValidator = [
-  param('id').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
-  param('actorId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid actor id'),
+  param('id')
+    .custom(isIdOrUUIDValid),
+  param('actorId')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoShare parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-shares.ts
+++ b/server/middlewares/validators/videos/video-shares.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import { param } from 'express-validator'
-import { isIdOrUUIDValid, isIdValid } from '../../../helpers/custom-validators/misc'
+import { checkIdOrUUID, checkId } from '../../../helpers/custom-validators/misc'
 import { logger } from '../../../helpers/logger'
 import { VideoShareModel } from '../../../models/video/video-share'
 import { areValidationErrors } from '../utils'
@@ -9,9 +9,9 @@ import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-c
 
 const videosShareValidator = [
   param('id')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
   param('actorId')
-    .custom(isIdValid),
+    .custom(checkId),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoShare parameters', { parameters: req.params })

--- a/server/middlewares/validators/videos/video-watch.ts
+++ b/server/middlewares/validators/videos/video-watch.ts
@@ -7,7 +7,9 @@ import { doesVideoExist } from '../../../helpers/middlewares'
 import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-codes'
 
 const videoWatchingValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
+
   body('currentTime')
     .customSanitizer(toIntOrNull)
     .isInt().withMessage('Should have correct current time'),

--- a/server/middlewares/validators/videos/video-watch.ts
+++ b/server/middlewares/validators/videos/video-watch.ts
@@ -1,6 +1,6 @@
 import { body, param } from 'express-validator'
 import * as express from 'express'
-import { isIdOrUUIDValid, toIntOrNull } from '../../../helpers/custom-validators/misc'
+import { checkIdOrUUID, toIntOrNull } from '../../../helpers/custom-validators/misc'
 import { areValidationErrors } from '../utils'
 import { logger } from '../../../helpers/logger'
 import { doesVideoExist } from '../../../helpers/middlewares'
@@ -8,7 +8,7 @@ import { HttpStatusCode } from '../../../../shared/core-utils/miscs/http-error-c
 
 const videoWatchingValidator = [
   param('videoId')
-    .custom(isIdOrUUIDValid),
+    .custom(checkIdOrUUID),
 
   body('currentTime')
     .customSanitizer(toIntOrNull)

--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -21,13 +21,13 @@ import {
   toIntOrNull,
   toValueOrNull
 } from '../../../helpers/custom-validators/misc'
-import { isBooleanBothQueryValid, isNumberArray, isStringArray } from '../../../helpers/custom-validators/search'
+import { checkBooleanBothQuery, isNumberArray, isStringArray } from '../../../helpers/custom-validators/search'
 import { checkUserCanTerminateOwnershipChange, doesChangeVideoOwnershipExist } from '../../../helpers/custom-validators/video-ownership'
 import {
   checkScheduleVideoUpdatePrivacy,
   checkVideoCategory,
   checkVideoDescription,
-  isVideoFileMimeTypeValid,
+  checkVideoFileMimeType,
   checkVideoFileSize,
   checkVideoFilter,
   checkVideoImage,
@@ -507,7 +507,7 @@ const commonVideosFiltersValidator = [
     .custom(isStringArray).withMessage('Should have a valid all of tags array'),
   query('nsfw')
     .optional()
-    .custom(isBooleanBothQueryValid).withMessage('Should have a valid NSFW attribute'),
+    .custom(checkBooleanBothQuery).withMessage('Should have a valid NSFW attribute'),
   query('isLive')
     .optional()
     .customSanitizer(toBooleanOrNull)
@@ -600,7 +600,7 @@ async function commonVideoChecksPass (parameters: {
   if (!await doesVideoChannelOfAccountExist(req.body.channelId, user, res)) return false
 
   try {
-    isVideoFileMimeTypeValid(files)
+    checkVideoFileMimeType(files)
   } catch (error) {
     res.status(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE_415)
        .json({ error })

--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -61,15 +61,13 @@ import { areValidationErrors } from '../utils'
 
 const videosAddLegacyValidator = getCommonVideoEditAttributes().concat([
   body('videofile')
-    .custom((value, { req }) => isFileFieldValid(req.files, 'videofile'))
-    .withMessage('Should have a file'),
+    .custom((value, { req }) => isFileFieldValid(req.files, 'videofile')),
   body('name')
     .trim()
-    .custom(isVideoNameValid)
-    .withMessage('Should have a valid name'),
+    .custom(isVideoNameValid),
   body('channelId')
     .customSanitizer(toIntOrNull)
-    .custom(isIdValid).withMessage('Should have correct video channel id'),
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videosAdd parameters', { parameters: req.body, files: req.files })
@@ -192,15 +190,16 @@ const videosAddResumableInitValidator = getCommonVideoEditAttributes().concat([
 ])
 
 const videosUpdateValidator = getCommonVideoEditAttributes().concat([
-  param('id').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdOrUUIDValid),
   body('name')
     .optional()
     .trim()
-    .custom(isVideoNameValid).withMessage('Should have a valid name'),
+    .custom(isVideoNameValid),
   body('channelId')
     .optional()
     .customSanitizer(toIntOrNull)
-    .custom(isIdValid).withMessage('Should have correct video channel id'),
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videosUpdate parameters', { parameters: req.body })
@@ -251,7 +250,8 @@ const videosCustomGetValidator = (
   authenticateInQuery = false
 ) => {
   return [
-    param('id').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
+    param('id')
+      .custom(isIdOrUUIDValid),
 
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
       logger.debug('Checking videosGet parameters', { parameters: req.params })
@@ -297,8 +297,10 @@ const videosGetValidator = videosCustomGetValidator('all')
 const videosDownloadValidator = videosCustomGetValidator('all', true)
 
 const videoFileMetadataGetValidator = getCommonVideoEditAttributes().concat([
-  param('id').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
-  param('videoFileId').custom(isIdValid).not().isEmpty().withMessage('Should have a valid videoFileId'),
+  param('id')
+    .custom(isIdOrUUIDValid),
+  param('videoFileId')
+    .custom(isIdValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videoFileMetadataGet parameters', { parameters: req.params })
@@ -311,7 +313,8 @@ const videoFileMetadataGetValidator = getCommonVideoEditAttributes().concat([
 ])
 
 const videosRemoveValidator = [
-  param('id').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdOrUUIDValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking videosRemove parameters', { parameters: req.params })
@@ -327,7 +330,8 @@ const videosRemoveValidator = [
 ]
 
 const videosChangeOwnershipValidator = [
-  param('videoId').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('videoId')
+    .custom(isIdOrUUIDValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking changeOwnership parameters', { parameters: req.params })
@@ -352,7 +356,8 @@ const videosChangeOwnershipValidator = [
 ]
 
 const videosTerminateChangeOwnershipValidator = [
-  param('id').custom(isIdOrUUIDValid).not().isEmpty().withMessage('Should have a valid id'),
+  param('id')
+    .custom(isIdOrUUIDValid),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     logger.debug('Checking changeOwnership parameters', { parameters: req.params })
@@ -447,15 +452,15 @@ function getCommonVideoEditAttributes () {
     body('description')
       .optional()
       .customSanitizer(toValueOrNull)
-      .custom(isVideoDescriptionValid).withMessage('Should have a valid description'),
+      .custom(isVideoDescriptionValid),
     body('support')
       .optional()
       .customSanitizer(toValueOrNull)
-      .custom(isVideoSupportValid).withMessage('Should have a valid support text'),
+      .custom(isVideoSupportValid),
     body('tags')
       .optional()
       .customSanitizer(toValueOrNull)
-      .custom(isVideoTagsValid).withMessage('Should have correct tags'),
+      .custom(isVideoTagsValid),
     body('commentsEnabled')
       .optional()
       .customSanitizer(toBooleanOrNull)
@@ -467,17 +472,17 @@ function getCommonVideoEditAttributes () {
     body('originallyPublishedAt')
       .optional()
       .customSanitizer(toValueOrNull)
-      .custom(isVideoOriginallyPublishedAtValid).withMessage('Should have a valid original publication date'),
+      .custom(isVideoOriginallyPublishedAtValid),
     body('scheduleUpdate')
       .optional()
       .customSanitizer(toValueOrNull),
     body('scheduleUpdate.updateAt')
       .optional()
-      .custom(isDateValid).withMessage('Should have a valid schedule update date'),
+      .custom(isDateValid),
     body('scheduleUpdate.privacy')
       .optional()
       .customSanitizer(toIntOrNull)
-      .custom(isScheduleVideoUpdatePrivacyValid).withMessage('Should have correct schedule update privacy')
+      .custom(isScheduleVideoUpdatePrivacyValid)
   ] as (ValidationChain | ExpressPromiseHandler)[]
 }
 

--- a/server/models/account/account.ts
+++ b/server/models/account/account.ts
@@ -19,7 +19,7 @@ import {
 import { ModelCache } from '@server/models/model-cache'
 import { AttributesOnly } from '@shared/core-utils'
 import { Account, AccountSummary } from '../../../shared/models/actors'
-import { isAccountDescriptionValid } from '../../helpers/custom-validators/accounts'
+import { checkAccountDescription } from '../../helpers/custom-validators/accounts'
 import { CONSTRAINTS_FIELDS, SERVER_ACTOR_NAME, WEBSERVER } from '../../initializers/constants'
 import { sendDeleteActor } from '../../lib/activitypub/send/send-delete'
 import {
@@ -150,7 +150,7 @@ export class AccountModel extends Model<Partial<AttributesOnly<AccountModel>>> {
 
   @AllowNull(true)
   @Default(null)
-  @Is('AccountDescription', value => throwIfNotValid(value, isAccountDescriptionValid, 'description', true))
+  @Is('AccountDescription', value => throwIfNotValid(value, checkAccountDescription, 'description', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.USERS.DESCRIPTION.max))
   description: string
 

--- a/server/models/server/server.ts
+++ b/server/models/server/server.ts
@@ -1,7 +1,7 @@
 import { AllowNull, Column, CreatedAt, Default, HasMany, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
 import { MServer, MServerFormattable } from '@server/types/models/server'
 import { AttributesOnly } from '@shared/core-utils'
-import { isHostValid } from '../../helpers/custom-validators/servers'
+import { checkHost } from '../../helpers/custom-validators/servers'
 import { ActorModel } from '../actor/actor'
 import { throwIfNotValid } from '../utils'
 import { ServerBlocklistModel } from './server-blocklist'
@@ -18,7 +18,7 @@ import { ServerBlocklistModel } from './server-blocklist'
 export class ServerModel extends Model<Partial<AttributesOnly<ServerModel>>> {
 
   @AllowNull(false)
-  @Is('Host', value => throwIfNotValid(value, isHostValid, 'valid host'))
+  @Is('Host', value => throwIfNotValid(value, checkHost, 'valid host'))
   @Column
   host: string
 

--- a/server/models/user/user.ts
+++ b/server/models/user/user.ts
@@ -51,7 +51,7 @@ import {
   isUserNSFWPolicyValid,
   isUserPasswordValid,
   isUserRoleValid,
-  isUserUsernameValid,
+  checkUserUsername,
   isUserVideoLanguages,
   isUserVideoQuotaDailyValid,
   isUserVideoQuotaValid,
@@ -243,7 +243,7 @@ export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
   password: string
 
   @AllowNull(false)
-  @Is('UserUsername', value => throwIfNotValid(value, catchErrorAsBoolean(isUserUsernameValid), 'user name'))
+  @Is('UserUsername', value => throwIfNotValid(value, catchErrorAsBoolean(checkUserUsername), 'user name'))
   @Column
   username: string
 

--- a/server/models/user/user.ts
+++ b/server/models/user/user.ts
@@ -73,7 +73,7 @@ import { VideoImportModel } from '../video/video-import'
 import { VideoLiveModel } from '../video/video-live'
 import { VideoPlaylistModel } from '../video/video-playlist'
 import { UserNotificationSettingModel } from './user-notification-setting'
-import { catchError } from '@server/helpers/custom-validators/misc'
+import { EtoB, catchError } from '@server/helpers/custom-validators/misc'
 
 enum ScopeNames {
   FOR_ME_API = 'FOR_ME_API',
@@ -243,7 +243,7 @@ export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
   password: string
 
   @AllowNull(false)
-  @Is('UserUsername', value => throwIfNotValid(value, catchError(isUserUsernameValid), 'user name'))
+  @Is('UserUsername', value => throwIfNotValid(value, EtoB(isUserUsernameValid), 'user name'))
   @Column
   username: string
 

--- a/server/models/user/user.ts
+++ b/server/models/user/user.ts
@@ -41,20 +41,20 @@ import { isThemeNameValid } from '../../helpers/custom-validators/plugins'
 import {
   isNoInstanceConfigWarningModal,
   isNoWelcomeModal,
-  isUserAdminFlagsValid,
+  checkUserAdminFlags,
   isUserAutoPlayNextVideoPlaylistValid,
   isUserAutoPlayNextVideoValid,
   isUserAutoPlayVideoValid,
-  isUserBlockedReasonValid,
+  checkUserBlockedReason,
   isUserBlockedValid,
   isUserEmailVerifiedValid,
   isUserNSFWPolicyValid,
-  isUserPasswordValid,
-  isUserRoleValid,
+  checkUserPassword,
+  checkUserRole,
   checkUserUsername,
-  isUserVideoLanguages,
-  isUserVideoQuotaDailyValid,
-  isUserVideoQuotaValid,
+  checkUserVideoLanguages,
+  checkUserVideoQuotaDaily,
+  checkUserVideoQuota,
   isUserVideosHistoryEnabledValid,
   isUserWebTorrentEnabledValid
 } from '../../helpers/custom-validators/users'
@@ -238,7 +238,7 @@ enum ScopeNames {
 export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
 
   @AllowNull(true)
-  @Is('UserPassword', value => throwIfNotValid(value, isUserPasswordValid, 'user password', true))
+  @Is('UserPassword', value => throwIfNotValid(value, catchErrorAsBoolean(checkUserPassword), 'user password', true))
   @Column
   password: string
 
@@ -303,13 +303,13 @@ export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
 
   @AllowNull(true)
   @Default(null)
-  @Is('UserVideoLanguages', value => throwIfNotValid(value, isUserVideoLanguages, 'video languages'))
+  @Is('UserVideoLanguages', value => throwIfNotValid(value, catchErrorAsBoolean(checkUserVideoLanguages), 'video languages'))
   @Column(DataType.ARRAY(DataType.STRING))
   videoLanguages: string[]
 
   @AllowNull(false)
   @Default(UserAdminFlag.NONE)
-  @Is('UserAdminFlags', value => throwIfNotValid(value, isUserAdminFlagsValid, 'user admin flags'))
+  @Is('UserAdminFlags', value => throwIfNotValid(value, catchErrorAsBoolean(checkUserAdminFlags), 'user admin flags'))
   @Column
   adminFlags?: UserAdminFlag
 
@@ -321,22 +321,22 @@ export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
 
   @AllowNull(true)
   @Default(null)
-  @Is('UserBlockedReason', value => throwIfNotValid(value, isUserBlockedReasonValid, 'blocked reason', true))
+  @Is('UserBlockedReason', value => throwIfNotValid(value, checkUserBlockedReason, 'blocked reason', true))
   @Column
   blockedReason: string
 
   @AllowNull(false)
-  @Is('UserRole', value => throwIfNotValid(value, isUserRoleValid, 'role'))
+  @Is('UserRole', value => throwIfNotValid(value, catchErrorAsBoolean(checkUserRole), 'role'))
   @Column
   role: number
 
   @AllowNull(false)
-  @Is('UserVideoQuota', value => throwIfNotValid(value, isUserVideoQuotaValid, 'video quota'))
+  @Is('UserVideoQuota', value => throwIfNotValid(value, catchErrorAsBoolean(checkUserVideoQuota), 'video quota'))
   @Column(DataType.BIGINT)
   videoQuota: number
 
   @AllowNull(false)
-  @Is('UserVideoQuotaDaily', value => throwIfNotValid(value, isUserVideoQuotaDailyValid, 'video quota daily'))
+  @Is('UserVideoQuotaDaily', value => throwIfNotValid(value, catchErrorAsBoolean(checkUserVideoQuotaDaily), 'video quota daily'))
   @Column(DataType.BIGINT)
   videoQuotaDaily: number
 

--- a/server/models/user/user.ts
+++ b/server/models/user/user.ts
@@ -73,6 +73,7 @@ import { VideoImportModel } from '../video/video-import'
 import { VideoLiveModel } from '../video/video-live'
 import { VideoPlaylistModel } from '../video/video-playlist'
 import { UserNotificationSettingModel } from './user-notification-setting'
+import { catchError } from '@server/helpers/custom-validators/misc'
 
 enum ScopeNames {
   FOR_ME_API = 'FOR_ME_API',
@@ -242,7 +243,7 @@ export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
   password: string
 
   @AllowNull(false)
-  @Is('UserUsername', value => throwIfNotValid(value, isUserUsernameValid, 'user name'))
+  @Is('UserUsername', value => throwIfNotValid(value, catchError(isUserUsernameValid), 'user name'))
   @Column
   username: string
 

--- a/server/models/user/user.ts
+++ b/server/models/user/user.ts
@@ -73,7 +73,7 @@ import { VideoImportModel } from '../video/video-import'
 import { VideoLiveModel } from '../video/video-live'
 import { VideoPlaylistModel } from '../video/video-playlist'
 import { UserNotificationSettingModel } from './user-notification-setting'
-import { EtoB, catchError } from '@server/helpers/custom-validators/misc'
+import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
 
 enum ScopeNames {
   FOR_ME_API = 'FOR_ME_API',
@@ -243,7 +243,7 @@ export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
   password: string
 
   @AllowNull(false)
-  @Is('UserUsername', value => throwIfNotValid(value, EtoB(isUserUsernameValid), 'user name'))
+  @Is('UserUsername', value => throwIfNotValid(value, catchErrorAsBoolean(isUserUsernameValid), 'user name'))
   @Column
   username: string
 

--- a/server/models/video/tag.ts
+++ b/server/models/video/tag.ts
@@ -3,7 +3,7 @@ import { AllowNull, BelongsToMany, Column, CreatedAt, Is, Model, Table, UpdatedA
 import { MTag } from '@server/types/models'
 import { AttributesOnly } from '@shared/core-utils'
 import { VideoPrivacy, VideoState } from '../../../shared/models/videos'
-import { isVideoTagValid } from '../../helpers/custom-validators/videos'
+import { checkVideoTag } from '../../helpers/custom-validators/videos'
 import { throwIfNotValid } from '../utils'
 import { VideoModel } from './video'
 import { VideoTagModel } from './video-tag'
@@ -25,7 +25,7 @@ import { VideoTagModel } from './video-tag'
 export class TagModel extends Model<Partial<AttributesOnly<TagModel>>> {
 
   @AllowNull(false)
-  @Is('VideoTag', value => throwIfNotValid(value, isVideoTagValid, 'tag'))
+  @Is('VideoTag', value => throwIfNotValid(value, checkVideoTag, 'tag'))
   @Column
   name: string
 

--- a/server/models/video/tag.ts
+++ b/server/models/video/tag.ts
@@ -7,6 +7,7 @@ import { checkVideoTag } from '../../helpers/custom-validators/videos'
 import { throwIfNotValid } from '../utils'
 import { VideoModel } from './video'
 import { VideoTagModel } from './video-tag'
+import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
 
 @Table({
   tableName: 'tag',
@@ -25,7 +26,7 @@ import { VideoTagModel } from './video-tag'
 export class TagModel extends Model<Partial<AttributesOnly<TagModel>>> {
 
   @AllowNull(false)
-  @Is('VideoTag', value => throwIfNotValid(value, checkVideoTag, 'tag'))
+  @Is('VideoTag', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoTag), 'tag'))
   @Column
   name: string
 

--- a/server/models/video/video-blacklist.ts
+++ b/server/models/video/video-blacklist.ts
@@ -3,7 +3,7 @@ import { AllowNull, BelongsTo, Column, CreatedAt, DataType, Default, ForeignKey,
 import { MVideoBlacklist, MVideoBlacklistFormattable } from '@server/types/models'
 import { AttributesOnly } from '@shared/core-utils'
 import { VideoBlacklist, VideoBlacklistType } from '../../../shared/models/videos'
-import { isVideoBlacklistReasonValid, isVideoBlacklistTypeValid } from '../../helpers/custom-validators/video-blacklist'
+import { checkVideoBlacklistReason, isVideoBlacklistTypeValid } from '../../helpers/custom-validators/video-blacklist'
 import { CONSTRAINTS_FIELDS } from '../../initializers/constants'
 import { getBlacklistSort, searchAttribute, SortType, throwIfNotValid } from '../utils'
 import { ThumbnailModel } from './thumbnail'
@@ -22,7 +22,7 @@ import { ScopeNames as VideoChannelScopeNames, SummaryOptions, VideoChannelModel
 export class VideoBlacklistModel extends Model<Partial<AttributesOnly<VideoBlacklistModel>>> {
 
   @AllowNull(true)
-  @Is('VideoBlacklistReason', value => throwIfNotValid(value, isVideoBlacklistReasonValid, 'reason', true))
+  @Is('VideoBlacklistReason', value => throwIfNotValid(value, checkVideoBlacklistReason, 'reason', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_BLACKLIST.REASON.max))
   reason: string
 

--- a/server/models/video/video-caption.ts
+++ b/server/models/video/video-caption.ts
@@ -19,7 +19,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { MVideo, MVideoCaption, MVideoCaptionFormattable, MVideoCaptionVideo } from '@server/types/models'
 import { AttributesOnly } from '@shared/core-utils'
 import { VideoCaption } from '../../../shared/models/videos/caption/video-caption.model'
-import { isVideoCaptionLanguageValid } from '../../helpers/custom-validators/video-captions'
+import { checkVideoCaptionLanguage } from '../../helpers/custom-validators/video-captions'
 import { logger } from '../../helpers/logger'
 import { CONFIG } from '../../initializers/config'
 import { CONSTRAINTS_FIELDS, LAZY_STATIC_PATHS, VIDEO_LANGUAGES, WEBSERVER } from '../../initializers/constants'
@@ -66,7 +66,7 @@ export class VideoCaptionModel extends Model<Partial<AttributesOnly<VideoCaption
   updatedAt: Date
 
   @AllowNull(false)
-  @Is('VideoCaptionLanguage', value => throwIfNotValid(value, isVideoCaptionLanguageValid, 'language'))
+  @Is('VideoCaptionLanguage', value => throwIfNotValid(value, checkVideoCaptionLanguage, 'language'))
   @Column
   language: string
 

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -23,7 +23,7 @@ import { AttributesOnly } from '@shared/core-utils'
 import { ActivityPubActor } from '../../../shared/models/activitypub'
 import { VideoChannel, VideoChannelSummary } from '../../../shared/models/videos'
 import {
-  isVideoChannelDescriptionValid,
+  checkVideoChannelDescription,
   isVideoChannelNameValid,
   isVideoChannelSupportValid
 } from '../../helpers/custom-validators/video-channels'
@@ -256,7 +256,7 @@ export class VideoChannelModel extends Model<Partial<AttributesOnly<VideoChannel
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoChannelDescription', value => throwIfNotValid(value, isVideoChannelDescriptionValid, 'description', true))
+  @Is('VideoChannelDescription', value => throwIfNotValid(value, checkVideoChannelDescription, 'description', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_CHANNELS.DESCRIPTION.max))
   description: string
 

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -24,8 +24,8 @@ import { ActivityPubActor } from '../../../shared/models/activitypub'
 import { VideoChannel, VideoChannelSummary } from '../../../shared/models/videos'
 import {
   checkVideoChannelDescription,
-  isVideoChannelNameValid,
-  isVideoChannelSupportValid
+  checkVideoChannelName,
+  checkVideoChannelSupport
 } from '../../helpers/custom-validators/video-channels'
 import { CONSTRAINTS_FIELDS, WEBSERVER } from '../../initializers/constants'
 import { sendDeleteActor } from '../../lib/activitypub/send'
@@ -250,7 +250,7 @@ export type SummaryOptions = {
 export class VideoChannelModel extends Model<Partial<AttributesOnly<VideoChannelModel>>> {
 
   @AllowNull(false)
-  @Is('VideoChannelName', value => throwIfNotValid(value, isVideoChannelNameValid, 'name'))
+  @Is('VideoChannelName', value => throwIfNotValid(value, checkVideoChannelName, 'name'))
   @Column
   name: string
 
@@ -262,7 +262,7 @@ export class VideoChannelModel extends Model<Partial<AttributesOnly<VideoChannel
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoChannelSupport', value => throwIfNotValid(value, isVideoChannelSupportValid, 'support', true))
+  @Is('VideoChannelSupport', value => throwIfNotValid(value, checkVideoChannelSupport, 'support', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_CHANNELS.SUPPORT.max))
   support: string
 

--- a/server/models/video/video-file.ts
+++ b/server/models/video/video-file.ts
@@ -27,7 +27,7 @@ import { getTorrentFilePath } from '@server/lib/video-paths'
 import { MStreamingPlaylistVideo, MVideo, MVideoWithHost } from '@server/types/models'
 import { AttributesOnly } from '@shared/core-utils'
 import {
-  isVideoFileExtnameValid,
+  checkVideoFileExtname,
   checkVideoFileInfoHash,
   checkVideoFileResolution,
   checkVideoFileSize,
@@ -169,7 +169,7 @@ export class VideoFileModel extends Model<Partial<AttributesOnly<VideoFileModel>
   size: number
 
   @AllowNull(false)
-  @Is('VideoFileExtname', value => throwIfNotValid(value, isVideoFileExtnameValid, 'extname'))
+  @Is('VideoFileExtname', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoFileExtname), 'extname'))
   @Column
   extname: string
 

--- a/server/models/video/video-file.ts
+++ b/server/models/video/video-file.ts
@@ -29,9 +29,9 @@ import { AttributesOnly } from '@shared/core-utils'
 import {
   isVideoFileExtnameValid,
   checkVideoFileInfoHash,
-  isVideoFileResolutionValid,
-  isVideoFileSizeValid,
-  isVideoFPSResolutionValid
+  checkVideoFileResolution,
+  checkVideoFileSize,
+  checkVideoFPSResolution
 } from '../../helpers/custom-validators/videos'
 import {
   LAZY_STATIC_PATHS,
@@ -47,6 +47,7 @@ import { VideoRedundancyModel } from '../redundancy/video-redundancy'
 import { parseAggregateResult, throwIfNotValid } from '../utils'
 import { VideoModel } from './video'
 import { VideoStreamingPlaylistModel } from './video-streaming-playlist'
+import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
 
 export enum ScopeNames {
   WITH_VIDEO = 'WITH_VIDEO',
@@ -158,12 +159,12 @@ export class VideoFileModel extends Model<Partial<AttributesOnly<VideoFileModel>
   updatedAt: Date
 
   @AllowNull(false)
-  @Is('VideoFileResolution', value => throwIfNotValid(value, isVideoFileResolutionValid, 'resolution'))
+  @Is('VideoFileResolution', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoFileResolution), 'resolution'))
   @Column
   resolution: number
 
   @AllowNull(false)
-  @Is('VideoFileSize', value => throwIfNotValid(value, isVideoFileSizeValid, 'size'))
+  @Is('VideoFileSize', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoFileSize), 'size'))
   @Column(DataType.BIGINT)
   size: number
 
@@ -173,13 +174,13 @@ export class VideoFileModel extends Model<Partial<AttributesOnly<VideoFileModel>
   extname: string
 
   @AllowNull(true)
-  @Is('VideoFileInfohash', value => throwIfNotValid(value, checkVideoFileInfoHash, 'info hash', true))
+  @Is('VideoFileInfohash', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoFileInfoHash), 'info hash', true))
   @Column
   infoHash: string
 
   @AllowNull(false)
   @Default(-1)
-  @Is('VideoFileFPS', value => throwIfNotValid(value, isVideoFPSResolutionValid, 'fps'))
+  @Is('VideoFileFPS', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoFPSResolution), 'fps'))
   @Column
   fps: number
 

--- a/server/models/video/video-file.ts
+++ b/server/models/video/video-file.ts
@@ -28,7 +28,7 @@ import { MStreamingPlaylistVideo, MVideo, MVideoWithHost } from '@server/types/m
 import { AttributesOnly } from '@shared/core-utils'
 import {
   isVideoFileExtnameValid,
-  isVideoFileInfoHashValid,
+  checkVideoFileInfoHash,
   isVideoFileResolutionValid,
   isVideoFileSizeValid,
   isVideoFPSResolutionValid
@@ -173,7 +173,7 @@ export class VideoFileModel extends Model<Partial<AttributesOnly<VideoFileModel>
   extname: string
 
   @AllowNull(true)
-  @Is('VideoFileInfohash', value => throwIfNotValid(value, isVideoFileInfoHashValid, 'info hash', true))
+  @Is('VideoFileInfohash', value => throwIfNotValid(value, checkVideoFileInfoHash, 'info hash', true))
   @Column
   infoHash: string
 

--- a/server/models/video/video-import.ts
+++ b/server/models/video/video-import.ts
@@ -17,7 +17,7 @@ import { afterCommitIfTransaction } from '@server/helpers/database-utils'
 import { MVideoImportDefault, MVideoImportFormattable } from '@server/types/models/video/video-import'
 import { AttributesOnly } from '@shared/core-utils'
 import { VideoImport, VideoImportState } from '../../../shared'
-import { isVideoImportStateValid, isVideoImportTargetUrlValid } from '../../helpers/custom-validators/video-imports'
+import { checkVideoImportState, checkVideoImportTargetUrl } from '../../helpers/custom-validators/video-imports'
 import { isVideoMagnetUriValid } from '../../helpers/custom-validators/videos'
 import { CONSTRAINTS_FIELDS, VIDEO_IMPORT_STATES } from '../../initializers/constants'
 import { UserModel } from '../user/user'
@@ -62,7 +62,7 @@ export class VideoImportModel extends Model<Partial<AttributesOnly<VideoImportMo
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoImportTargetUrl', value => throwIfNotValid(value, isVideoImportTargetUrlValid, 'targetUrl', true))
+  @Is('VideoImportTargetUrl', value => throwIfNotValid(value, checkVideoImportTargetUrl, 'targetUrl', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_IMPORTS.URL.max))
   targetUrl: string
 
@@ -79,7 +79,7 @@ export class VideoImportModel extends Model<Partial<AttributesOnly<VideoImportMo
 
   @AllowNull(false)
   @Default(null)
-  @Is('VideoImportState', value => throwIfNotValid(value, isVideoImportStateValid, 'state'))
+  @Is('VideoImportState', value => throwIfNotValid(value, checkVideoImportState, 'state'))
   @Column
   state: VideoImportState
 

--- a/server/models/video/video-import.ts
+++ b/server/models/video/video-import.ts
@@ -18,11 +18,12 @@ import { MVideoImportDefault, MVideoImportFormattable } from '@server/types/mode
 import { AttributesOnly } from '@shared/core-utils'
 import { VideoImport, VideoImportState } from '../../../shared'
 import { checkVideoImportState, checkVideoImportTargetUrl } from '../../helpers/custom-validators/video-imports'
-import { isVideoMagnetUriValid } from '../../helpers/custom-validators/videos'
+import { checkVideoMagnetUri } from '../../helpers/custom-validators/videos'
 import { CONSTRAINTS_FIELDS, VIDEO_IMPORT_STATES } from '../../initializers/constants'
 import { UserModel } from '../user/user'
 import { getSort, throwIfNotValid } from '../utils'
 import { ScopeNames as VideoModelScopeNames, VideoModel } from './video'
+import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
 
 @DefaultScope(() => ({
   include: [
@@ -62,13 +63,13 @@ export class VideoImportModel extends Model<Partial<AttributesOnly<VideoImportMo
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoImportTargetUrl', value => throwIfNotValid(value, checkVideoImportTargetUrl, 'targetUrl', true))
+  @Is('VideoImportTargetUrl', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoImportTargetUrl), 'targetUrl', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_IMPORTS.URL.max))
   targetUrl: string
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoImportMagnetUri', value => throwIfNotValid(value, isVideoMagnetUriValid, 'magnetUri', true))
+  @Is('VideoImportMagnetUri', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoMagnetUri), 'magnetUri', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_IMPORTS.URL.max)) // Use the same constraints than URLs
   magnetUri: string
 
@@ -79,7 +80,7 @@ export class VideoImportModel extends Model<Partial<AttributesOnly<VideoImportMo
 
   @AllowNull(false)
   @Default(null)
-  @Is('VideoImportState', value => throwIfNotValid(value, checkVideoImportState, 'state'))
+  @Is('VideoImportState', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoImportState), 'state'))
   @Column
   state: VideoImportState
 

--- a/server/models/video/video-playlist.ts
+++ b/server/models/video/video-playlist.ts
@@ -28,9 +28,9 @@ import { VideoPlaylist } from '../../../shared/models/videos/playlist/video-play
 import { activityPubCollectionPagination } from '../../helpers/activitypub'
 import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
 import {
-  isVideoPlaylistDescriptionValid,
-  isVideoPlaylistNameValid,
-  isVideoPlaylistPrivacyValid
+  checkVideoPlaylistDescription,
+  checkVideoPlaylistName,
+  checkVideoPlaylistPrivacy
 } from '../../helpers/custom-validators/video-playlists'
 import {
   ACTIVITY_PUB,
@@ -230,17 +230,17 @@ export class VideoPlaylistModel extends Model<Partial<AttributesOnly<VideoPlayli
   updatedAt: Date
 
   @AllowNull(false)
-  @Is('VideoPlaylistName', value => throwIfNotValid(value, isVideoPlaylistNameValid, 'name'))
+  @Is('VideoPlaylistName', value => throwIfNotValid(value, checkVideoPlaylistName, 'name'))
   @Column
   name: string
 
   @AllowNull(true)
-  @Is('VideoPlaylistDescription', value => throwIfNotValid(value, isVideoPlaylistDescriptionValid, 'description', true))
+  @Is('VideoPlaylistDescription', value => throwIfNotValid(value, checkVideoPlaylistDescription, 'description', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_PLAYLISTS.DESCRIPTION.max))
   description: string
 
   @AllowNull(false)
-  @Is('VideoPlaylistPrivacy', value => throwIfNotValid(value, isVideoPlaylistPrivacyValid, 'privacy'))
+  @Is('VideoPlaylistPrivacy', value => throwIfNotValid(value, checkVideoPlaylistPrivacy, 'privacy'))
   @Column
   privacy: VideoPlaylistPrivacy
 

--- a/server/models/video/video-playlist.ts
+++ b/server/models/video/video-playlist.ts
@@ -56,6 +56,7 @@ import { buildServerIdsFollowedBy, buildWhereIdOrUUID, getPlaylistSort, isOutdat
 import { ThumbnailModel } from './thumbnail'
 import { ScopeNames as VideoChannelScopeNames, VideoChannelModel } from './video-channel'
 import { VideoPlaylistElementModel } from './video-playlist-element'
+import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
 
 enum ScopeNames {
   AVAILABLE_FOR_LIST = 'AVAILABLE_FOR_LIST',
@@ -230,17 +231,17 @@ export class VideoPlaylistModel extends Model<Partial<AttributesOnly<VideoPlayli
   updatedAt: Date
 
   @AllowNull(false)
-  @Is('VideoPlaylistName', value => throwIfNotValid(value, checkVideoPlaylistName, 'name'))
+  @Is('VideoPlaylistName', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoPlaylistName), 'name'))
   @Column
   name: string
 
   @AllowNull(true)
-  @Is('VideoPlaylistDescription', value => throwIfNotValid(value, checkVideoPlaylistDescription, 'description', true))
+  @Is('VideoPlaylistDescription', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoPlaylistDescription), 'description', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEO_PLAYLISTS.DESCRIPTION.max))
   description: string
 
   @AllowNull(false)
-  @Is('VideoPlaylistPrivacy', value => throwIfNotValid(value, checkVideoPlaylistPrivacy, 'privacy'))
+  @Is('VideoPlaylistPrivacy', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoPlaylistPrivacy), 'privacy'))
   @Column
   privacy: VideoPlaylistPrivacy
 

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -8,7 +8,7 @@ import { VideoStreamingPlaylistType } from '../../../shared/models/videos/video-
 import { sha1 } from '../../helpers/core-utils'
 import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
 import { isArrayOf } from '../../helpers/custom-validators/misc'
-import { isVideoFileInfoHashValid } from '../../helpers/custom-validators/videos'
+import { checkVideoFileInfoHash } from '../../helpers/custom-validators/videos'
 import { CONSTRAINTS_FIELDS, MEMOIZE_LENGTH, MEMOIZE_TTL, P2P_MEDIA_LOADER_PEER_VERSION, STATIC_PATHS } from '../../initializers/constants'
 import { VideoRedundancyModel } from '../redundancy/video-redundancy'
 import { throwIfNotValid } from '../utils'
@@ -48,7 +48,7 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   playlistUrl: string
 
   @AllowNull(false)
-  @Is('VideoStreamingPlaylistInfoHashes', value => throwIfNotValid(value, v => isArrayOf(v, isVideoFileInfoHashValid), 'info hashes'))
+  @Is('VideoStreamingPlaylistInfoHashes', value => throwIfNotValid(value, v => isArrayOf(v, checkVideoFileInfoHash), 'info hashes'))
   @Column(DataType.ARRAY(DataType.STRING))
   p2pMediaLoaderInfohashes: string[]
 

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -7,7 +7,7 @@ import { MStreamingPlaylist } from '@server/types/models'
 import { VideoStreamingPlaylistType } from '../../../shared/models/videos/video-streaming-playlist.type'
 import { sha1 } from '../../helpers/core-utils'
 import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
-import { catchErrorAsBoolean, isArrayOf } from '../../helpers/custom-validators/misc'
+import { catchErrorAsBoolean, checkArrayWith } from '../../helpers/custom-validators/misc'
 import { checkVideoFileInfoHash } from '../../helpers/custom-validators/videos'
 import { CONSTRAINTS_FIELDS, MEMOIZE_LENGTH, MEMOIZE_TTL, P2P_MEDIA_LOADER_PEER_VERSION, STATIC_PATHS } from '../../initializers/constants'
 import { VideoRedundancyModel } from '../redundancy/video-redundancy'
@@ -49,7 +49,7 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
 
   @AllowNull(false)
   @Is('VideoStreamingPlaylistInfoHashes', value => {
-    throwIfNotValid(value, v => isArrayOf(v, catchErrorAsBoolean(checkVideoFileInfoHash)), 'info hashes')
+    throwIfNotValid(value, v => catchErrorAsBoolean(checkArrayWith)(v, checkVideoFileInfoHash), 'info hashes')
   })
   @Column(DataType.ARRAY(DataType.STRING))
   p2pMediaLoaderInfohashes: string[]

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -7,7 +7,7 @@ import { MStreamingPlaylist } from '@server/types/models'
 import { VideoStreamingPlaylistType } from '../../../shared/models/videos/video-streaming-playlist.type'
 import { sha1 } from '../../helpers/core-utils'
 import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
-import { isArrayOf } from '../../helpers/custom-validators/misc'
+import { catchErrorAsBoolean, isArrayOf } from '../../helpers/custom-validators/misc'
 import { checkVideoFileInfoHash } from '../../helpers/custom-validators/videos'
 import { CONSTRAINTS_FIELDS, MEMOIZE_LENGTH, MEMOIZE_TTL, P2P_MEDIA_LOADER_PEER_VERSION, STATIC_PATHS } from '../../initializers/constants'
 import { VideoRedundancyModel } from '../redundancy/video-redundancy'
@@ -48,7 +48,9 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   playlistUrl: string
 
   @AllowNull(false)
-  @Is('VideoStreamingPlaylistInfoHashes', value => throwIfNotValid(value, v => isArrayOf(v, checkVideoFileInfoHash), 'info hashes'))
+  @Is('VideoStreamingPlaylistInfoHashes', value => {
+    throwIfNotValid(value, v => isArrayOf(v, catchErrorAsBoolean(checkVideoFileInfoHash)), 'info hashes')
+  })
   @Column(DataType.ARRAY(DataType.STRING))
   p2pMediaLoaderInfohashes: string[]
 

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -44,14 +44,14 @@ import { isActivityPubUrlValid } from '../../helpers/custom-validators/activityp
 import { isBooleanValid } from '../../helpers/custom-validators/misc'
 import {
   isVideoCategoryValid,
-  isVideoDescriptionValid,
-  isVideoDurationValid,
+  checkVideoDescription,
+  checkVideoDuration,
   isVideoLanguageValid,
   isVideoLicenceValid,
-  isVideoNameValid,
+  checkVideoName,
   isVideoPrivacyValid,
   isVideoStateValid,
-  isVideoSupportValid
+  checkVideoSupport
 } from '../../helpers/custom-validators/videos'
 import { getVideoFileResolution } from '../../helpers/ffprobe-utils'
 import { logger } from '../../helpers/logger'
@@ -499,7 +499,7 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
   uuid: string
 
   @AllowNull(false)
-  @Is('VideoName', value => throwIfNotValid(value, isVideoNameValid, 'name'))
+  @Is('VideoName', value => throwIfNotValid(value, checkVideoName, 'name'))
   @Column
   name: string
 
@@ -533,18 +533,18 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoDescription', value => throwIfNotValid(value, isVideoDescriptionValid, 'description', true))
+  @Is('VideoDescription', value => throwIfNotValid(value, checkVideoDescription, 'description', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.DESCRIPTION.max))
   description: string
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoSupport', value => throwIfNotValid(value, isVideoSupportValid, 'support', true))
+  @Is('VideoSupport', value => throwIfNotValid(value, checkVideoSupport, 'support', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.SUPPORT.max))
   support: string
 
   @AllowNull(false)
-  @Is('VideoDuration', value => throwIfNotValid(value, isVideoDurationValid, 'duration'))
+  @Is('VideoDuration', value => throwIfNotValid(value, checkVideoDuration, 'duration'))
   @Column
   duration: number
 

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -41,16 +41,16 @@ import { VideoFilter } from '../../../shared/models/videos/video-query.type'
 import { VideoStreamingPlaylistType } from '../../../shared/models/videos/video-streaming-playlist.type'
 import { peertubeTruncate } from '../../helpers/core-utils'
 import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
-import { isBooleanValid } from '../../helpers/custom-validators/misc'
+import { catchErrorAsBoolean, isBooleanValid } from '../../helpers/custom-validators/misc'
 import {
-  isVideoCategoryValid,
+  checkVideoCategory,
   checkVideoDescription,
   checkVideoDuration,
-  isVideoLanguageValid,
-  isVideoLicenceValid,
+  checkVideoLanguage,
+  checkVideoLicence,
   checkVideoName,
-  isVideoPrivacyValid,
-  isVideoStateValid,
+  checkVideoPrivacy,
+  checkVideoState,
   checkVideoSupport
 } from '../../helpers/custom-validators/videos'
 import { getVideoFileResolution } from '../../helpers/ffprobe-utils'
@@ -499,30 +499,30 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
   uuid: string
 
   @AllowNull(false)
-  @Is('VideoName', value => throwIfNotValid(value, checkVideoName, 'name'))
+  @Is('VideoName', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoName), 'name'))
   @Column
   name: string
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoCategory', value => throwIfNotValid(value, isVideoCategoryValid, 'category', true))
+  @Is('VideoCategory', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoCategory), 'category', true))
   @Column
   category: number
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoLicence', value => throwIfNotValid(value, isVideoLicenceValid, 'licence', true))
+  @Is('VideoLicence', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoLicence), 'licence', true))
   @Column
   licence: number
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoLanguage', value => throwIfNotValid(value, isVideoLanguageValid, 'language', true))
+  @Is('VideoLanguage', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoLanguage), 'language', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.LANGUAGE.max))
   language: string
 
   @AllowNull(false)
-  @Is('VideoPrivacy', value => throwIfNotValid(value, isVideoPrivacyValid, 'privacy'))
+  @Is('VideoPrivacy', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoPrivacy), 'privacy'))
   @Column
   privacy: VideoPrivacy
 
@@ -533,18 +533,18 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoDescription', value => throwIfNotValid(value, checkVideoDescription, 'description', true))
+  @Is('VideoDescription', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoDescription), 'description', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.DESCRIPTION.max))
   description: string
 
   @AllowNull(true)
   @Default(null)
-  @Is('VideoSupport', value => throwIfNotValid(value, checkVideoSupport, 'support', true))
+  @Is('VideoSupport', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoSupport), 'support', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.SUPPORT.max))
   support: string
 
   @AllowNull(false)
-  @Is('VideoDuration', value => throwIfNotValid(value, checkVideoDuration, 'duration'))
+  @Is('VideoDuration', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoDuration), 'duration'))
   @Column
   duration: number
 
@@ -597,7 +597,7 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
 
   @AllowNull(false)
   @Default(null)
-  @Is('VideoState', value => throwIfNotValid(value, isVideoStateValid, 'state'))
+  @Is('VideoState', value => throwIfNotValid(value, catchErrorAsBoolean(checkVideoState), 'state'))
   @Column
   state: VideoState
 

--- a/server/tests/fixtures/peertube-plugin-test-four/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-four/main.js
@@ -134,7 +134,7 @@ async function unblockServer (peertubeHelpers, body) {
 async function blockAccount (peertubeHelpers, body) {
   const serverActor = await peertubeHelpers.server.getServerActor()
 
-  await peertubeHelpers.moderation.blockAccount({ byAccountId: serverActor.Account.id, handleToBlock: body.handleToBlock })
+  await peertubeHelpers.moderation.blockAccount({ byAccountId: serverActor.Account.id, handlcatchErrorAsBooleanlock: body.handlcatchErrorAsBooleanlock })
 }
 
 async function unblockAccount (peertubeHelpers, body) {

--- a/server/tests/plugins/plugin-helpers.ts
+++ b/server/tests/plugins/plugin-helpers.ts
@@ -184,7 +184,7 @@ describe('Test plugin helpers', function () {
     })
 
     it('Should mute account of server 2', async function () {
-      await postCommand(servers[0], 'blockAccount', { handleToBlock: `root@localhost:${servers[1].port}` })
+      await postCommand(servers[0], 'blockAccount', { handlcatchErrorAsBooleanlock: `root@localhost:${servers[1].port}` })
 
       const res = await getVideosList(servers[0].url)
       const videos = res.body.data

--- a/server/tools/peertube-auth.ts
+++ b/server/tools/peertube-auth.ts
@@ -6,7 +6,7 @@ registerTSPaths()
 import * as program from 'commander'
 import * as prompt from 'prompt'
 import { getNetrc, getSettings, writeSettings } from './cli'
-import { isUserUsernameValid } from '../helpers/custom-validators/users'
+import { checkUserUsername } from '../helpers/custom-validators/users'
 import { getAccessToken } from '../../shared/extra-utils'
 import * as CliTable3 from 'cli-table3'
 import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
@@ -80,7 +80,7 @@ program
           required: true
         },
         username: {
-          conform: (value) => catchErrorAsBoolean(isUserUsernameValid)(value),
+          conform: (value) => catchErrorAsBoolean(checkUserUsername)(value),
           message: 'Name must be only letters, spaces, or dashes',
           required: true
         },

--- a/server/tools/peertube-auth.ts
+++ b/server/tools/peertube-auth.ts
@@ -9,7 +9,7 @@ import { getNetrc, getSettings, writeSettings } from './cli'
 import { isUserUsernameValid } from '../helpers/custom-validators/users'
 import { getAccessToken } from '../../shared/extra-utils'
 import * as CliTable3 from 'cli-table3'
-import { catchError } from '@server/helpers/custom-validators/misc'
+import { EtoB } from '@server/helpers/custom-validators/misc'
 
 async function delInstance (url: string) {
   const [ settings, netrc ] = await Promise.all([ getSettings(), getNetrc() ])
@@ -80,7 +80,7 @@ program
           required: true
         },
         username: {
-          conform: (value) => catchError(isUserUsernameValid)(value),
+          conform: (value) => EtoB(isUserUsernameValid)(value),
           message: 'Name must be only letters, spaces, or dashes',
           required: true
         },

--- a/server/tools/peertube-auth.ts
+++ b/server/tools/peertube-auth.ts
@@ -9,6 +9,7 @@ import { getNetrc, getSettings, writeSettings } from './cli'
 import { isUserUsernameValid } from '../helpers/custom-validators/users'
 import { getAccessToken } from '../../shared/extra-utils'
 import * as CliTable3 from 'cli-table3'
+import { catchError } from '@server/helpers/custom-validators/misc'
 
 async function delInstance (url: string) {
   const [ settings, netrc ] = await Promise.all([ getSettings(), getNetrc() ])
@@ -79,7 +80,7 @@ program
           required: true
         },
         username: {
-          conform: (value) => isUserUsernameValid(value),
+          conform: (value) => catchError(isUserUsernameValid)(value),
           message: 'Name must be only letters, spaces, or dashes',
           required: true
         },

--- a/server/tools/peertube-auth.ts
+++ b/server/tools/peertube-auth.ts
@@ -9,7 +9,7 @@ import { getNetrc, getSettings, writeSettings } from './cli'
 import { isUserUsernameValid } from '../helpers/custom-validators/users'
 import { getAccessToken } from '../../shared/extra-utils'
 import * as CliTable3 from 'cli-table3'
-import { EtoB } from '@server/helpers/custom-validators/misc'
+import { catchErrorAsBoolean } from '@server/helpers/custom-validators/misc'
 
 async function delInstance (url: string) {
   const [ settings, netrc ] = await Promise.all([ getSettings(), getNetrc() ])
@@ -80,7 +80,7 @@ program
           required: true
         },
         username: {
-          conform: (value) => EtoB(isUserUsernameValid)(value),
+          conform: (value) => catchErrorAsBoolean(isUserUsernameValid)(value),
           message: 'Name must be only letters, spaces, or dashes',
           required: true
         },

--- a/server/types/plugins/register-server-option.model.ts
+++ b/server/types/plugins/register-server-option.model.ts
@@ -46,7 +46,7 @@ export type PeerTubeHelpers = {
   moderation: {
     blockServer: (options: { byAccountId: number, hostToBlock: string }) => Promise<void>
     unblockServer: (options: { byAccountId: number, hostToUnblock: string }) => Promise<void>
-    blockAccount: (options: { byAccountId: number, handleToBlock: string }) => Promise<void>
+    blockAccount: (options: { byAccountId: number, handlcatchErrorAsBooleanlock: string }) => Promise<void>
     unblockAccount: (options: { byAccountId: number, handleToUnblock: string }) => Promise<void>
 
     blacklistVideo: (options: { videoIdOrUUID: number | string, createOptions: VideoBlacklistCreate }) => Promise<void>

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -22,7 +22,7 @@ info:
     - [Kotlin](https://framagit.org/framasoft/peertube/clients/kotlin)
 
     See the [REST API quick start](https://docs.joinpeertube.org/api-rest-getting-started) for a few
-    examples of using with the PeerTube API.
+    examples of using the PeerTube API.
 
     # Authentication
 
@@ -125,7 +125,7 @@ tags:
     description: |
       As a visitor, you can use this API to open an account (if registrations are open on
       that PeerTube instance). As an admin, you should use the dedicated [User creation 
-      API](#operation/createUser) instead.
+      API](#operation/addUser) instead.
   - name: Session
     x-displayName: Login/Logout
     description: |
@@ -690,7 +690,7 @@ paths:
   /users:
     post:
       summary: Create a user
-      operationId: createUser
+      operationId: addUser
       security:
         - OAuth2:
           - admin
@@ -705,18 +705,18 @@ paths:
                 $ref: '#/components/schemas/AddUserResponse'
           links:
             # GET /users/{id}
-            GetUserId:
-              operationId: getUserId
+            GetUser:
+              operationId: getUser
               parameters:
                 id: '$response.body#/user/id'
             # PUT /users/{id}
-            PutUserId:
-              operationId: putUserId
+            PutUser:
+              operationId: putUser
               parameters:
                 id: '$response.body#/user/id'
             # DELETE /users/{id}
-            DelUserId:
-              operationId: delUserId
+            DelUser:
+              operationId: delUser
               parameters:
                 id: '$response.body#/user/id'
         '403':
@@ -764,7 +764,7 @@ paths:
           - admin
       tags:
         - Users
-      operationId: delUserId
+      operationId: delUser
       responses:
         '204':
           description: successful operation
@@ -774,7 +774,7 @@ paths:
         - OAuth2: []
       tags:
         - Users
-      operationId: getUserId
+      operationId: getUser
       parameters:
         - name: withStats
           in: query
@@ -799,7 +799,7 @@ paths:
         - OAuth2: []
       tags:
         - Users
-      operationId: putUserId
+      operationId: putUser
       responses:
         '204':
           description: successful operation
@@ -1493,6 +1493,7 @@ paths:
   /videos:
     get:
       summary: List videos
+      operationId: getVideos
       tags:
         - Video
       parameters:
@@ -2024,7 +2025,7 @@ paths:
   /videos/live:
     post:
       summary: Create a live
-      operationId: createLive
+      operationId: addLive
       security:
         - OAuth2: []
       tags:
@@ -2874,7 +2875,7 @@ paths:
     post:
       summary: Create a video playlist
       description: If the video playlist is set as public, `videoChannelId` is mandatory.
-      operationId: createPlaylist
+      operationId: addPlaylist
       security:
         - OAuth2: []
       tags:
@@ -2994,6 +2995,7 @@ paths:
   /video-playlists/{playlistId}/videos:
     get:
       summary: 'List videos of a playlist'
+      operationId: getVideoPlaylistVideos
       tags:
         - Videos
         - Video Playlists
@@ -3008,6 +3010,7 @@ paths:
                 $ref: '#/components/schemas/VideoListResponse'
     post:
       summary: Add a video in a playlist
+      operationId: addVideoPlaylistVideo
       security:
         - OAuth2: []
       tags:
@@ -3054,6 +3057,7 @@ paths:
   /video-playlists/{playlistId}/videos/reorder:
     post:
       summary: 'Reorder a playlist'
+      operationId: reorderVideoPlaylist
       security:
         - OAuth2: []
       tags:
@@ -3088,6 +3092,7 @@ paths:
   /video-playlists/{playlistId}/videos/{playlistElementId}:
     put:
       summary: Update a playlist element
+      operationId: putVideoPlaylistVideo
       security:
         - OAuth2: []
       tags:
@@ -3114,6 +3119,7 @@ paths:
                   description: Stop the video at this specific timestamp
     delete:
       summary: Delete an element from a playlist
+      operationId: delVideoPlaylistVideo
       security:
         - OAuth2: []
       tags:
@@ -3368,6 +3374,7 @@ paths:
       tags:
         - Search
       summary: Search videos
+      operationId: searchVideos
       parameters:
         - name: search
           in: query
@@ -3444,6 +3451,7 @@ paths:
       tags:
         - Search
       summary: Search channels
+      operationId: searchChannels
       parameters:
         - name: search
           in: query
@@ -3632,6 +3640,7 @@ paths:
       tags:
         - Video Mirroring
       summary: List videos being mirrored
+      operationId: getMirroredVideos
       security:
         - OAuth2:
           - admin
@@ -3661,6 +3670,7 @@ paths:
       tags:
         - Video Mirroring
       summary: Mirror a video
+      operationId: putMirroredVideo
       security:
         - OAuth2:
           - admin
@@ -3689,6 +3699,7 @@ paths:
       tags:
         - Video Mirroring
       summary: Delete a mirror done on a video
+      operationId: delMirroredVideo
       security:
         - OAuth2:
           - admin
@@ -3710,6 +3721,7 @@ paths:
       tags:
         - Feeds
       summary: List comments on videos
+      operationId: getSyndicatedComments
       parameters:
         - name: format
           in: path
@@ -3804,6 +3816,7 @@ paths:
       tags:
         - Feeds
       summary: List videos
+      operationId: getSyndicatedVideos
       parameters:
         - name: format
           in: path
@@ -3892,6 +3905,7 @@ paths:
         - Feeds
         - Account
       summary: List videos of subscriptions tied to a token
+      operationId: getSyndicatedSubscriptionVideos
       parameters:
         - name: format
           in: path
@@ -3954,6 +3968,7 @@ paths:
       tags:
         - Plugins
       summary: List plugins
+      operationId: getPlugins
       security:
         - OAuth2:
           - admin
@@ -3982,6 +3997,7 @@ paths:
       tags:
         - Plugins
       summary: List available plugins
+      operationId: getAvailablePlugins
       security:
         - OAuth2:
           - admin
@@ -4016,6 +4032,7 @@ paths:
       tags:
         - Plugins
       summary: Install a plugin
+      operationId: addPlugin
       security:
         - OAuth2:
           - admin
@@ -4050,6 +4067,7 @@ paths:
       tags:
         - Plugins
       summary: Update a plugin
+      operationId: updatePlugin
       security:
         - OAuth2:
           - admin
@@ -4086,6 +4104,7 @@ paths:
       tags:
         - Plugins
       summary: Uninstall a plugin
+      operationId: uninstallPlugin
       security:
         - OAuth2:
           - admin
@@ -4112,6 +4131,7 @@ paths:
       tags:
         - Plugins
       summary: Get a plugin
+      operationId: getPlugin
       security:
         - OAuth2:
           - admin

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -45,7 +45,7 @@ info:
     Content-Type: application/json
 
     {
-      "errorCode": 1
+      "errorCode": 1,
       "error": "Account not found"
     }
     ```


### PR DESCRIPTION
## Description

The goal is to have more descriptive error messages on malformed parameters, by replacing all-encompassing parameter checks that just produce a boolean, by an error thrown as close as possible to the failing check, where each check has an associated message:

```diff
{
  "errors": {
    "name": {
      "value": "<video name>",
-     "msg": "Should have a valid name",
+     "msg": "Should have a video name between 3 and 120 characters long",
      "param": "name",
      "location": "body"
    }
  }
}
```

I didn't change all checks, but focused on parameters which error messages might need reading the documentation in detail.

### Implementation details

Error being thrown in validation middlewares are okay so long as they are used within a [validator function](https://express-validator.github.io/docs/validation-chain-api.html#customvalidator). However some validation middlewares are also currently used as pure boolean checks, i.e. within another validation middleware or within a full-request validation function. The error there needs to be catched, for which we transform the potentially-returning function by wrapping it with `EtoB`:

```typescript
/**
 * Handle errors thrown by non-pure boolean validators as boolean
 */
function EtoB (fun: Function) (...args: any[]) => boolean | Error {
  return (...args) => {
    try {
      fun(...args)
    } catch (error) {
      return error
    }
    return true
  }
}
```

We also need to distinguish functions that might throw an `Error` from that which only return booleans. Sadly, [there is still no way to express that yet in Typescript itself](https://github.com/microsoft/TypeScript/issues/13219) ; so I marked such functions with JSDoc comments for now, i.e.:

```typescript
/**
 * @throws {Error}
 */
function isDateValid (value: string) {
  if (!exists(value)) throw new Error('Should have a date')
  if (!validator.isISO8601(value)) throw new Error('Should have a date conforming to ISO8601')
  return true
}
```

Within a pure-boolean check, this translates to `if (!EtoB(isDateValid)(value)) { …`. If you want to programmatically get the error message, you can switch the return mode by using `const error = EtoB(isDateValid, true)(value)`.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
fixes #4026

## Has this been tested?

- [x] 🙅 no, because they aren't needed