### PR TITLE
Fix user-dropdown-indicator position on touchscreens

### DIFF
--- a/client/src/app/menu/menu.component.scss
+++ b/client/src/app/menu/menu.component.scss
@@ -114,8 +114,8 @@ my-notification {
         display: inherit !important;
       }
 
-      .dropdown-toggle:first-child {
-        @include padding-left(30px !important);
+      .dropdown-toggle {
+        max-width: 88% !important;
       }
     }
   }


### PR DESCRIPTION
## Description

Remove padding-left and adapt max-width for user dropdown-toggle on touchscreens in order to get the correct position of the indicator.

## Related issues

Closes https://github.com/Chocobozzz/PeerTube/issues/4263

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code

## Screenshots

![Capture d’écran du 2021-07-22 15-15-59](https://user-images.githubusercontent.com/1877318/126646092-672319e5-d014-4130-a5e0-0efbfb5a41ff.png)
