### PR TITLE
Fix CLI plugins list command: use command parameters.

### DIFF
--- a/server/tools/peertube-plugins.ts
+++ b/server/tools/peertube-plugins.ts
@@ -24,7 +24,7 @@ program
   .option('-p, --password <token>', 'Password')
   .option('-t, --only-themes', 'List themes only')
   .option('-P, --only-plugins', 'List plugins only')
-  .action(() => pluginsListCLI())
+  .action((options, command) => pluginsListCLI(command, options))
 
 program
   .command('install')
@@ -61,12 +61,10 @@ if (!process.argv.slice(2).length) {
 
 program.parse(process.argv)
 
-const options = program.opts()
-
 // ----------------------------------------------------------------------------
 
-async function pluginsListCLI () {
-  const { url, username, password } = await getServerCredentials(program)
+async function pluginsListCLI (command: commander.CommanderStatic, options: commander.OptionValues) {
+  const { url, username, password } = await getServerCredentials(command)
   const accessToken = await getAdminTokenOrDie(url, username, password)
 
   let pluginType: PluginType


### PR DESCRIPTION
## Description

The `plugins list` command was not using --url, --username and --password parameters, and was always requesting on the first server in the .netrc file.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->
