### PR TITLE
allow public video privacy to be deleted in the web client

### DIFF
--- a/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
+++ b/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
@@ -184,7 +184,7 @@ export class VideoEditComponent implements OnInit, OnDestroy {
 
     this.serverService.getVideoPrivacies()
       .subscribe(privacies => {
-        this.videoPrivacies = this.videoService.explainedPrivacyLabels(privacies)
+        this.videoPrivacies = this.videoService.explainedPrivacyLabels(privacies).videoPrivacies
         if (this.schedulePublicationPossible) {
           this.videoPrivacies.push({
             id: this.SPECIAL_SCHEDULED_PRIVACY,

--- a/client/src/app/+videos/+video-edit/video-add-components/video-go-live.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-go-live.component.ts
@@ -30,8 +30,6 @@ export class VideoGoLiveComponent extends VideoSend implements OnInit, AfterView
   videoUUID: string
   error: string
 
-  protected readonly DEFAULT_VIDEO_PRIVACY = VideoPrivacy.PUBLIC
-
   constructor (
     protected formValidatorService: FormValidatorService,
     protected loadingBar: LoadingBarService,

--- a/client/src/app/+videos/+video-edit/video-add-components/video-import-torrent.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-import-torrent.component.ts
@@ -32,8 +32,6 @@ export class VideoImportTorrentComponent extends VideoSend implements OnInit, Af
   video: VideoEdit
   error: string
 
-  protected readonly DEFAULT_VIDEO_PRIVACY = VideoPrivacy.PUBLIC
-
   constructor (
     protected formValidatorService: FormValidatorService,
     protected loadingBar: LoadingBarService,

--- a/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-import-url.component.ts
@@ -31,8 +31,6 @@ export class VideoImportUrlComponent extends VideoSend implements OnInit, AfterV
   video: VideoEdit
   error: string
 
-  protected readonly DEFAULT_VIDEO_PRIVACY = VideoPrivacy.PUBLIC
-
   constructor (
     protected formValidatorService: FormValidatorService,
     protected loadingBar: LoadingBarService,

--- a/client/src/app/+videos/+video-edit/video-add-components/video-send.ts
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-send.ts
@@ -20,7 +20,6 @@ export abstract class VideoSend extends FormReactive implements OnInit {
 
   abstract firstStepDone: EventEmitter<string>
   abstract firstStepError: EventEmitter<void>
-  protected abstract readonly DEFAULT_VIDEO_PRIVACY: VideoPrivacy
 
   protected loadingBar: LoadingBarService
   protected notifier: Notifier
@@ -46,9 +45,10 @@ export abstract class VideoSend extends FormReactive implements OnInit {
     this.serverService.getVideoPrivacies()
         .subscribe(
           privacies => {
-            this.videoPrivacies = this.videoService.explainedPrivacyLabels(privacies)
+            const { videoPrivacies, defaultPrivacyId } = this.videoService.explainedPrivacyLabels(privacies)
 
-            this.firstStepPrivacyId = this.DEFAULT_VIDEO_PRIVACY
+            this.videoPrivacies = videoPrivacies
+            this.firstStepPrivacyId = defaultPrivacyId
           })
   }
 

--- a/client/src/app/+videos/+video-edit/video-add-components/video-upload.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-upload.component.ts
@@ -46,7 +46,6 @@ export class VideoUploadComponent extends VideoSend implements OnInit, OnDestroy
   enableRetryAfterError: boolean
 
   // So that it can be accessed in the template
-  protected readonly DEFAULT_VIDEO_PRIVACY = VideoPrivacy.PUBLIC
   protected readonly BASE_VIDEO_UPLOAD_URL = VideoService.BASE_VIDEO_URL + 'upload-resumable'
 
   private uploadxOptions: UploadxOptions

--- a/client/src/app/shared/shared-main/video/video.service.ts
+++ b/client/src/app/shared/shared-main/video/video.service.ts
@@ -1,8 +1,8 @@
-import { Observable, of, throwError } from 'rxjs'
-import { catchError, map, mergeMap, switchMap } from 'rxjs/operators'
-import { HttpClient, HttpErrorResponse, HttpParams, HttpRequest } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { catchError, map, switchMap } from 'rxjs/operators'
+import { HttpClient, HttpParams, HttpRequest } from '@angular/common/http'
 import { Injectable } from '@angular/core'
-import { ComponentPaginationLight, RestExtractor, RestService, ServerService, UserService, AuthService } from '@app/core'
+import { ComponentPaginationLight, RestExtractor, RestService, ServerService, UserService } from '@app/core'
 import { objectToFormData } from '@app/helpers'
 import {
   FeedFormat,
@@ -378,7 +378,7 @@ export class VideoService implements VideosProvider {
                )
   }
 
-  explainedPrivacyLabels (privacies: VideoConstant<VideoPrivacy>[]) {
+  explainedPrivacyLabels (privacies: VideoConstant<VideoPrivacy>[], defaultPrivacyId = VideoPrivacy.PUBLIC) {
     const base = [
       {
         id: VideoPrivacy.PRIVATE,
@@ -398,9 +398,14 @@ export class VideoService implements VideosProvider {
       }
     ]
 
-    return base
+    const videoPrivacies = base
       .filter(o => !!privacies.find(p => p.id === o.id)) // filter down to privacies that where in the input
       .map(o => ({ ...privacies[o.id - 1], ...o })) // merge the input privacies that contain a label, and extend them with a description
+
+    return {
+      defaultPrivacyId: videoPrivacies.find(p => p.id === defaultPrivacyId)?.id || videoPrivacies[0].id,
+      videoPrivacies
+    }
   }
 
   nsfwPolicyToParam (nsfwPolicy: NSFWPolicyType) {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
A small fix that factorises the static default video privacy to the function returning filtered video privacies, and computes the default video privacy based on those returned by the API.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- start with closing keywords if any apply: https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords -->
fixes #4159

## Has this been tested?

<!--- Put an `x` in the box that applies: -->
- [x] 👍 yes, light tests using the feature

