### PR TITLE
add possible OSX/postgres message to dependencies documentation

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -307,7 +307,7 @@ brew services run redis
 ```
 
 On macOS, the `postgresql` user can be `_postgres` instead of `postgres`.
-If `sudo -u postgres createuser -P peertube` gives you an error, you can try `sudo -u _postgres createuser -U peertube`.
+If `sudo -u postgres createuser -P peertube` gives you an `unknown user: postgres` error, you can try `sudo -u _postgres createuser -U peertube`.
 
 ## Gentoo
 


### PR DESCRIPTION
## Description

Specify message of possible Mac OS error in dependencies documentation, so people know whether to apply the suggested solution.

## Related issues

N/A

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Just a minor addition to documentation :)