### PR TITLE
Allow caching for HLS playlists & videos

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "tsconfig-paths": "^3.9.0",
     "tslib": "^2.0.0",
     "useragent": "^2.3.0",
+    "uuidv4": "^6.2.11",
     "validator": "^13.0.0",
     "webfinger.js": "^2.6.6",
     "webtorrent": "^1.0.0",

--- a/server/controllers/api/videos/upload.ts
+++ b/server/controllers/api/videos/upload.ts
@@ -240,7 +240,7 @@ async function buildNewFile (video: MVideo, videoPhysicalFile: express.VideoUplo
     videoFile.resolution = (await getVideoFileResolution(videoPhysicalFile.path)).videoFileResolution
   }
 
-  videoFile.filename = generateVideoFilename(video, false, videoFile.resolution, videoFile.extname)
+  videoFile.filename = generateVideoFilename(false, videoFile.resolution, videoFile.extname)
 
   return videoFile
 }

--- a/server/lib/hls.ts
+++ b/server/lib/hls.ts
@@ -2,7 +2,7 @@ import { close, ensureDir, move, open, outputJSON, pathExists, read, readFile, r
 import { flatten, uniq } from 'lodash'
 import { basename, dirname, join } from 'path'
 import { MVideoWithFile } from '@server/types/models'
-import { sha256 } from '../helpers/core-utils'
+import { sha1, sha256 } from '../helpers/core-utils'
 import { getAudioStreamCodec, getVideoStreamCodec, getVideoStreamSize } from '../helpers/ffprobe-utils'
 import { logger } from '../helpers/logger'
 import { doRequest, doRequestAndSaveToFile } from '../helpers/requests'
@@ -58,7 +58,7 @@ async function updateMasterHLSPlaylist (video: MVideoWithFile) {
     line += `,CODECS="${codecs.filter(c => !!c).join(',')}"`
 
     masterPlaylists.push(line)
-    masterPlaylists.push(VideoStreamingPlaylistModel.getHlsPlaylistFilename(file.resolution))
+    masterPlaylists.push(`${VideoStreamingPlaylistModel.getHlsPlaylistFilename(file.resolution)}?hash=${sha1(file.filename)}`)
   }
 
   await writeFile(masterPlaylistPath, masterPlaylists.join('\n') + '\n')

--- a/server/lib/job-queue/handlers/video-file-import.ts
+++ b/server/lib/job-queue/handlers/video-file-import.ts
@@ -72,7 +72,7 @@ async function updateVideoFile (video: MVideoFullLight, inputFilePath: string) {
   const newVideoFile = new VideoFileModel({
     resolution: videoFileResolution,
     extname: fileExt,
-    filename: generateVideoFilename(video, false, videoFileResolution, fileExt),
+    filename: generateVideoFilename(false, videoFileResolution, fileExt),
     size,
     fps,
     videoId: video.id

--- a/server/lib/job-queue/handlers/video-import.ts
+++ b/server/lib/job-queue/handlers/video-import.ts
@@ -124,7 +124,7 @@ async function processFile (downloader: () => Promise<string>, videoImport: MVid
       extname: fileExt,
       resolution: videoFileResolution,
       size: stats.size,
-      filename: generateVideoFilename(videoImport.Video, false, videoFileResolution, fileExt),
+      filename: generateVideoFilename(false, videoFileResolution, fileExt),
       fps,
       videoId: videoImport.videoId
     }

--- a/server/lib/transcoding/video-transcoding.ts
+++ b/server/lib/transcoding/video-transcoding.ts
@@ -16,6 +16,7 @@ import { VideoStreamingPlaylistModel } from '../../models/video/video-streaming-
 import { updateMasterHLSPlaylist, updateSha256VODSegments } from '../hls'
 import { generateVideoFilename, generateVideoStreamingPlaylistName, getVideoFilePath } from '../video-paths'
 import { VideoTranscodingProfilesManager } from './video-transcoding-profiles'
+import { uuid as uuidv4 } from 'uuidv4'
 
 /**
  *
@@ -60,7 +61,7 @@ async function optimizeOriginalVideofile (video: MVideoFullLight, inputVideoFile
 
     // Important to do this before getVideoFilename() to take in account the new filename
     inputVideoFile.extname = newExtname
-    inputVideoFile.filename = generateVideoFilename(video, false, resolution, newExtname)
+    inputVideoFile.filename = generateVideoFilename(false, resolution, newExtname)
 
     const videoOutputPath = getVideoFilePath(video, inputVideoFile)
 
@@ -86,7 +87,7 @@ async function transcodeNewWebTorrentResolution (video: MVideoFullLight, resolut
   const newVideoFile = new VideoFileModel({
     resolution,
     extname,
-    filename: generateVideoFilename(video, false, resolution, extname),
+    filename: generateVideoFilename(false, resolution, extname),
     size: 0,
     videoId: video.id
   })
@@ -169,7 +170,7 @@ async function mergeAudioVideofile (video: MVideoFullLight, resolution: VideoRes
 
   // Important to do this before getVideoFilename() to take in account the new file extension
   inputVideoFile.extname = newExtname
-  inputVideoFile.filename = generateVideoFilename(video, false, inputVideoFile.resolution, newExtname)
+  inputVideoFile.filename = generateVideoFilename(false, inputVideoFile.resolution, newExtname)
 
   const videoOutputPath = getVideoFilePath(video, inputVideoFile)
   // ffmpeg generated a new video file, so update the video duration
@@ -271,7 +272,8 @@ async function generateHlsPlaylistCommon (options: {
   const videoTranscodedBasePath = join(transcodeDirectory, type)
   await ensureDir(videoTranscodedBasePath)
 
-  const videoFilename = generateVideoStreamingPlaylistName(video.uuid, resolution)
+  const uuid = uuidv4()
+  const videoFilename = generateVideoStreamingPlaylistName(uuid, resolution)
   const playlistFilename = VideoStreamingPlaylistModel.getHlsPlaylistFilename(resolution)
   const playlistFileTranscodePath = join(videoTranscodedBasePath, playlistFilename)
 
@@ -319,7 +321,7 @@ async function generateHlsPlaylistCommon (options: {
     resolution,
     extname,
     size: 0,
-    filename: generateVideoFilename(video, true, resolution, extname),
+    filename: videoFilename,
     fps: -1,
     videoStreamingPlaylistId: videoStreamingPlaylist.id
   })
@@ -337,7 +339,6 @@ async function generateHlsPlaylistCommon (options: {
   await move(join(videoTranscodedBasePath, videoFilename), videoFilePath, { overwrite: true })
 
   const stats = await stat(videoFilePath)
-
   newVideoFile.size = stats.size
   newVideoFile.fps = await getVideoFileFPS(videoFilePath)
   newVideoFile.metadata = await getMetadataFromFile(videoFilePath)

--- a/server/lib/video-paths.ts
+++ b/server/lib/video-paths.ts
@@ -1,4 +1,5 @@
 import { join } from 'path'
+import { uuid as uuidv4 } from 'uuidv4'
 import { extractVideo } from '@server/helpers/video'
 import { CONFIG } from '@server/initializers/config'
 import { HLS_REDUNDANCY_DIRECTORY, HLS_STREAMING_PLAYLIST_DIRECTORY, STATIC_PATHS, WEBSERVER } from '@server/initializers/constants'
@@ -6,12 +7,8 @@ import { isStreamingPlaylist, MStreamingPlaylist, MStreamingPlaylistVideo, MVide
 
 // ################## Video file name ##################
 
-function generateVideoFilename (videoOrPlaylist: MVideo | MStreamingPlaylistVideo, isHls: boolean, resolution: number, extname: string) {
-  const video = extractVideo(videoOrPlaylist)
-
-  // FIXME: use a generated uuid instead, that will break compatibility with PeerTube < 3.1
-  // const uuid = uuidv4()
-  const uuid = video.uuid
+function generateVideoFilename (isHls: boolean, resolution: number, extname: string) {
+  const uuid = uuidv4()
 
   if (isHls) {
     return generateVideoStreamingPlaylistName(uuid, resolution)

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -171,10 +171,6 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
     return join(STATIC_PATHS.STREAMING_PLAYLISTS.HLS, videoUUID, VideoStreamingPlaylistModel.getMasterHlsPlaylistFilename())
   }
 
-  static getHlsPlaylistStaticPath (videoUUID: string, resolution: number) {
-    return join(STATIC_PATHS.STREAMING_PLAYLISTS.HLS, videoUUID, VideoStreamingPlaylistModel.getHlsPlaylistFilename(resolution))
-  }
-
   static getHlsSha256SegmentsStaticPath (videoUUID: string, isLive: boolean) {
     if (isLive) return join('/live', 'segments-sha256', videoUUID)
 

--- a/server/tests/api/live/live.ts
+++ b/server/tests/api/live/live.ts
@@ -529,8 +529,8 @@ describe('Test live', function () {
             expect(file.fps).to.be.approximately(30, 2)
           }
 
-          const filename = `${video.uuid}-${resolution}-fragmented.mp4`
-          const segmentPath = buildServerDirectory(servers[0], join('streaming-playlists', 'hls', video.uuid, filename))
+          const filename = new RegExp(`${resolution}-fragmented.mp4$`)
+          const segmentPath = buildServerDirectory(servers[0], join('streaming-playlists', 'hls', video.uuid), filename)
 
           const probe = await ffprobePromise(segmentPath)
           const videoStream = await getVideoStreamFromFile(segmentPath, probe)

--- a/server/tests/api/redundancy/redundancy.ts
+++ b/server/tests/api/redundancy/redundancy.ts
@@ -228,9 +228,9 @@ async function check1PlaylistRedundancies (videoUUID?: string) {
     expect(files).to.have.length.at.least(4)
 
     for (const resolution of [ 240, 360, 480, 720 ]) {
-      const filename = `${videoUUID}-${resolution}-fragmented.mp4`
+      const filename = new RegExp(`${resolution}-fragmented.mp4$`)
 
-      expect(files.find(f => f === filename)).to.not.be.undefined
+      expect(files.find(f => filename.test(f))).to.be.true
     }
   }
 }

--- a/server/tests/api/videos/audio-only.ts
+++ b/server/tests/api/videos/audio-only.ts
@@ -82,7 +82,7 @@ describe('Test audio only video transcoding', function () {
   it('0p transcoded video should not have video', async function () {
     const paths = [
       buildServerDirectory(servers[0], join('videos', videoUUID + '-0.mp4')),
-      buildServerDirectory(servers[0], join('streaming-playlists', 'hls', videoUUID, videoUUID + '-0-fragmented.mp4'))
+      buildServerDirectory(servers[0], join('streaming-playlists', 'hls', videoUUID), new RegExp('-0-fragmented.mp4$'))
     ]
 
     for (const path of paths) {

--- a/server/tests/api/videos/video-hls.ts
+++ b/server/tests/api/videos/video-hls.ts
@@ -53,9 +53,9 @@ async function checkHlsPlaylist (servers: ServerInfo[], videoUUID: string, hlsOn
 
       expect(file.magnetUri).to.have.lengthOf.above(2)
       expect(file.torrentUrl).to.equal(`http://${server.host}/lazy-static/torrents/${videoDetails.uuid}-${file.resolution.id}-hls.torrent`)
-      expect(file.fileUrl).to.equal(
-        `${baseUrl}/static/streaming-playlists/hls/${videoDetails.uuid}/${videoDetails.uuid}-${file.resolution.id}-fragmented.mp4`
-      )
+      expect(file.fileUrl).to.match(new RegExp(
+        `${baseUrl}/static/streaming-playlists/hls/${videoDetails.uuid}/.*-${file.resolution.id}-fragmented.mp4`
+      ))
       expect(file.resolution.label).to.equal(resolution + 'p')
 
       await makeRawRequest(file.torrentUrl, HttpStatusCode.OK_200)
@@ -84,7 +84,7 @@ async function checkHlsPlaylist (servers: ServerInfo[], videoUUID: string, hlsOn
         const res = await getPlaylist(`${baseUrl}/static/streaming-playlists/hls/${videoUUID}/${resolution}.m3u8`)
 
         const subPlaylist = res.text
-        expect(subPlaylist).to.contain(`${videoUUID}-${resolution}-fragmented.mp4`)
+        expect(subPlaylist).to.contain(new RegExp(`-${resolution}-fragmented.mp4$`))
       }
     }
 

--- a/shared/extra-utils/miscs/miscs.ts
+++ b/shared/extra-utils/miscs/miscs.ts
@@ -2,7 +2,7 @@
 
 import * as chai from 'chai'
 import * as ffmpeg from 'fluent-ffmpeg'
-import { ensureDir, pathExists, readFile, stat } from 'fs-extra'
+import { ensureDir, pathExists, readFile, stat, readdirSync } from 'fs-extra'
 import { basename, dirname, isAbsolute, join, resolve } from 'path'
 import * as request from 'supertest'
 import * as WebTorrent from 'webtorrent'
@@ -45,8 +45,16 @@ function root () {
   return root
 }
 
-function buildServerDirectory (server: { internalServerNumber: number }, directory: string) {
-  return join(root(), 'test' + server.internalServerNumber, directory)
+function buildServerDirectory (server: { internalServerNumber: number }, directory: string, filenameRegexp?: RegExp) {
+  let fullPath = join(root(), 'test' + server.internalServerNumber, directory)
+
+  if (filenameRegexp) {
+    const foundFile = readdirSync(fullPath).find(f => filenameRegexp.test(f))
+
+    fullPath += `/${foundFile}`
+  }
+
+  return fullPath
 }
 
 async function testImage (url: string, imageName: string, imagePath: string, extension = '.jpg') {

--- a/shared/extra-utils/videos/live.ts
+++ b/shared/extra-utils/videos/live.ts
@@ -198,7 +198,7 @@ async function checkLiveCleanup (server: ServerInfo, videoUUID: string, resoluti
   expect(files).to.have.lengthOf(resolutions.length * 2 + 2)
 
   for (const resolution of resolutions) {
-    expect(files).to.contain(`${videoUUID}-${resolution}-fragmented.mp4`)
+    expect(files.filter(f => (new RegExp(`${resolution}-fragmented.mp4$`)).test(f)).length).to.equal(1)
     expect(files).to.contain(`${resolution}.m3u8`)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -995,6 +995,11 @@
   resolved "https://registry.yarnpkg.com/@types/tv4/-/tv4-1.2.30.tgz#3159a6fd5ac90c42d27aecfb20a6a150fb565668"
   integrity sha512-Uj68uOn6T94IQsEGxLRrFiAqYsP4AUaXiYWrm+DR9/PNtIxuXaq/oHwBbGVR0uXHox4UZMKxCuf+z5M40MpoBw==
 
+"@types/uuid@8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
+  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
+
 "@types/validator@^13.0.0":
   version "13.1.4"
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.1.4.tgz#d2e3c27523ce1b5d9dc13d16cbce65dc4db2adbe"
@@ -8411,6 +8416,14 @@ uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuidv4@^6.2.11:
+  version "6.2.11"
+  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.2.11.tgz#34d5a03324eb38296b87ae523a64233b5286cc27"
+  integrity sha512-OTS4waH9KplrXNADKo+Q1kT9AHWr8DaC0S5F54RQzEwcUaEzBEWQQlJyDUw/u1bkRhJyqkqhLD4M4lbFbV+89g==
+  dependencies:
+    "@types/uuid" "8.3.1"
+    uuid "8.3.2"
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
## Description
HLS video files gets named by a unique uuid (not the same as video uuid), which gets updated when the files changes. All m3u8 playlists and segments files gets query param with a hash based on the video file names. This ensures that if a video changes also the URL will be changed.

## Related issues
Closes #4210

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work