### PR TITLE
Correct dropdown/dropup z-index

### DIFF
--- a/client/src/app/+videos/+video-watch/shared/information/privacy-concerns.component.scss
+++ b/client/src/app/+videos/+video-watch/shared/information/privacy-concerns.component.scss
@@ -25,6 +25,13 @@
   }
 }
 
+// Avoid higher z-index when overlay on touchscreens
+:host-context(.menu-open) {
+  .privacy-concerns {
+    z-index: z(overlay) - 1;
+  }
+}
+
 // Or if we are in the small view
 @media screen and (max-width: $small-view) {
   .privacy-concerns {

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -59,7 +59,8 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
 }
 
 /* rules for dropdowns excepts when in button group, to avoid impacting the dropdown-toggle */
-.dropdown {
+.dropdown,
+.dropup {
   z-index: z(dropdown) !important;
 }
 

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -214,7 +214,7 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
         content: '';
         display: block;
         position: fixed;
-        z-index: z('menu') - 1;
+        z-index: z(overlay);
       }
     }
   }

--- a/client/src/sass/bootstrap.scss
+++ b/client/src/sass/bootstrap.scss
@@ -65,7 +65,7 @@ $icon-font-path: '~@neos21/bootstrap3-glyphicons/assets/fonts/';
 
 .list-overflow-menu,
 .parent-entry {
-  z-index: z(header) - 1 !important;
+  z-index: z(menu) - 1 !important;
 }
 
 .btn-group,

--- a/client/src/sass/include/_variables.scss
+++ b/client/src/sass/include/_variables.scss
@@ -159,8 +159,8 @@ $variables: (
 
 $zindex: (
   miniature       :    10,
-  privacymsg      :    20,
   sub-menu        : 12500,
+  overlay         : 12550,
   menu            : 12600,
   search-typeahead: 12650,
   popover         : 13000,
@@ -169,6 +169,7 @@ $zindex: (
   modal           : 16000,
   dropdown        : 17000,
   help-popover    : 17000,
+  privacymsg      : 17500,
   header          : 17500,
   notification    : 18000,
   hotkeys         : 19000

--- a/client/src/sass/include/_variables.scss
+++ b/client/src/sass/include/_variables.scss
@@ -163,13 +163,13 @@ $zindex: (
   sub-menu        : 12500,
   menu            : 12600,
   search-typeahead: 12650,
-  header          : 12700,
   popover         : 13000,
   tooltip         : 14000,
   loadbar         : 15000,
   modal           : 16000,
   dropdown        : 17000,
   help-popover    : 17000,
+  header          : 17500,
   notification    : 18000,
   hotkeys         : 19000
 );


### PR DESCRIPTION
## Description

This PR try to correct all known issues about dropdown z-index especially with :
- user dropdown notification placing hover the sub-menu titles (also as a dropdown-menu)
- dropdowns moving hover the header and privacy message on scroll
- missing `.dropup` z-index rule especially in report admin page

## Related issues

Closes https://github.com/Chocobozzz/PeerTube/issues/4262 and https://github.com/Chocobozzz/PeerTube/issues/4265

Plus floating dropdown hover menu and privacy message on scroll as the following screenshots : 

![Capture d’écran du 2021-07-21 13-07-19](https://user-images.githubusercontent.com/1877318/126482872-38de22be-9d72-4f16-ab40-d638c7d92c9f.png)
![Capture d’écran du 2021-07-21 12-54-41](https://user-images.githubusercontent.com/1877318/126482873-70e16c60-de9e-4f06-a310-9b7eba4293d5.png)

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code
