### PR TITLE
Change default order in search results to -views

### DIFF
--- a/client/src/app/+search/search-filters.component.html
+++ b/client/src/app/+search/search-filters.component.html
@@ -5,7 +5,7 @@
       <div class="form-group">
         <div class="radio-label label-container">
           <label i18n>Sort</label>
-          <button i18n class="reset-button reset-button-small" (click)="resetField('sort', '-match')" *ngIf="advancedSearch.sort !== '-match'">
+          <button i18n class="reset-button reset-button-small" (click)="resetField('sort', '-views')" *ngIf="advancedSearch.sort !== '-match'">
             Reset
           </button>
         </div>

--- a/client/src/app/shared/shared-search/advanced-search.model.ts
+++ b/client/src/app/shared/shared-search/advanced-search.model.ts
@@ -73,7 +73,7 @@ export class AdvancedSearch {
     if (isNaN(this.durationMin)) this.durationMin = undefined
     if (isNaN(this.durationMax)) this.durationMax = undefined
 
-    this.sort = options.sort || '-match'
+    this.sort = options.sort || '-views'
   }
 
   containsValues () {

--- a/server/controllers/api/search/search-videos.ts
+++ b/server/controllers/api/search/search-videos.ts
@@ -19,7 +19,7 @@ import {
   optionalAuthenticate,
   paginationValidator,
   setDefaultPagination,
-  setDefaultSearchSort,
+  setDefaultSearchVideoSort,
   videosSearchSortValidator,
   videosSearchValidator
 } from '../../../middlewares'
@@ -33,7 +33,7 @@ searchVideosRouter.get('/videos',
   paginationValidator,
   setDefaultPagination,
   videosSearchSortValidator,
-  setDefaultSearchSort,
+  setDefaultSearchVideoSort,
   optionalAuthenticate,
   commonVideosFiltersValidator,
   videosSearchValidator,

--- a/server/middlewares/sort.ts
+++ b/server/middlewares/sort.ts
@@ -8,6 +8,8 @@ const setDefaultVideoRedundanciesSort = setDefaultSortFactory('name')
 
 const setDefaultSearchSort = setDefaultSortFactory('-match')
 
+const setDefaultSearchVideoSort = setDefaultSortFactory('-views')
+
 function setBlacklistSort (req: express.Request, res: express.Response, next: express.NextFunction) {
   const newSort: SortType = { sortModel: undefined, sortValue: '' }
 
@@ -34,6 +36,7 @@ function setBlacklistSort (req: express.Request, res: express.Response, next: ex
 export {
   setDefaultSort,
   setDefaultSearchSort,
+  setDefaultSearchVideoSort,
   setDefaultVideosSort,
   setDefaultVideoRedundanciesSort,
   setBlacklistSort


### PR DESCRIPTION
## Description
Change default sort order in search results to -views, since the relevance search order doesn't really makes sense.

## Related issues
Closes #4219


## Has this been tested?

- [x] 🙋 no, because I need help

Does this really need a test?