### PR TITLE
Prefilled contact form with subject and body queryParams

### DIFF
--- a/client/src/app/+about/about-instance/about-instance.component.html
+++ b/client/src/app/+about/about-instance/about-instance.component.html
@@ -4,7 +4,7 @@
     <div class="about-instance-title">
       <h1 i18n class="title">About {{ instanceName }}</h1>
 
-      <a routerLink="contact" i18n *ngIf="isContactFormEnabled" class="contact-admin">Contact administrator</a>
+      <a routerLink="/about/contact" i18n *ngIf="isContactFormEnabled" class="contact-admin">Contact administrator</a>
     </div>
 
     <div class="instance-badges" *ngIf="categories.length !== 0 || languages.length !== 0">
@@ -218,4 +218,4 @@
   </div>
 </div>
 
-<my-contact-admin-modal></my-contact-admin-modal>
+<my-contact-admin-modal #contactAdminModal></my-contact-admin-modal>

--- a/client/src/app/+about/about-instance/about-instance.component.html
+++ b/client/src/app/+about/about-instance/about-instance.component.html
@@ -4,7 +4,7 @@
     <div class="about-instance-title">
       <h1 i18n class="title">About {{ instanceName }}</h1>
 
-      <button i18n *ngIf="isContactFormEnabled" (click)="openContactModal()" (keydown.enter)="openContactModal()" class="contact-admin">Contact administrator</button>
+      <a routerLink="contact" i18n *ngIf="isContactFormEnabled" class="contact-admin">Contact administrator</a>
     </div>
 
     <div class="instance-badges" *ngIf="categories.length !== 0 || languages.length !== 0">
@@ -218,4 +218,4 @@
   </div>
 </div>
 
-<my-contact-admin-modal #contactAdminModal></my-contact-admin-modal>
+<my-contact-admin-modal></my-contact-admin-modal>

--- a/client/src/app/+about/about-instance/about-instance.component.scss
+++ b/client/src/app/+about/about-instance/about-instance.component.scss
@@ -11,15 +11,10 @@
   }
 
   .contact-admin {
-    @include peertube-button;
+    @include peertube-button-link;
     @include orange-button;
 
     height: fit-content;
-
-    &:hover,
-    &:active {
-      text-decoration: none;
-    }
   }
 }
 
@@ -57,6 +52,10 @@
 .block {
   margin-bottom: 75px;
   font-size: 15px;
+}
+
+.short-description {
+  margin-top: 10px;
 }
 
 .short-description .dedicated-to-nsfw {

--- a/client/src/app/+about/about-instance/about-instance.component.scss
+++ b/client/src/app/+about/about-instance/about-instance.component.scss
@@ -15,6 +15,11 @@
     @include orange-button;
 
     height: fit-content;
+
+    &:hover,
+    &:active {
+      text-decoration: none;
+    }
   }
 }
 

--- a/client/src/app/+about/about-instance/about-instance.component.ts
+++ b/client/src/app/+about/about-instance/about-instance.component.ts
@@ -1,13 +1,12 @@
 import { ViewportScroller } from '@angular/common'
 import { AfterViewChecked, Component, ElementRef, OnInit, ViewChild } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
-import { ContactAdminModalComponent } from '@app/+about/about-instance/contact-admin-modal.component'
 import { Notifier, ServerService } from '@app/core'
-import { CustomMarkupService } from '@app/shared/shared-custom-markup'
 import { InstanceService } from '@app/shared/shared-instance'
-import { About, HTMLServerConfig, ServerConfig } from '@shared/models'
-import { copyToClipboard } from '../../../root-helpers/utils'
+import { copyToClipboard } from '@root-helpers/utils'
+import { HTMLServerConfig } from '@shared/models/server'
 import { ResolverData } from './about-instance.resolver'
+import { ContactAdminModalComponent } from './contact-admin-modal.component'
 
 @Component({
   selector: 'my-about-instance',
@@ -16,6 +15,7 @@ import { ResolverData } from './about-instance.resolver'
 })
 export class AboutInstanceComponent implements OnInit, AfterViewChecked {
   @ViewChild('descriptionWrapper') descriptionWrapper: ElementRef<HTMLInputElement>
+  @ViewChild('contactAdminModal', { static: true }) contactAdminModal: ContactAdminModalComponent
 
   shortDescription = ''
   descriptionContent: string
@@ -64,6 +64,14 @@ export class AboutInstanceComponent implements OnInit, AfterViewChecked {
     const { about, languages, categories }: ResolverData = this.route.snapshot.data.instanceData
 
     this.serverConfig = this.serverService.getHTMLConfig()
+
+    this.route.data.subscribe(data => {
+      if (!data?.isContact) return
+
+      const prefill = this.route.snapshot.queryParams
+
+      this.contactAdminModal.show(prefill)
+    })
 
     this.languages = languages
     this.categories = categories

--- a/client/src/app/+about/about-instance/about-instance.component.ts
+++ b/client/src/app/+about/about-instance/about-instance.component.ts
@@ -16,7 +16,6 @@ import { ResolverData } from './about-instance.resolver'
 })
 export class AboutInstanceComponent implements OnInit, AfterViewChecked {
   @ViewChild('descriptionWrapper') descriptionWrapper: ElementRef<HTMLInputElement>
-  @ViewChild('contactAdminModal', { static: true }) contactAdminModal: ContactAdminModalComponent
 
   shortDescription = ''
   descriptionContent: string
@@ -83,10 +82,6 @@ export class AboutInstanceComponent implements OnInit, AfterViewChecked {
 
       this.lastScrollHash = window.location.hash
     }
-  }
-
-  openContactModal () {
-    return this.contactAdminModal.show()
   }
 
   onClickCopyLink (anchor: HTMLAnchorElement) {

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.html
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.html
@@ -6,7 +6,7 @@
 
   <div class="modal-body">
 
-    <form novalidate [formGroup]="form" (ngSubmit)="sendForm()">
+    <form *ngIf="isContactFormEnabled()" novalidate [formGroup]="form" (ngSubmit)="sendForm()">
       <div class="form-group">
         <label i18n for="fromName">Your name</label>
         <input
@@ -52,6 +52,8 @@
         <input type="submit" i18n-value value="Submit" class="peertube-button orange-button" [disabled]="!form.valid" />
       </div>
     </form>
+
+    <div *ngIf="!isContactFormEnabled()" class="alert alert-error" i18n>The contact form is not enabled on this instance.</div>
 
   </div>
 </ng-template>

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.scss
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.scss
@@ -4,8 +4,18 @@
 input[type=text] {
   @include peertube-input-text(340px);
   display: block;
+
+  @media screen and (max-width: #{map-get($container-max-widths, sm)}) {
+    width: 100%;
+  }
 }
 
 textarea {
   @include peertube-textarea(100%, 200px);
+}
+
+@media screen and (max-width: breakpoint(md)) {
+  .modal-body {
+    text-align: left;
+  }
 }

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.scss
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.scss
@@ -3,6 +3,7 @@
 
 input[type=text] {
   @include peertube-input-text(340px);
+  display: block;
 }
 
 textarea {

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.scss
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.scss
@@ -1,21 +1,16 @@
 @import 'variables';
 @import 'mixins';
 
+.modal-body {
+  text-align: left;
+}
+
 input[type=text] {
   @include peertube-input-text(340px);
-  display: block;
 
-  @media screen and (max-width: #{map-get($container-max-widths, sm)}) {
-    width: 100%;
-  }
+  display: block;
 }
 
 textarea {
   @include peertube-textarea(100%, 200px);
-}
-
-@media screen and (max-width: breakpoint(md)) {
-  .modal-body {
-    text-align: left;
-  }
 }

--- a/client/src/app/+about/about-routing.module.ts
+++ b/client/src/app/+about/about-routing.module.ts
@@ -27,13 +27,20 @@ const aboutRoutes: Routes = [
         },
         resolve: {
           instanceData: AboutInstanceResolver
+        }
+      },
+      {
+        path: 'contact',
+        component: AboutInstanceComponent,
+        data: {
+          meta: {
+            title: $localize`Contact`
+          },
+          isContact: true
         },
-        children: [
-          {
-            path: 'contact',
-            component: ContactAdminModalComponent
-          }
-        ]
+        resolve: {
+          instanceData: AboutInstanceResolver
+        }
       },
       {
         path: 'peertube',

--- a/client/src/app/+about/about-routing.module.ts
+++ b/client/src/app/+about/about-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router'
 import { AboutFollowsComponent } from '@app/+about/about-follows/about-follows.component'
 import { AboutInstanceComponent } from '@app/+about/about-instance/about-instance.component'
 import { AboutInstanceResolver } from '@app/+about/about-instance/about-instance.resolver'
+import { ContactAdminModalComponent } from '@app/+about/about-instance/contact-admin-modal.component'
 import { AboutPeertubeComponent } from '@app/+about/about-peertube/about-peertube.component'
 import { AboutComponent } from './about.component'
 
@@ -26,7 +27,13 @@ const aboutRoutes: Routes = [
         },
         resolve: {
           instanceData: AboutInstanceResolver
-        }
+        },
+        children: [
+          {
+            path: 'contact',
+            component: ContactAdminModalComponent
+          }
+        ]
       },
       {
         path: 'peertube',

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -102,7 +102,7 @@
     opacity: 0.7;
   }
 
-  @media screen and (max-width: $width) {
+  @media screen and (max-width: calc(#{$width} + 40px)) {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Description

This PR adds a sub-route `/about/instance/contact` in order to prefill the contact form with a subject and a body queryParams.
Also fixes minor CSS issues for input displaying in the contact-form.

## Related issues

closes https://github.com/Chocobozzz/PeerTube/issues/4160

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, light tests as follows are enough

1. Enable the contact-form in the administration and configure a SMTP mail to test it.

- Click on the contact form button in `/about/instance`, it should open the modal with `/about/instance/contact`
- When you close the modal the router should redirect to `/about/instance`
- When you click on the modal body overlay, it should keeps the input value history when re-open the modal

- Access to `/about/instance/contact?subject=My Subject&body=My Body multiline%0Aline 1%0Aline 2`
- It should display the contact form in the modal with pre-filled inputs as shown in the screenshots
- When you click on the modal body overlay, it should keeps the input value history when re-open the modal when back browsing history
- When you close the modal the router should redirect to `/about/instance`

2. Disable the contact-form
- When accessing to `/about/instance/contact` it should display a 404 error


## Screenshots

![Capture d’écran du 2021-06-04 15-04-40](https://user-images.githubusercontent.com/1877318/120809732-aca9e800-c54a-11eb-89d7-486e6d0eeedf.png)

Minor CSS fixes
![Screenshot 2021-06-03 at 21-18-25 About this instance - PeerTube](https://user-images.githubusercontent.com/1877318/120809752-b03d6f00-c54a-11eb-9969-67d7705a1faf.png)

