### PR TITLE
Postgresql-setup init option for auth-host

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -101,7 +101,7 @@ sudo -H -u peertube CC=/opt/rh/devtoolset-7/root/usr/bin/gcc CXX=/opt/rh/devtool
 6. Initialize the PostgreSQL database:
 
 ```
-sudo postgresql-setup initdb --auth-host=md5
+sudo PGSETUP_INITDB_OPTIONS='--auth-host=md5' postgresql-setup --initdb --unit postgresql
 ```
 
 Now that dependencies are installed, before running PeerTube you should enable and start PostgreSQL and Redis:
@@ -141,7 +141,7 @@ sudo ln -s /usr/bin/python3 /usr/bin/python
 6. Initialize the PostgreSQL database:
 
 ```
-sudo postgresql-setup initdb --auth-host=md5
+sudo PGSETUP_INITDB_OPTIONS='--auth-host=md5' postgresql-setup --initdb --unit postgresql
 ```
 
 Now that dependencies are installed, before running PeerTube you should enable and start PostgreSQL and Redis:
@@ -208,7 +208,7 @@ _from [PostgreSQL documentation](https://www.postgresql.org/download/linux/redha
 
 ```
 # PostgreSQL
-sudo postgresql-setup initdb --auth-host=md5
+sudo PGSETUP_INITDB_OPTIONS='--auth-host=md5' postgresql-setup --initdb --unit postgresql
 sudo systemctl enable postgresql.service
 sudo systemctl start postgresql.service
 # Nginx

--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -101,7 +101,7 @@ sudo -H -u peertube CC=/opt/rh/devtoolset-7/root/usr/bin/gcc CXX=/opt/rh/devtool
 6. Initialize the PostgreSQL database:
 
 ```
-sudo postgresql-setup initdb
+sudo postgresql-setup initdb --auth-host=md5
 ```
 
 Now that dependencies are installed, before running PeerTube you should enable and start PostgreSQL and Redis:
@@ -141,7 +141,7 @@ sudo ln -s /usr/bin/python3 /usr/bin/python
 6. Initialize the PostgreSQL database:
 
 ```
-sudo postgresql-setup initdb
+sudo postgresql-setup initdb --auth-host=md5
 ```
 
 Now that dependencies are installed, before running PeerTube you should enable and start PostgreSQL and Redis:
@@ -188,7 +188,7 @@ This is necessary because `ffmpeg` is not in the Fedora repos.
 7. Run:
 
 ```
-sudo dnf install nginx ffmpeg postgresql-server postgresql-contrib openssl gcc-c++ make redis git vim oidentd
+sudo dnf install nginx ffmpeg postgresql-server postgresql-contrib openssl gcc-c++ make redis git vim
 ffmpeg -version # Should be >= 4.1
 g++ -v # Should be >= 5.x
 ```
@@ -208,7 +208,7 @@ _from [PostgreSQL documentation](https://www.postgresql.org/download/linux/redha
 
 ```
 # PostgreSQL
-sudo postgresql-setup initdb
+sudo postgresql-setup initdb --auth-host=md5
 sudo systemctl enable postgresql.service
 sudo systemctl start postgresql.service
 # Nginx
@@ -217,9 +217,6 @@ sudo systemctl start nginx.service
 # Redis
 sudo systemctl enable redis.service
 sudo systemctl start redis.service
-# oidentd
-sudo systemctl enable oidentd.service
-sudo systemctl start oidentd.service
 ```
 
 10. Firewall


### PR DESCRIPTION
## Description

Initializing the postgresql database uses `ident` instead of `md5` as authentication for host on Red Hat family distributions. PeerTube uses (and expects) password authentication for postgresql. By using postgresql-setup/initdb with this specific setup option, one doesn't need to install oidentd which needs a 'peertube' Linux user to match authentication and doesn't exist yet when you are using the dependencies guide for development (in the production guide the peertube user is created in /var/www/peertube). This way of setup also prevents editing the pg_hba.conf manually afterwards.

## Has this been tested?

Tested on RHEL8 and Fedora. Syntax for postgresql-setup with --initdb as argument replaces obsoleted initdb mode call. See 'Post-installation' at https://www.postgresql.org/download/linux/redhat/

## Screenshots

Result after using this (last 12 lines of pg_hba.conf, `md5` replaced `ident`):

```
# TYPE  DATABASE        USER            ADDRESS                 METHOD

# "local" is for Unix domain socket connections only
local   all             all                                     peer
# IPv4 local connections:
host    all             all             127.0.0.1/32            md5
# IPv6 local connections:
host    all             all             ::1/128                 md5
# Allow replication connections from localhost, by a user with the
# replication privilege.
local   replication     all                                     peer
host    replication     all             127.0.0.1/32            md5
host    replication     all             ::1/128                 md5
```
