### PR TITLE
Allow setting log level using PEERTUBE_LOG_LEVEL envvar

### DIFF
--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -46,6 +46,7 @@ smtp:
   from_address: "PEERTUBE_SMTP_FROM"
 
 log:
+  level: "PEERTUBE_LOG_LEVEL"
   log_ping_requests:
     __name: "PEERTUBE_LOG_PING_REQUESTS"
     __format: "json"


### PR DESCRIPTION
## Description

Add an environment variable for `log.level`.

## Related issues

I was asked in #4071 to run PeerTube with log level set to debug and figured it was not possible to set it using an environment variable.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

I tested on my own instance by modifying the `custom-environment-variables.yaml` file and setting `LOG_LEVEL=debug`.