### PR TITLE
Allow SSL database parameter

### DIFF
--- a/support/docker/production/.env
+++ b/support/docker/production/.env
@@ -8,6 +8,7 @@ POSTGRES_DB=peertube
 #PEERTUBE_DB_SUFFIX=_prod
 PEERTUBE_DB_USERNAME=<MY POSTGRES USERNAME>
 PEERTUBE_DB_PASSWORD=<MY POSTGRES PASSWORD>
+PEERTUBE_DB_SSL=false
 # Default to Postgres service name "postgres" in docker-compose.yml
 PEERTUBE_DB_HOSTNAME=postgres
 

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -19,7 +19,9 @@ database:
   suffix: "PEERTUBE_DB_SUFFIX"
   username: "PEERTUBE_DB_USERNAME"
   password: "PEERTUBE_DB_PASSWORD"
-  ssl: "PEERTUBE_DB_SSL"
+  ssl:
+    __name: "PEERTUBE_DB_SSL"
+    __format: "json"
 
 redis:
   hostname: "PEERTUBE_REDIS_HOSTNAME"

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -19,6 +19,7 @@ database:
   suffix: "PEERTUBE_DB_SUFFIX"
   username: "PEERTUBE_DB_USERNAME"
   password: "PEERTUBE_DB_PASSWORD"
+  ssl: "PEERTUBE_DB_SSL"
 
 redis:
   hostname: "PEERTUBE_REDIS_HOSTNAME"


### PR DESCRIPTION
Allow SSL database parameter via environment variable

## Description

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
