### PR TITLE
Fix 4106: default boolean plugin setting for frontend

### DIFF
--- a/server/models/server/plugin.ts
+++ b/server/models/server/plugin.ts
@@ -284,7 +284,7 @@ export class PluginModel extends Model {
     for (const r of registeredSettings) {
       if (r.private !== false) continue
 
-      result[r.name] = settings[r.name] || r.default || null
+      result[r.name] = settings[r.name] ?? r.default ?? null
     }
 
     return result


### PR DESCRIPTION
## Description

If a plugin checkbox settings has a default value true, the frontend receive always true as value.

NB: I'm merging this on release/3.2.0 because I need this fix for the 3.2.0 release, and I tested the fix on this branch. Sorry if this is not right.

## Related issues

Fix for https://github.com/Chocobozzz/PeerTube/issues/4106

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

I have no time to add tests to this PR, sorry.
