### PR TITLE
Show logo in mobile view

### DIFF
--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -70,6 +70,7 @@
   display: flex;
   align-items: center;
   overflow: hidden;
+  padding: 0 0 0 10px;
 
   .instance-name {
     @include ellipsis;

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -75,6 +75,10 @@
     @include ellipsis;
 
     width: 100%;
+
+    @media screen and (max-width: $mobile-view) {
+      display: none;
+    }
   }
 
   .icon.icon-logo {
@@ -82,10 +86,6 @@
     width: 23px;
     height: 24px;
     margin-right: 0.5rem;
-  }
-
-  @media screen and (max-width: $mobile-view) {
-    display: none;
   }
 }
 


### PR DESCRIPTION
## Description
Changes the mobile CSS so that only the instance name is hidden in mobile view.

## Has this been tested?

- [x] 👍 yes, light tests as follows are enough

1) Open the site with a screen res with max-width < 500 px.