### PR TITLE
Remove annoying superfluous slash

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-PEERTUBE_PATH=${1:-/var/www/peertube/}
+PEERTUBE_PATH=${1:-/var/www/peertube}
 
 if [ ! -e "$PEERTUBE_PATH" ]; then
   echo "Error - path \"$PEERTUBE_PATH\" wasn't found"


### PR DESCRIPTION
## Description

After running the automatic upgrade script a lot of paths get an extra slash (like the symbolic link for peertube-latest), because PEERTUBE_PATH has an unnecessary trailing slash. Although this doesn't lead to bugs, it's annoying the hell out of me for a couple of years now.

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [ ] 👍 yes, I added tests to the test suite
- [ ] 👍 yes, light tests as follows are enough
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
