### PR TITLE
API doc: downloadEnabled boolean to PUT video

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -1740,6 +1740,9 @@ paths:
                 commentsEnabled:
                   description: Enable or disable comments for this video
                   type: boolean
+                downloadEnabled:
+                  description: Enable or disable downloading for this video
+                  type: boolean
                 originallyPublishedAt:
                   description: Date when the content was originally published
                   type: string
@@ -2203,7 +2206,7 @@ paths:
                   description: Enable or disable comments for this live video/replay
                   type: boolean
                 downloadEnabled:
-                  description: Enable or disable downloading for the replay of this live
+                  description: Enable or disable downloading for the replay of this live video
                   type: boolean
               required:
                 - channelId


### PR DESCRIPTION
## Description

When updating a video through the API, you can set the downloadEnabled boolean on PUT, but it's missing from the OpenAPI doc.

## Has this been tested?

Yes, I'm using a script on the API to bulk update downloadEnabled to true for all videos from a channel. Tested on a live production instance with the latest release.

## Addendum

This pull request also contains an addition of the word 'video' which seemed to be accidentally left out in a description for handling live videos.