### PR TITLE
Expose to plugin a way to reset categories to their initial state

### DIFF
--- a/server/tests/fixtures/peertube-plugin-test-video-constants/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-video-constants/main.js
@@ -1,13 +1,10 @@
 async function register ({
-  registerHook,
-  registerSetting,
-  settingsManager,
-  storageManager,
   videoCategoryManager,
   videoLicenceManager,
   videoLanguageManager,
   videoPrivacyManager,
-  playlistPrivacyManager
+  playlistPrivacyManager,
+  getRouter
 }) {
   videoLanguageManager.addLanguage('al_bhed', 'Al Bhed')
   videoLanguageManager.addLanguage('al_bhed2', 'Al Bhed 2')
@@ -28,19 +25,20 @@ async function register ({
 
   videoPrivacyManager.deletePrivacy(2)
   playlistPrivacyManager.deletePlaylistPrivacy(3)
+
+  {
+    const router = getRouter()
+    router.get('/reset-categories', (req, res) => {
+      videoCategoryManager.resetCategories()
+
+      res.sendStatus(204)
+    })
+  }
 }
 
-async function unregister () {
-  return
-}
+async function unregister () {}
 
 module.exports = {
   register,
   unregister
-}
-
-// ############################################################################
-
-function addToCount (obj) {
-  return Object.assign({}, obj, { count: obj.count + 1 })
 }

--- a/server/tests/plugins/video-constants.ts
+++ b/server/tests/plugins/video-constants.ts
@@ -2,21 +2,24 @@
 
 import * as chai from 'chai'
 import 'mocha'
-import { cleanupTests, flushAndRunServer, ServerInfo } from '../../../shared/extra-utils/server/servers'
+import {cleanupTests, flushAndRunServer, ServerInfo} from '../../../shared/extra-utils/server/servers'
 import {
   createVideoPlaylist,
   getPluginTestPath,
   getVideo,
   getVideoCategories,
   getVideoLanguages,
-  getVideoLicences, getVideoPlaylistPrivacies, getVideoPrivacies,
+  getVideoLicences,
+  getVideoPlaylistPrivacies,
+  getVideoPrivacies,
   installPlugin,
+  makeGetRequest,
   setAccessTokensToServers,
   uninstallPlugin,
   uploadVideo
 } from '../../../shared/extra-utils'
-import { VideoDetails, VideoPlaylistPrivacy } from '../../../shared/models/videos'
-import { HttpStatusCode } from '../../../shared/core-utils/miscs/http-error-codes'
+import {VideoDetails, VideoPlaylistPrivacy} from '../../../shared/models/videos'
+import {HttpStatusCode} from '../../../shared/core-utils/miscs/http-error-codes'
 
 const expect = chai.expect
 
@@ -171,6 +174,38 @@ describe('Test plugin altering video constants', function () {
       expect(playlistPrivacies[2]).to.exist
       expect(playlistPrivacies[3]).to.exist
     }
+  })
+
+  it('Should be able to reset categories', async function () {
+    await installPlugin({
+      url: server.url,
+      accessToken: server.accessToken,
+      path: getPluginTestPath('-video-constants')
+    })
+
+    let { body: categories } = await getVideoCategories(server.url)
+
+    expect(categories[1]).to.not.exist
+    expect(categories[2]).to.not.exist
+
+    expect(categories[42]).to.exist
+    expect(categories[43]).to.exist
+
+    await makeGetRequest({
+      url: server.url,
+      token: server.accessToken,
+      path: '/plugins/test-video-constants/router/reset-categories',
+      statusCodeExpected: HttpStatusCode.NO_CONTENT_204
+    })
+
+    const { body } = await getVideoCategories(server.url)
+    categories = body
+
+    expect(categories[1]).to.exist
+    expect(categories[2]).to.exist
+
+    expect(categories[42]).to.not.exist
+    expect(categories[43]).to.not.exist
   })
 
   after(async function () {

--- a/shared/models/plugins/server/managers/plugin-video-category-manager.model.ts
+++ b/shared/models/plugins/server/managers/plugin-video-category-manager.model.ts
@@ -2,4 +2,6 @@ export interface PluginVideoCategoryManager {
   addCategory: (categoryKey: number, categoryLabel: string) => boolean
 
   deleteCategory: (categoryKey: number) => boolean
+
+  resetCategories: () => void
 }

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -237,12 +237,19 @@ function register ({
 You can add/delete video categories, licences or languages using the appropriate managers:
 
 ```js
-function register (...) {
+function register ({ 
+  videoLanguageManager, 
+  videoCategoryManager, 
+  videoLicenceManager, 
+  videoPrivacyManager, 
+  playlistPrivacyManager 
+}) {
   videoLanguageManager.addLanguage('al_bhed', 'Al Bhed')
   videoLanguageManager.deleteLanguage('fr')
 
   videoCategoryManager.addCategory(42, 'Best category')
   videoCategoryManager.deleteCategory(1) // Music
+  videoCategoryManager.resetCategories() // Reset to initial categories
 
   videoLicenceManager.addLicence(42, 'Best licence')
   videoLicenceManager.deleteLicence(7) // Public domain


### PR DESCRIPTION
## Description

Expose a `resetCategories` method on the `PluginCategoriesManager` allowing a plugin developer to reset *customizations* done on the `VIDEO_CATEGORIES` to be clean on demand.

> - add a `resetConstants` method allowing to clean only one `type` of *alteration* for a specific plugin.
> - make `hash` map global for easier reference and dry up constants methods a little bit

This would help simplify some customization workflow when it involves renaming, updating, deleting, etc...

> I hesitated to create another method `getCategories` on the manager because I'm having another other issue where I find myself unable to call the API to retrieve the list of the categories. In the `register` method when the instance restarted the Rest API is not yet available... but I'll probably create a separate issue. 
> Would *reading* infos about the constants from these managers be considered insane? Shall it always go through the Rest API instead?

### Possible evolutions (or further refacto)

- expose such method on other *ConstantsManger*
- move `VideoConstant` interface to shared and rename \
- create a `PluginConstantManager` interface such as:
```
export interface PluginConstantManager {
  add: (key: string, label: string) => boolean
  delete: (key: string) => boolean
  reset: () => void
}
```
> All *managers* could then be created generically and reduce code duplication

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

> see https://framacolibri.org/t/plugin-system-issues/12417 for some background

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite