### PR TITLE
Add Service-Worker-Allowed header to plugin static files

### DIFF
--- a/server/controllers/plugins.ts
+++ b/server/controllers/plugins.ts
@@ -38,6 +38,12 @@ pluginsRouter.get('/plugins/:pluginName/:pluginVersion/static/:staticEndpoint(*)
   servePluginStaticDirectory
 )
 
+pluginsRouter.get('/plugins/:pluginName/:pluginVersion/service-worker-scripts/:staticEndpoint(*)',
+  getPluginValidator(PluginType.PLUGIN),
+  pluginStaticDirectoryValidator,
+  servePluginServiceWorkerDirectory
+)
+
 pluginsRouter.get('/plugins/:pluginName/:pluginVersion/client-scripts/:staticEndpoint(*)',
   getPluginValidator(PluginType.PLUGIN),
   pluginStaticDirectoryValidator,
@@ -113,7 +119,19 @@ function servePluginStaticDirectory (req: express.Request, res: express.Response
   if (!staticPath) return res.status(HttpStatusCode.NOT_FOUND_404).end()
 
   const filepath = file.join('/')
+
   return res.sendFile(join(plugin.path, staticPath, filepath), sendFileOptions)
+}
+
+function servePluginServiceWorkerDirectory (req: express.Request, res: express.Response) {
+  const plugin: RegisteredPlugin = res.locals.registeredPlugin
+  const staticEndpoint = req.params.staticEndpoint
+
+  if (!plugin.serviceWorkerScripts.includes(staticEndpoint)) return res.status(HttpStatusCode.NOT_FOUND_404).end()
+
+  return res.set({
+    'Service-Worker-Allowed': `/plugins/${plugin.name}`
+  }).sendFile(join(plugin.path, staticEndpoint), sendFileOptions)
 }
 
 function servePluginCustomRoutes (req: express.Request, res: express.Response, next: express.NextFunction) {

--- a/server/lib/plugins/plugin-manager.ts
+++ b/server/lib/plugins/plugin-manager.ts
@@ -32,6 +32,7 @@ export interface RegisteredPlugin {
 
   staticDirs: { [name: string]: string }
   clientScripts: { [name: string]: ClientScript }
+  serviceWorkerScripts: string[]
 
   css: string[]
 
@@ -407,6 +408,7 @@ export class PluginManager implements ServerHook {
       path: pluginPath,
       staticDirs: packageJSON.staticDirs,
       clientScripts,
+      serviceWorkerScripts: packageJSON.serviceWorkerScripts,
       css: packageJSON.css,
       registerHelpers: registerHelpers || undefined,
       unregister: library ? library.unregister : undefined

--- a/shared/models/plugins/plugin-package-json.model.ts
+++ b/shared/models/plugins/plugin-package-json.model.ts
@@ -21,6 +21,7 @@ export type PluginPackageJson = {
   library: string
 
   staticDirs: { [ name: string ]: string }
+  serviceWorkerScripts: string[]
   css: string[]
 
   clientScripts: ClientScript[]


### PR DESCRIPTION
## Description
Plugin files listed under serviceWorkerScripts in package.json will be served with a Service-Worker-Allowed header in the HTTP resp.

## Related issues
Closes #3830

## Has this been tested?

- [x] 🙋 no, because I need help <!-- Detail how we can help you >

This could be tested with the hello-world plugin if we add a service worker file to it. Right now it can be tested with https://framagit.org/kontrollanten/peertube-plugin-one-signal (don't use the version published to npm).