### PR TITLE
add new filter hook to /overviews/videos

### DIFF
--- a/server/controllers/api/overviews.ts
+++ b/server/controllers/api/overviews.ts
@@ -7,6 +7,7 @@ import { CategoryOverview, ChannelOverview, TagOverview, VideosOverview } from '
 import { MEMOIZE_TTL, OVERVIEWS } from '../../initializers/constants'
 import * as memoizee from 'memoizee'
 import { logger } from '@server/helpers/logger'
+import { Hooks } from '../../lib/plugins/hooks'
 
 const overviewsRouter = express.Router()
 
@@ -108,7 +109,7 @@ async function getVideos (
   res: express.Response,
   where: { videoChannelId?: number, tagsOneOf?: string[], categoryOneOf?: number[] }
 ) {
-  const query = Object.assign({
+  let query = Object.assign({
     start: 0,
     count: 12,
     sort: '-createdAt',
@@ -119,7 +120,13 @@ async function getVideos (
     countVideos: false
   }, where)
 
-  const { data } = await VideoModel.listForApi(query)
+  query = await Hooks.wrapObject(query, 'filter:api.overviews.videos.list.params')
+
+  const { data } = await Hooks.wrapPromiseFun(
+    VideoModel.listForApi,
+    query,
+    'filter:api.overviews.videos.list.result'
+  )
 
   return data.map(d => d.toFormattedJSON())
 }

--- a/shared/models/plugins/server/server-hook.model.ts
+++ b/shared/models/plugins/server/server-hook.model.ts
@@ -18,6 +18,10 @@ export const serverFilterHookObject = {
   'filter:api.user.me.videos.list.params': true,
   'filter:api.user.me.videos.list.result': true,
 
+  // Filter params/result used to list overview videos for the REST API
+  'filter:api.overviews.videos.list.params': true,
+  'filter:api.overviews.videos.list.result': true,
+
   // Filter params/results to search videos/channels in the DB or on the remote index
   'filter:api.search.videos.local.list.params': true,
   'filter:api.search.videos.local.list.result': true,


### PR DESCRIPTION
Hi, Thanks for PeerTube! :smiley_cat:

## Description

This change adds new filter hooks `filter:api.overviews.videos.list.params` and `filter:api.overviews.videos.list.params` to /overviews/videos.

The motivation is because I want to make a plugin to [use `originallyPublishedAt` in all places where `publishedAt` is used](https://github.com/ahdinosaur/peertube-plugin-originally-published-at).

I got every other page working using hooks, (well except for the user history page), but the overview ("Discovery") page seems to use a different API endpoint without any hooks setup.

This is my first time poking in the code, so not sure if this is the best approach, but seemed to follow existing patterns.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help

What and where should I be testing?