### PR TITLE
Trim access log messages to prevent double line break

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -164,7 +164,7 @@ morgan.token('user-agent', (req: express.Request) => {
 })
 app.use(morgan('combined', {
   stream: {
-    write: (str: string) => logger.info(str, { tags: [ 'http' ] })
+    write: (str: string) => logger.info(str.trim(), { tags: [ 'http' ] })
   },
   skip: req => CONFIG.LOG.LOG_PING_REQUESTS === false && req.originalUrl === '/api/v1/ping'
 }))


### PR DESCRIPTION
## Description

Currently access logs are printed with double line breaks at the end:
 
```
[peertube.br0.fr:443] 2021-07-05 15:40:55.767 info: xxx - - [05/Jul/2021:15:40:55 +0000] "GET /api/v1/instance HTTP/1.1" 400 - "-" "FediList agent (https://fedilist.com/)"

[peertube.br0.fr:443] 2021-07-05 15:40:55.940 info: xxx - - [05/Jul/2021:15:40:55 +0000] "GET /.well-known/nodeinfo HTTP/1.1" 200 120 "-" "FediList agent (https://fedilist.com/)"

[peertube.br0.fr:443] 2021-07-05 15:40:56.155 info: xxx - - [05/Jul/2021:15:40:56 +0000] "GET /nodeinfo/2.0.json HTTP/1.1" 200 1659 "-" "FediList agent (https://fedilist.com/)"

```

Other logs are printed with only one line break:

```
[peertube.br0.fr:443] 2021-07-05 15:38:25.784 info: Processing ActivityPub fetcher in job 98.
[peertube.br0.fr:443] 2021-07-05 15:38:25.789 info: Crawling ActivityPub data on https://skeptikon.fr/accounts/ospring/playlists.
[peertube.br0.fr:443] 2021-07-05 15:38:25.882 info: Processing 0 ActivityPub items for https://skeptikon.fr/accounts/ospring/playlists?page=1.
[peertube.br0.fr:443] 2021-07-05 15:38:25.884 info: Processing ActivityPub fetcher in job 99.
[peertube.br0.fr:443] 2021-07-05 15:38:25.888 info: Crawling ActivityPub data on https://skeptikon.fr/accounts/ana06/playlists.
[peertube.br0.fr:443] 2021-07-05 15:38:25.982 info: Processing 0 ActivityPub items for https://skeptikon.fr/accounts/ana06/playlists?page=1.
```

Mixed logs produce mixed outputs:

```
[peertube.br0.fr:443] 2021-07-05 15:40:55.767 info: xxx - - [05/Jul/2021:15:40:55 +0000] "GET /api/v1/instance HTTP/1.1" 400 - "-" "FediList agent (https://fedilist.com/)"

[peertube.br0.fr:443] 2021-07-05 15:40:55.940 info: xxx - - [05/Jul/2021:15:40:55 +0000] "GET /.well-known/nodeinfo HTTP/1.1" 200 120 "-" "FediList agent (https://fedilist.com/)"

[peertube.br0.fr:443] 2021-07-05 15:40:56.155 info: xxx - - [05/Jul/2021:15:40:56 +0000] "GET /nodeinfo/2.0.json HTTP/1.1" 200 1659 "-" "FediList agent (https://fedilist.com/)"

[peertube.br0.fr:443] 2021-07-05 15:41:46.984 info: Receiving inbox requests for 1 activities by https://indymotion.fr/accounts/peertube.
[peertube.br0.fr:443] 2021-07-05 15:41:46.985 info: xxx - - [05/Jul/2021:15:41:46 +0000] "POST /inbox HTTP/1.1" 204 - "-" "PeerTube/3.2.1 (+https://indymotion.fr)"

```

## Related issues

I didn’t find one.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help

Not sure if I should add test for that nor how to do it.