### PR TITLE
Unique video/playlist file names

### DIFF
--- a/scripts/prune-storage.ts
+++ b/scripts/prune-storage.ts
@@ -2,11 +2,11 @@ import { registerTSPaths } from '../server/helpers/register-ts-paths'
 registerTSPaths()
 
 import * as prompt from 'prompt'
-import { join } from 'path'
+import { join, basename } from 'path'
 import { CONFIG } from '../server/initializers/config'
 import { VideoModel } from '../server/models/video/video'
 import { initDatabaseModels } from '../server/initializers/database'
-import { readdir, remove } from 'fs-extra'
+import { readdir, remove, stat } from 'fs-extra'
 import { VideoRedundancyModel } from '../server/models/redundancy/video-redundancy'
 import * as Bluebird from 'bluebird'
 import { getUUIDFromFilename } from '../server/helpers/utils'
@@ -14,6 +14,7 @@ import { ThumbnailModel } from '../server/models/video/thumbnail'
 import { ActorImageModel } from '../server/models/actor/actor-image'
 import { uniq, values } from 'lodash'
 import { ThumbnailType } from '@shared/models'
+import { VideoFileModel } from '@server/models/video/video-file'
 
 run()
   .then(() => process.exit(0))
@@ -37,8 +38,8 @@ async function run () {
   console.log('Detecting files to remove, it could take a while...')
 
   toDelete = toDelete.concat(
-    await pruneDirectory(CONFIG.STORAGE.VIDEOS_DIR, doesVideoExist(true)),
-    await pruneDirectory(CONFIG.STORAGE.TORRENTS_DIR, doesVideoExist(true)),
+    await pruneDirectory(CONFIG.STORAGE.VIDEOS_DIR, doesWebTorrentFileExist()),
+    await pruneDirectory(CONFIG.STORAGE.TORRENTS_DIR, doesTorrentFileExist()),
 
     await pruneDirectory(CONFIG.STORAGE.REDUNDANCY_DIR, doesRedundancyExist),
 
@@ -78,26 +79,27 @@ async function pruneDirectory (directory: string, existFun: ExistFun) {
 
   const toDelete: string[] = []
   await Bluebird.map(files, async file => {
-    if (await existFun(file) !== true) {
-      toDelete.push(join(directory, file))
+    const filePath = join(directory, file)
+
+    if (await existFun(filePath) !== true) {
+      toDelete.push(filePath)
     }
   }, { concurrency: 20 })
 
   return toDelete
 }
 
-function doesVideoExist (keepOnlyOwned: boolean) {
-  return async (file: string) => {
-    const uuid = getUUIDFromFilename(file)
-    const video = await VideoModel.load(uuid)
+function doesWebTorrentFileExist () {
+  return (filePath: string) => VideoFileModel.doesOwnedWebTorrentVideoFileExist(basename(filePath))
+}
 
-    return video && (keepOnlyOwned === false || video.isOwned())
-  }
+function doesTorrentFileExist () {
+  return (filePath: string) => VideoFileModel.doesOwnedTorrentFileExist(basename(filePath))
 }
 
 function doesThumbnailExist (keepOnlyOwned: boolean, type: ThumbnailType) {
-  return async (file: string) => {
-    const thumbnail = await ThumbnailModel.loadByFilename(file, type)
+  return async (filePath: string) => {
+    const thumbnail = await ThumbnailModel.loadByFilename(basename(filePath), type)
     if (!thumbnail) return false
 
     if (keepOnlyOwned) {
@@ -109,21 +111,20 @@ function doesThumbnailExist (keepOnlyOwned: boolean, type: ThumbnailType) {
   }
 }
 
-async function doesActorImageExist (file: string) {
-  const image = await ActorImageModel.loadByName(file)
+async function doesActorImageExist (filePath: string) {
+  const image = await ActorImageModel.loadByName(basename(filePath))
 
   return !!image
 }
 
-async function doesRedundancyExist (file: string) {
-  const uuid = getUUIDFromFilename(file)
-  const video = await VideoModel.loadWithFiles(uuid)
-
-  if (!video) return false
-
-  const isPlaylist = file.includes('.') === false
+async function doesRedundancyExist (filePath: string) {
+  const isPlaylist = (await stat(filePath)).isDirectory()
 
   if (isPlaylist) {
+    const uuid = getUUIDFromFilename(filePath)
+    const video = await VideoModel.loadWithFiles(uuid)
+    if (!video) return false
+
     const p = video.getHLSPlaylist()
     if (!p) return false
 
@@ -131,19 +132,10 @@ async function doesRedundancyExist (file: string) {
     return !!redundancy
   }
 
-  const resolution = parseInt(file.split('-')[5], 10)
-  if (isNaN(resolution)) {
-    console.error('Cannot prune %s because we cannot guess guess the resolution.', file)
-    return true
-  }
+  const file = await VideoFileModel.loadByFilename(basename(filePath))
+  if (!file) return false
 
-  const videoFile = video.getWebTorrentFile(resolution)
-  if (!videoFile) {
-    console.error('Cannot find webtorrent file of video %s - %d', video.url, resolution)
-    return true
-  }
-
-  const redundancy = await VideoRedundancyModel.loadLocalByFileId(videoFile.id)
+  const redundancy = await VideoRedundancyModel.loadLocalByFileId(file.id)
   return !!redundancy
 }
 

--- a/server/controllers/api/videos/upload.ts
+++ b/server/controllers/api/videos/upload.ts
@@ -6,7 +6,7 @@ import { uuidToShort } from '@server/helpers/uuid'
 import { createTorrentAndSetInfoHash } from '@server/helpers/webtorrent'
 import { getLocalVideoActivityPubUrl } from '@server/lib/activitypub/url'
 import { addOptimizeOrMergeAudioJob, buildLocalVideoFromReq, buildVideoThumbnailsFromReq, setVideoTags } from '@server/lib/video'
-import { generateVideoFilename, getVideoFilePath } from '@server/lib/video-paths'
+import { generateWebTorrentVideoFilename, getVideoFilePath } from '@server/lib/video-paths'
 import { openapiOperationDoc } from '@server/middlewares/doc'
 import { MVideo, MVideoFile, MVideoFullLight } from '@server/types/models'
 import { uploadx } from '@uploadx/core'
@@ -240,7 +240,7 @@ async function buildNewFile (video: MVideo, videoPhysicalFile: express.VideoUplo
     videoFile.resolution = (await getVideoFileResolution(videoPhysicalFile.path)).videoFileResolution
   }
 
-  videoFile.filename = generateVideoFilename(video, false, videoFile.resolution, videoFile.extname)
+  videoFile.filename = generateWebTorrentVideoFilename(videoFile.resolution, videoFile.extname)
 
   return videoFile
 }

--- a/server/helpers/ffmpeg-utils.ts
+++ b/server/helpers/ffmpeg-utils.ts
@@ -212,14 +212,17 @@ async function transcode (options: TranscodeOptions) {
 
 async function getLiveTranscodingCommand (options: {
   rtmpUrl: string
+
   outPath: string
+  masterPlaylistName: string
+
   resolutions: number[]
   fps: number
 
   availableEncoders: AvailableEncoders
   profile: string
 }) {
-  const { rtmpUrl, outPath, resolutions, fps, availableEncoders, profile } = options
+  const { rtmpUrl, outPath, resolutions, fps, availableEncoders, profile, masterPlaylistName } = options
   const input = rtmpUrl
 
   const command = getFFmpeg(input, 'live')
@@ -301,14 +304,14 @@ async function getLiveTranscodingCommand (options: {
 
   command.complexFilter(complexFilter)
 
-  addDefaultLiveHLSParams(command, outPath)
+  addDefaultLiveHLSParams(command, outPath, masterPlaylistName)
 
   command.outputOption('-var_stream_map', varStreamMap.join(' '))
 
   return command
 }
 
-function getLiveMuxingCommand (rtmpUrl: string, outPath: string) {
+function getLiveMuxingCommand (rtmpUrl: string, outPath: string, masterPlaylistName: string) {
   const command = getFFmpeg(rtmpUrl, 'live')
 
   command.outputOption('-c:v copy')
@@ -316,7 +319,7 @@ function getLiveMuxingCommand (rtmpUrl: string, outPath: string) {
   command.outputOption('-map 0:a?')
   command.outputOption('-map 0:v?')
 
-  addDefaultLiveHLSParams(command, outPath)
+  addDefaultLiveHLSParams(command, outPath, masterPlaylistName)
 
   return command
 }
@@ -371,12 +374,12 @@ function addDefaultEncoderParams (options: {
   }
 }
 
-function addDefaultLiveHLSParams (command: ffmpeg.FfmpegCommand, outPath: string) {
+function addDefaultLiveHLSParams (command: ffmpeg.FfmpegCommand, outPath: string, masterPlaylistName: string) {
   command.outputOption('-hls_time ' + VIDEO_LIVE.SEGMENT_TIME_SECONDS)
   command.outputOption('-hls_list_size ' + VIDEO_LIVE.SEGMENTS_LIST_SIZE)
   command.outputOption('-hls_flags delete_segments+independent_segments')
   command.outputOption(`-hls_segment_filename ${join(outPath, '%v-%06d.ts')}`)
-  command.outputOption('-master_pl_name master.m3u8')
+  command.outputOption('-master_pl_name ' + masterPlaylistName)
   command.outputOption(`-f hls`)
 
   command.output(join(outPath, '%v.m3u8'))

--- a/server/helpers/webtorrent.ts
+++ b/server/helpers/webtorrent.ts
@@ -103,6 +103,11 @@ async function createTorrentAndSetInfoHash (
 
   await writeFile(torrentPath, torrent)
 
+  // Remove old torrent file if it existed
+  if (videoFile.hasTorrent()) {
+    await remove(join(CONFIG.STORAGE.TORRENTS_DIR, videoFile.torrentFilename))
+  }
+
   const parsedTorrent = parseTorrent(torrent)
   videoFile.infoHash = parsedTorrent.infoHash
   videoFile.torrentFilename = torrentFilename

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -24,7 +24,7 @@ import { CONFIG, registerConfigChangedHandler } from './config'
 
 // ---------------------------------------------------------------------------
 
-const LAST_MIGRATION_VERSION = 650
+const LAST_MIGRATION_VERSION = 655
 
 // ---------------------------------------------------------------------------
 

--- a/server/initializers/migrations/0655-streaming-playlist-filenames.ts
+++ b/server/initializers/migrations/0655-streaming-playlist-filenames.ts
@@ -1,0 +1,66 @@
+import * as Sequelize from 'sequelize'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction
+  queryInterface: Sequelize.QueryInterface
+  sequelize: Sequelize.Sequelize
+  db: any
+}): Promise<void> {
+  {
+    for (const column of [ 'playlistUrl', 'segmentsSha256Url' ]) {
+      const data = {
+        type: Sequelize.STRING,
+        allowNull: true,
+        defaultValue: null
+      }
+
+      await utils.queryInterface.changeColumn('videoStreamingPlaylist', column, data)
+    }
+  }
+
+  {
+    await utils.sequelize.query(
+      `UPDATE "videoStreamingPlaylist" SET "playlistUrl" = NULL, "segmentsSha256Url" = NULL ` +
+      `WHERE "videoId" IN (SELECT id FROM video WHERE remote IS FALSE)`
+    )
+  }
+
+  {
+    for (const column of [ 'playlistFilename', 'segmentsSha256Filename' ]) {
+      const data = {
+        type: Sequelize.STRING,
+        allowNull: true,
+        defaultValue: null
+      }
+
+      await utils.queryInterface.addColumn('videoStreamingPlaylist', column, data)
+    }
+  }
+
+  {
+    await utils.sequelize.query(
+      `UPDATE "videoStreamingPlaylist" SET "playlistFilename" = 'master.m3u8', "segmentsSha256Filename" = 'segments-sha256.json'`
+    )
+  }
+
+  {
+    for (const column of [ 'playlistFilename', 'segmentsSha256Filename' ]) {
+      const data = {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: null
+      }
+
+      await utils.queryInterface.changeColumn('videoStreamingPlaylist', column, data)
+    }
+  }
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export {
+  up,
+  down
+}

--- a/server/lib/hls.ts
+++ b/server/lib/hls.ts
@@ -36,8 +36,10 @@ async function updateMasterHLSPlaylist (video: MVideoWithFile) {
   const streamingPlaylist = video.getHLSPlaylist()
 
   for (const file of streamingPlaylist.VideoFiles) {
+    const playlistFilename = VideoStreamingPlaylistModel.getHlsPlaylistFilename(file.resolution)
+
     // If we did not generated a playlist for this resolution, skip
-    const filePlaylistPath = join(directory, VideoStreamingPlaylistModel.getHlsPlaylistFilename(file.resolution))
+    const filePlaylistPath = join(directory, playlistFilename)
     if (await pathExists(filePlaylistPath) === false) continue
 
     const videoFilePath = getVideoFilePath(streamingPlaylist, file)
@@ -58,7 +60,7 @@ async function updateMasterHLSPlaylist (video: MVideoWithFile) {
     line += `,CODECS="${codecs.filter(c => !!c).join(',')}"`
 
     masterPlaylists.push(line)
-    masterPlaylists.push(VideoStreamingPlaylistModel.getHlsPlaylistFilename(file.resolution))
+    masterPlaylists.push(playlistFilename)
   }
 
   await writeFile(masterPlaylistPath, masterPlaylists.join('\n') + '\n')

--- a/server/lib/job-queue/handlers/video-file-import.ts
+++ b/server/lib/job-queue/handlers/video-file-import.ts
@@ -2,7 +2,7 @@ import * as Bull from 'bull'
 import { copy, stat } from 'fs-extra'
 import { getLowercaseExtension } from '@server/helpers/core-utils'
 import { createTorrentAndSetInfoHash } from '@server/helpers/webtorrent'
-import { generateVideoFilename, getVideoFilePath } from '@server/lib/video-paths'
+import { generateWebTorrentVideoFilename, getVideoFilePath } from '@server/lib/video-paths'
 import { UserModel } from '@server/models/user/user'
 import { MVideoFullLight } from '@server/types/models'
 import { VideoFileImportPayload } from '@shared/models'
@@ -72,7 +72,7 @@ async function updateVideoFile (video: MVideoFullLight, inputFilePath: string) {
   const newVideoFile = new VideoFileModel({
     resolution: videoFileResolution,
     extname: fileExt,
-    filename: generateVideoFilename(video, false, videoFileResolution, fileExt),
+    filename: generateWebTorrentVideoFilename(videoFileResolution, fileExt),
     size,
     fps,
     videoId: video.id

--- a/server/lib/job-queue/handlers/video-file-import.ts
+++ b/server/lib/job-queue/handlers/video-file-import.ts
@@ -61,8 +61,7 @@ async function updateVideoFile (video: MVideoFullLight, inputFilePath: string) {
 
   if (currentVideoFile) {
     // Remove old file and old torrent
-    await video.removeFile(currentVideoFile)
-    await currentVideoFile.removeTorrent()
+    await video.removeFileAndTorrent(currentVideoFile)
     // Remove the old video file from the array
     video.VideoFiles = video.VideoFiles.filter(f => f !== currentVideoFile)
 

--- a/server/lib/job-queue/handlers/video-import.ts
+++ b/server/lib/job-queue/handlers/video-import.ts
@@ -8,7 +8,7 @@ import { Hooks } from '@server/lib/plugins/hooks'
 import { ServerConfigManager } from '@server/lib/server-config-manager'
 import { isAbleToUploadVideo } from '@server/lib/user'
 import { addOptimizeOrMergeAudioJob } from '@server/lib/video'
-import { generateVideoFilename, getVideoFilePath } from '@server/lib/video-paths'
+import { generateWebTorrentVideoFilename, getVideoFilePath } from '@server/lib/video-paths'
 import { ThumbnailModel } from '@server/models/video/thumbnail'
 import { MVideoImportDefault, MVideoImportDefaultFiles, MVideoImportVideo } from '@server/types/models/video/video-import'
 import {
@@ -124,7 +124,7 @@ async function processFile (downloader: () => Promise<string>, videoImport: MVid
       extname: fileExt,
       resolution: videoFileResolution,
       size: stats.size,
-      filename: generateVideoFilename(videoImport.Video, false, videoFileResolution, fileExt),
+      filename: generateWebTorrentVideoFilename(videoFileResolution, fileExt),
       fps,
       videoId: videoImport.videoId
     }

--- a/server/lib/job-queue/handlers/video-transcoding.ts
+++ b/server/lib/job-queue/handlers/video-transcoding.ts
@@ -125,8 +125,7 @@ async function onHlsPlaylistGeneration (video: MVideoFullLight, user: MUser, pay
   if (payload.isMaxQuality && CONFIG.TRANSCODING.WEBTORRENT.ENABLED === false) {
     // Remove webtorrent files if not enabled
     for (const file of video.VideoFiles) {
-      await video.removeFile(file)
-      await file.removeTorrent()
+      await video.removeFileAndTorrent(file)
       await file.destroy()
     }
 

--- a/server/lib/live/shared/muxing-session.ts
+++ b/server/lib/live/shared/muxing-session.ts
@@ -112,13 +112,16 @@ class MuxingSession extends EventEmitter {
     this.ffmpegCommand = CONFIG.LIVE.TRANSCODING.ENABLED
       ? await getLiveTranscodingCommand({
         rtmpUrl: this.rtmpUrl,
+
         outPath,
+        masterPlaylistName: this.streamingPlaylist.playlistFilename,
+
         resolutions: this.allResolutions,
         fps: this.fps,
         availableEncoders: VideoTranscodingProfilesManager.Instance.getAvailableEncoders(),
         profile: CONFIG.LIVE.TRANSCODING.PROFILE
       })
-      : getLiveMuxingCommand(this.rtmpUrl, outPath)
+      : getLiveMuxingCommand(this.rtmpUrl, outPath, this.streamingPlaylist.playlistFilename)
 
     logger.info('Running live muxing/transcoding for %s.', this.videoUUID, this.lTags)
 
@@ -182,7 +185,7 @@ class MuxingSession extends EventEmitter {
   }
 
   private watchMasterFile (outPath: string) {
-    this.masterWatcher = chokidar.watch(outPath + '/master.m3u8')
+    this.masterWatcher = chokidar.watch(outPath + '/' + this.streamingPlaylist.playlistFilename)
 
     this.masterWatcher.on('add', async () => {
       this.emit('master-playlist-created', { videoId: this.videoId })

--- a/server/lib/transcoding/video-transcoding.ts
+++ b/server/lib/transcoding/video-transcoding.ts
@@ -14,7 +14,7 @@ import { HLS_STREAMING_PLAYLIST_DIRECTORY, P2P_MEDIA_LOADER_PEER_VERSION, WEBSER
 import { VideoFileModel } from '../../models/video/video-file'
 import { VideoStreamingPlaylistModel } from '../../models/video/video-streaming-playlist'
 import { updateMasterHLSPlaylist, updateSha256VODSegments } from '../hls'
-import { generateVideoFilename, generateVideoStreamingPlaylistName, getVideoFilePath } from '../video-paths'
+import { generateHLSVideoFilename, generateWebTorrentVideoFilename, getVideoFilePath } from '../video-paths'
 import { VideoTranscodingProfilesManager } from './video-transcoding-profiles'
 
 /**
@@ -60,7 +60,7 @@ async function optimizeOriginalVideofile (video: MVideoFullLight, inputVideoFile
 
     // Important to do this before getVideoFilename() to take in account the new filename
     inputVideoFile.extname = newExtname
-    inputVideoFile.filename = generateVideoFilename(video, false, resolution, newExtname)
+    inputVideoFile.filename = generateWebTorrentVideoFilename(resolution, newExtname)
 
     const videoOutputPath = getVideoFilePath(video, inputVideoFile)
 
@@ -86,7 +86,7 @@ async function transcodeNewWebTorrentResolution (video: MVideoFullLight, resolut
   const newVideoFile = new VideoFileModel({
     resolution,
     extname,
-    filename: generateVideoFilename(video, false, resolution, extname),
+    filename: generateWebTorrentVideoFilename(resolution, extname),
     size: 0,
     videoId: video.id
   })
@@ -169,7 +169,7 @@ async function mergeAudioVideofile (video: MVideoFullLight, resolution: VideoRes
 
   // Important to do this before getVideoFilename() to take in account the new file extension
   inputVideoFile.extname = newExtname
-  inputVideoFile.filename = generateVideoFilename(video, false, inputVideoFile.resolution, newExtname)
+  inputVideoFile.filename = generateWebTorrentVideoFilename(inputVideoFile.resolution, newExtname)
 
   const videoOutputPath = getVideoFilePath(video, inputVideoFile)
   // ffmpeg generated a new video file, so update the video duration
@@ -271,7 +271,7 @@ async function generateHlsPlaylistCommon (options: {
   const videoTranscodedBasePath = join(transcodeDirectory, type)
   await ensureDir(videoTranscodedBasePath)
 
-  const videoFilename = generateVideoStreamingPlaylistName(video.uuid, resolution)
+  const videoFilename = generateHLSVideoFilename(resolution)
   const playlistFilename = VideoStreamingPlaylistModel.getHlsPlaylistFilename(resolution)
   const playlistFileTranscodePath = join(videoTranscodedBasePath, playlistFilename)
 
@@ -319,7 +319,7 @@ async function generateHlsPlaylistCommon (options: {
     resolution,
     extname,
     size: 0,
-    filename: generateVideoFilename(video, true, resolution, extname),
+    filename: videoFilename,
     fps: -1,
     videoStreamingPlaylistId: videoStreamingPlaylist.id
   })

--- a/server/lib/video-paths.ts
+++ b/server/lib/video-paths.ts
@@ -3,29 +3,20 @@ import { extractVideo } from '@server/helpers/video'
 import { CONFIG } from '@server/initializers/config'
 import { HLS_REDUNDANCY_DIRECTORY, HLS_STREAMING_PLAYLIST_DIRECTORY, STATIC_PATHS, WEBSERVER } from '@server/initializers/constants'
 import { isStreamingPlaylist, MStreamingPlaylist, MStreamingPlaylistVideo, MVideo, MVideoFile, MVideoUUID } from '@server/types/models'
+import { buildUUID } from '@server/helpers/uuid'
 
 // ################## Video file name ##################
 
-function generateVideoFilename (videoOrPlaylist: MVideo | MStreamingPlaylistVideo, isHls: boolean, resolution: number, extname: string) {
-  const video = extractVideo(videoOrPlaylist)
+function generateWebTorrentVideoFilename (resolution: number, extname: string) {
+  const uuid = buildUUID()
 
-  // FIXME: use a generated uuid instead, that will break compatibility with PeerTube < 3.1
-  // const uuid = uuidv4()
-  const uuid = video.uuid
-
-  if (isHls) {
-    return generateVideoStreamingPlaylistName(uuid, resolution)
-  }
-
-  return generateWebTorrentVideoName(uuid, resolution, extname)
-}
-
-function generateVideoStreamingPlaylistName (uuid: string, resolution: number) {
-  return `${uuid}-${resolution}-fragmented.mp4`
-}
-
-function generateWebTorrentVideoName (uuid: string, resolution: number, extname: string) {
   return uuid + '-' + resolution + extname
+}
+
+function generateHLSVideoFilename (resolution: number) {
+  const uuid = buildUUID()
+
+  return `${uuid}-${resolution}-fragmented.mp4`
 }
 
 function getVideoFilePath (videoOrPlaylist: MVideo | MStreamingPlaylistVideo, videoFile: MVideoFile, isRedundancy = false) {
@@ -66,12 +57,8 @@ function getHLSDirectory (video: MVideoUUID, isRedundancy = false) {
 // ################## Torrents ##################
 
 function generateTorrentFileName (videoOrPlaylist: MVideo | MStreamingPlaylistVideo, resolution: number) {
-  const video = extractVideo(videoOrPlaylist)
   const extension = '.torrent'
-
-  // FIXME: use a generated uuid instead, that will break compatibility with PeerTube < 3.1
-  // const uuid = uuidv4()
-  const uuid = video.uuid
+  const uuid = buildUUID()
 
   if (isStreamingPlaylist(videoOrPlaylist)) {
     return `${uuid}-${resolution}-${videoOrPlaylist.getStringType()}${extension}`
@@ -95,9 +82,9 @@ function getLocalVideoFileMetadataUrl (video: MVideoUUID, videoFile: MVideoFile)
 // ---------------------------------------------------------------------------
 
 export {
-  generateVideoStreamingPlaylistName,
-  generateWebTorrentVideoName,
-  generateVideoFilename,
+  generateHLSVideoFilename,
+  generateWebTorrentVideoFilename,
+
   getVideoFilePath,
 
   generateTorrentFileName,

--- a/server/lib/video-paths.ts
+++ b/server/lib/video-paths.ts
@@ -4,19 +4,16 @@ import { CONFIG } from '@server/initializers/config'
 import { HLS_REDUNDANCY_DIRECTORY, HLS_STREAMING_PLAYLIST_DIRECTORY, STATIC_PATHS, WEBSERVER } from '@server/initializers/constants'
 import { isStreamingPlaylist, MStreamingPlaylist, MStreamingPlaylistVideo, MVideo, MVideoFile, MVideoUUID } from '@server/types/models'
 import { buildUUID } from '@server/helpers/uuid'
+import { removeFragmentedMP4Ext } from '@shared/core-utils'
 
 // ################## Video file name ##################
 
 function generateWebTorrentVideoFilename (resolution: number, extname: string) {
-  const uuid = buildUUID()
-
-  return uuid + '-' + resolution + extname
+  return buildUUID() + '-' + resolution + extname
 }
 
 function generateHLSVideoFilename (resolution: number) {
-  const uuid = buildUUID()
-
-  return `${uuid}-${resolution}-fragmented.mp4`
+  return `${buildUUID()}-${resolution}-fragmented.mp4`
 }
 
 function getVideoFilePath (videoOrPlaylist: MVideo | MStreamingPlaylistVideo, videoFile: MVideoFile, isRedundancy = false) {
@@ -52,6 +49,23 @@ function getHLSDirectory (video: MVideoUUID, isRedundancy = false) {
     : HLS_STREAMING_PLAYLIST_DIRECTORY
 
   return join(baseDir, video.uuid)
+}
+
+function getHlsResolutionPlaylistFilename (videoFilename: string) {
+  // Video file name already contain resolution
+  return removeFragmentedMP4Ext(videoFilename) + '.m3u8'
+}
+
+function generateHLSMasterPlaylistFilename (isLive = false) {
+  if (isLive) return 'master.m3u8'
+
+  return buildUUID() + '-master.m3u8'
+}
+
+function generateHlsSha256SegmentsFilename (isLive = false) {
+  if (isLive) return 'segments-sha256.json'
+
+  return buildUUID() + '-segments-sha256.json'
 }
 
 // ################## Torrents ##################
@@ -91,6 +105,9 @@ export {
   getTorrentFilePath,
 
   getHLSDirectory,
+  generateHLSMasterPlaylistFilename,
+  generateHlsSha256SegmentsFilename,
+  getHlsResolutionPlaylistFilename,
 
   getLocalVideoFileMetadataUrl,
 

--- a/server/lib/video.ts
+++ b/server/lib/video.ts
@@ -5,7 +5,7 @@ import { sequelizeTypescript } from '@server/initializers/database'
 import { TagModel } from '@server/models/video/tag'
 import { VideoModel } from '@server/models/video/video'
 import { FilteredModelAttributes } from '@server/types'
-import { MThumbnail, MUserId, MVideo, MVideoFile, MVideoTag, MVideoThumbnail, MVideoUUID } from '@server/types/models'
+import { MThumbnail, MUserId, MVideoFile, MVideoTag, MVideoThumbnail, MVideoUUID } from '@server/types/models'
 import { ThumbnailType, VideoCreate, VideoPrivacy, VideoTranscodingPayload } from '@shared/models'
 import { federateVideoIfNeeded } from './activitypub/videos'
 import { JobQueue } from './job-queue/job-queue'
@@ -105,7 +105,7 @@ async function publishAndFederateIfNeeded (video: MVideoUUID, wasLive = false) {
   }
 }
 
-async function addOptimizeOrMergeAudioJob (video: MVideo, videoFile: MVideoFile, user: MUserId) {
+async function addOptimizeOrMergeAudioJob (video: MVideoUUID, videoFile: MVideoFile, user: MUserId) {
   let dataInput: VideoTranscodingPayload
 
   if (videoFile.isAudio()) {

--- a/server/models/actor/actor-follow.ts
+++ b/server/models/actor/actor-follow.ts
@@ -19,8 +19,8 @@ import {
   UpdatedAt
 } from 'sequelize-typescript'
 import { isActivityPubUrlValid } from '@server/helpers/custom-validators/activitypub/misc'
+import { doesExist } from '@server/helpers/database-utils'
 import { getServerActor } from '@server/models/application/application'
-import { VideoModel } from '@server/models/video/video'
 import {
   MActorFollowActorsDefault,
   MActorFollowActorsDefaultSubscription,
@@ -166,14 +166,8 @@ export class ActorFollowModel extends Model<Partial<AttributesOnly<ActorFollowMo
 
   static isFollowedBy (actorId: number, followerActorId: number) {
     const query = 'SELECT 1 FROM "actorFollow" WHERE "actorId" = $followerActorId AND "targetActorId" = $actorId LIMIT 1'
-    const options = {
-      type: QueryTypes.SELECT as QueryTypes.SELECT,
-      bind: { actorId, followerActorId },
-      raw: true
-    }
 
-    return VideoModel.sequelize.query(query, options)
-                     .then(results => results.length === 1)
+    return doesExist(query, { actorId, followerActorId })
   }
 
   static loadByActorAndTarget (actorId: number, targetActorId: number, t?: Transaction): Promise<MActorFollowActorsDefault> {

--- a/server/models/redundancy/video-redundancy.ts
+++ b/server/models/redundancy/video-redundancy.ts
@@ -160,8 +160,8 @@ export class VideoRedundancyModel extends Model<Partial<AttributesOnly<VideoRedu
       const logIdentifier = `${videoFile.Video.uuid}-${videoFile.resolution}`
       logger.info('Removing duplicated video file %s.', logIdentifier)
 
-      videoFile.Video.removeFile(videoFile, true)
-               .catch(err => logger.error('Cannot delete %s files.', logIdentifier, { err }))
+      videoFile.Video.removeFileAndTorrent(videoFile, true)
+        .catch(err => logger.error('Cannot delete %s files.', logIdentifier, { err }))
     }
 
     if (instance.videoStreamingPlaylistId) {

--- a/server/models/video/formatter/video-format-utils.ts
+++ b/server/models/video/formatter/video-format-utils.ts
@@ -182,8 +182,8 @@ function streamingPlaylistsModelToFormattedJSON (
       return {
         id: playlist.id,
         type: playlist.type,
-        playlistUrl: playlist.playlistUrl,
-        segmentsSha256Url: playlist.segmentsSha256Url,
+        playlistUrl: playlist.getMasterPlaylistUrl(video),
+        segmentsSha256Url: playlist.getSha256SegmentsUrl(video),
         redundancies,
         files
       }
@@ -331,7 +331,7 @@ function videoModelToActivityPubObject (video: MVideoAP): VideoObject {
       type: 'Link',
       name: 'sha256',
       mediaType: 'application/json' as 'application/json',
-      href: playlist.segmentsSha256Url
+      href: playlist.getSha256SegmentsUrl(video)
     })
 
     addVideoFilesInAPAcc(tag, video, playlist.VideoFiles || [])
@@ -339,7 +339,7 @@ function videoModelToActivityPubObject (video: MVideoAP): VideoObject {
     url.push({
       type: 'Link',
       mediaType: 'application/x-mpegURL' as 'application/x-mpegURL',
-      href: playlist.playlistUrl,
+      href: playlist.getMasterPlaylistUrl(video),
       tag
     })
   }

--- a/server/models/video/sql/shared/video-tables.ts
+++ b/server/models/video/sql/shared/video-tables.ts
@@ -92,12 +92,13 @@ export class VideoTables {
   }
 
   getStreamingPlaylistAttributes () {
-    let playlistKeys = [ 'id', 'playlistUrl', 'type' ]
+    let playlistKeys = [ 'id', 'playlistUrl', 'playlistFilename', 'type' ]
 
     if (this.mode === 'get') {
       playlistKeys = playlistKeys.concat([
         'p2pMediaLoaderInfohashes',
         'p2pMediaLoaderPeerVersion',
+        'segmentsSha256Filename',
         'segmentsSha256Url',
         'videoId',
         'createdAt',

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -1,19 +1,27 @@
 import * as memoizee from 'memoizee'
 import { join } from 'path'
-import { Op, QueryTypes } from 'sequelize'
+import { Op } from 'sequelize'
 import { AllowNull, BelongsTo, Column, CreatedAt, DataType, ForeignKey, HasMany, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
+import { doesExist } from '@server/helpers/database-utils'
 import { VideoFileModel } from '@server/models/video/video-file'
-import { MStreamingPlaylist } from '@server/types/models'
+import { MStreamingPlaylist, MVideo } from '@server/types/models'
+import { AttributesOnly } from '@shared/core-utils'
 import { VideoStreamingPlaylistType } from '../../../shared/models/videos/video-streaming-playlist.type'
 import { sha1 } from '../../helpers/core-utils'
 import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
 import { isArrayOf } from '../../helpers/custom-validators/misc'
 import { isVideoFileInfoHashValid } from '../../helpers/custom-validators/videos'
-import { CONSTRAINTS_FIELDS, MEMOIZE_LENGTH, MEMOIZE_TTL, P2P_MEDIA_LOADER_PEER_VERSION, STATIC_PATHS } from '../../initializers/constants'
+import {
+  CONSTRAINTS_FIELDS,
+  MEMOIZE_LENGTH,
+  MEMOIZE_TTL,
+  P2P_MEDIA_LOADER_PEER_VERSION,
+  STATIC_PATHS,
+  WEBSERVER
+} from '../../initializers/constants'
 import { VideoRedundancyModel } from '../redundancy/video-redundancy'
 import { throwIfNotValid } from '../utils'
 import { VideoModel } from './video'
-import { AttributesOnly } from '@shared/core-utils'
 
 @Table({
   tableName: 'videoStreamingPlaylist',
@@ -43,7 +51,11 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   type: VideoStreamingPlaylistType
 
   @AllowNull(false)
-  @Is('PlaylistUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'playlist url'))
+  @Column
+  playlistFilename: string
+
+  @AllowNull(true)
+  @Is('PlaylistUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'playlist url', true))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.URL.max))
   playlistUrl: string
 
@@ -57,7 +69,11 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   p2pMediaLoaderPeerVersion: number
 
   @AllowNull(false)
-  @Is('VideoStreamingSegmentsSha256Url', value => throwIfNotValid(value, isActivityPubUrlValid, 'segments sha256 url'))
+  @Column
+  segmentsSha256Filename: string
+
+  @AllowNull(true)
+  @Is('VideoStreamingSegmentsSha256Url', value => throwIfNotValid(value, isActivityPubUrlValid, 'segments sha256 url', true))
   @Column
   segmentsSha256Url: string
 
@@ -98,14 +114,8 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
 
   static doesInfohashExist (infoHash: string) {
     const query = 'SELECT 1 FROM "videoStreamingPlaylist" WHERE $infoHash = ANY("p2pMediaLoaderInfohashes") LIMIT 1'
-    const options = {
-      type: QueryTypes.SELECT as QueryTypes.SELECT,
-      bind: { infoHash },
-      raw: true
-    }
 
-    return VideoModel.sequelize.query<object>(query, options)
-              .then(results => results.length === 1)
+    return doesExist(query, { infoHash })
   }
 
   static buildP2PMediaLoaderInfoHashes (playlistUrl: string, files: unknown[]) {
@@ -125,7 +135,13 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
         p2pMediaLoaderPeerVersion: {
           [Op.ne]: P2P_MEDIA_LOADER_PEER_VERSION
         }
-      }
+      },
+      include: [
+        {
+          model: VideoModel.unscoped(),
+          required: true
+        }
+      ]
     }
 
     return VideoStreamingPlaylistModel.findAll(query)
@@ -144,7 +160,7 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
     return VideoStreamingPlaylistModel.findByPk(id, options)
   }
 
-  static loadHLSPlaylistByVideo (videoId: number) {
+  static loadHLSPlaylistByVideo (videoId: number): Promise<MStreamingPlaylist> {
     const options = {
       where: {
         type: VideoStreamingPlaylistType.HLS,
@@ -155,30 +171,29 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
     return VideoStreamingPlaylistModel.findOne(options)
   }
 
-  static getHlsPlaylistFilename (resolution: number) {
-    return resolution + '.m3u8'
+  static async loadOrGenerate (video: MVideo) {
+    let playlist = await VideoStreamingPlaylistModel.loadHLSPlaylistByVideo(video.id)
+    if (!playlist) playlist = new VideoStreamingPlaylistModel()
+
+    return Object.assign(playlist, { videoId: video.id, Video: video })
   }
 
-  static getMasterHlsPlaylistFilename () {
-    return 'master.m3u8'
+  assignP2PMediaLoaderInfoHashes (video: MVideo, files: unknown[]) {
+    const masterPlaylistUrl = this.getMasterPlaylistUrl(video)
+
+    this.p2pMediaLoaderInfohashes = VideoStreamingPlaylistModel.buildP2PMediaLoaderInfoHashes(masterPlaylistUrl, files)
   }
 
-  static getHlsSha256SegmentsFilename () {
-    return 'segments-sha256.json'
+  getMasterPlaylistUrl (video: MVideo) {
+    if (video.isOwned()) return WEBSERVER.URL + this.getMasterPlaylistStaticPath(video.uuid)
+
+    return this.playlistUrl
   }
 
-  static getHlsMasterPlaylistStaticPath (videoUUID: string) {
-    return join(STATIC_PATHS.STREAMING_PLAYLISTS.HLS, videoUUID, VideoStreamingPlaylistModel.getMasterHlsPlaylistFilename())
-  }
+  getSha256SegmentsUrl (video: MVideo) {
+    if (video.isOwned()) return WEBSERVER.URL + this.getSha256SegmentsStaticPath(video.uuid, video.isLive)
 
-  static getHlsPlaylistStaticPath (videoUUID: string, resolution: number) {
-    return join(STATIC_PATHS.STREAMING_PLAYLISTS.HLS, videoUUID, VideoStreamingPlaylistModel.getHlsPlaylistFilename(resolution))
-  }
-
-  static getHlsSha256SegmentsStaticPath (videoUUID: string, isLive: boolean) {
-    if (isLive) return join('/live', 'segments-sha256', videoUUID)
-
-    return join(STATIC_PATHS.STREAMING_PLAYLISTS.HLS, videoUUID, VideoStreamingPlaylistModel.getHlsSha256SegmentsFilename())
+    return this.segmentsSha256Url
   }
 
   getStringType () {
@@ -194,5 +209,15 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   hasSameUniqueKeysThan (other: MStreamingPlaylist) {
     return this.type === other.type &&
       this.videoId === other.videoId
+  }
+
+  private getMasterPlaylistStaticPath (videoUUID: string) {
+    return join(STATIC_PATHS.STREAMING_PLAYLISTS.HLS, videoUUID, this.playlistFilename)
+  }
+
+  private getSha256SegmentsStaticPath (videoUUID: string, isLive: boolean) {
+    if (isLive) return join('/live', 'segments-sha256', videoUUID)
+
+    return join(STATIC_PATHS.STREAMING_PLAYLISTS.HLS, videoUUID, this.segmentsSha256Filename)
   }
 }

--- a/server/tests/api/check-params/abuses.ts
+++ b/server/tests/api/check-params/abuses.ts
@@ -41,7 +41,7 @@ describe('Test abuses API validators', function () {
     userToken = await server.users.generateUserAndToken('user_1')
     userToken2 = await server.users.generateUserAndToken('user_2')
 
-    server.store.video = await server.videos.upload()
+    server.store.videoCreated = await server.videos.upload()
 
     command = server.abuses
   })
@@ -223,25 +223,25 @@ describe('Test abuses API validators', function () {
     })
 
     it('Should fail with a non authenticated user', async function () {
-      const fields = { video: { id: server.store.video.id }, reason: 'my super reason' }
+      const fields = { video: { id: server.store.videoCreated.id }, reason: 'my super reason' }
 
       await makePostBodyRequest({ url: server.url, path, token: 'hello', fields, expectedStatus: HttpStatusCode.UNAUTHORIZED_401 })
     })
 
     it('Should fail with a reason too short', async function () {
-      const fields = { video: { id: server.store.video.id }, reason: 'h' }
+      const fields = { video: { id: server.store.videoCreated.id }, reason: 'h' }
 
       await makePostBodyRequest({ url: server.url, path, token: userToken, fields })
     })
 
     it('Should fail with a too big reason', async function () {
-      const fields = { video: { id: server.store.video.id }, reason: 'super'.repeat(605) }
+      const fields = { video: { id: server.store.videoCreated.id }, reason: 'super'.repeat(605) }
 
       await makePostBodyRequest({ url: server.url, path, token: userToken, fields })
     })
 
     it('Should succeed with the correct parameters (basic)', async function () {
-      const fields: AbuseCreate = { video: { id: server.store.video.shortUUID }, reason: 'my super reason' }
+      const fields: AbuseCreate = { video: { id: server.store.videoCreated.shortUUID }, reason: 'my super reason' }
 
       const res = await makePostBodyRequest({
         url: server.url,
@@ -254,19 +254,19 @@ describe('Test abuses API validators', function () {
     })
 
     it('Should fail with a wrong predefined reason', async function () {
-      const fields = { video: { id: server.store.video.id }, reason: 'my super reason', predefinedReasons: [ 'wrongPredefinedReason' ] }
+      const fields = { video: server.store.videoCreated, reason: 'my super reason', predefinedReasons: [ 'wrongPredefinedReason' ] }
 
       await makePostBodyRequest({ url: server.url, path, token: userToken, fields })
     })
 
     it('Should fail with negative timestamps', async function () {
-      const fields = { video: { id: server.store.video.id, startAt: -1 }, reason: 'my super reason' }
+      const fields = { video: { id: server.store.videoCreated.id, startAt: -1 }, reason: 'my super reason' }
 
       await makePostBodyRequest({ url: server.url, path, token: userToken, fields })
     })
 
     it('Should fail mith misordered startAt/endAt', async function () {
-      const fields = { video: { id: server.store.video.id, startAt: 5, endAt: 1 }, reason: 'my super reason' }
+      const fields = { video: { id: server.store.videoCreated.id, startAt: 5, endAt: 1 }, reason: 'my super reason' }
 
       await makePostBodyRequest({ url: server.url, path, token: userToken, fields })
     })
@@ -274,7 +274,7 @@ describe('Test abuses API validators', function () {
     it('Should succeed with the corret parameters (advanced)', async function () {
       const fields: AbuseCreate = {
         video: {
-          id: server.store.video.id,
+          id: server.store.videoCreated.id,
           startAt: 1,
           endAt: 5
         },
@@ -413,7 +413,7 @@ describe('Test abuses API validators', function () {
 
       await doubleFollow(anotherServer, server)
 
-      const server2VideoId = await anotherServer.videos.getId({ uuid: server.store.video.uuid })
+      const server2VideoId = await anotherServer.videos.getId({ uuid: server.store.videoCreated.uuid })
       await anotherServer.abuses.report({ reason: 'remote server', videoId: server2VideoId })
 
       await waitJobs([ server, anotherServer ])

--- a/server/tests/api/check-params/services.ts
+++ b/server/tests/api/check-params/services.ts
@@ -24,7 +24,7 @@ describe('Test services API validators', function () {
     await setAccessTokensToServers([ server ])
     await setDefaultVideoChannel([ server ])
 
-    server.store.video = await server.videos.upload({ attributes: { name: 'my super name' } })
+    server.store.videoCreated = await server.videos.upload({ attributes: { name: 'my super name' } })
 
     {
       const created = await server.playlists.create({
@@ -47,7 +47,7 @@ describe('Test services API validators', function () {
     })
 
     it('Should fail with an invalid host', async function () {
-      const embedUrl = 'http://hello.com/videos/watch/' + server.store.video.uuid
+      const embedUrl = 'http://hello.com/videos/watch/' + server.store.videoCreated.uuid
       await checkParamEmbed(server, embedUrl)
     })
 
@@ -62,37 +62,37 @@ describe('Test services API validators', function () {
     })
 
     it('Should fail with an invalid path', async function () {
-      const embedUrl = `http://localhost:${server.port}/videos/watchs/${server.store.video.uuid}`
+      const embedUrl = `http://localhost:${server.port}/videos/watchs/${server.store.videoCreated.uuid}`
 
       await checkParamEmbed(server, embedUrl)
     })
 
     it('Should fail with an invalid max height', async function () {
-      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.video.uuid}`
+      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.videoCreated.uuid}`
 
       await checkParamEmbed(server, embedUrl, HttpStatusCode.BAD_REQUEST_400, { maxheight: 'hello' })
     })
 
     it('Should fail with an invalid max width', async function () {
-      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.video.uuid}`
+      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.videoCreated.uuid}`
 
       await checkParamEmbed(server, embedUrl, HttpStatusCode.BAD_REQUEST_400, { maxwidth: 'hello' })
     })
 
     it('Should fail with an invalid format', async function () {
-      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.video.uuid}`
+      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.videoCreated.uuid}`
 
       await checkParamEmbed(server, embedUrl, HttpStatusCode.BAD_REQUEST_400, { format: 'blabla' })
     })
 
     it('Should fail with a non supported format', async function () {
-      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.video.uuid}`
+      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.videoCreated.uuid}`
 
       await checkParamEmbed(server, embedUrl, HttpStatusCode.NOT_IMPLEMENTED_501, { format: 'xml' })
     })
 
     it('Should succeed with the correct params with a video', async function () {
-      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.video.uuid}`
+      const embedUrl = `http://localhost:${server.port}/videos/watch/${server.store.videoCreated.uuid}`
       const query = {
         format: 'json',
         maxheight: 400,

--- a/server/tests/api/check-params/video-blacklist.ts
+++ b/server/tests/api/check-params/video-blacklist.ts
@@ -51,7 +51,7 @@ describe('Test video blacklist API validators', function () {
     }
 
     {
-      servers[0].store.video = await servers[0].videos.upload({ token: userAccessToken1 })
+      servers[0].store.videoCreated = await servers[0].videos.upload({ token: userAccessToken1 })
     }
 
     {
@@ -73,7 +73,7 @@ describe('Test video blacklist API validators', function () {
     const basePath = '/api/v1/videos/'
 
     it('Should fail with nothing', async function () {
-      const path = basePath + servers[0].store.video + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated + '/blacklist'
       const fields = {}
       await makePostBodyRequest({ url: servers[0].url, path, token: servers[0].accessToken, fields })
     })
@@ -85,13 +85,13 @@ describe('Test video blacklist API validators', function () {
     })
 
     it('Should fail with a non authenticated user', async function () {
-      const path = basePath + servers[0].store.video + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated + '/blacklist'
       const fields = {}
       await makePostBodyRequest({ url: servers[0].url, path, token: 'hello', fields, expectedStatus: HttpStatusCode.UNAUTHORIZED_401 })
     })
 
     it('Should fail with a non admin user', async function () {
-      const path = basePath + servers[0].store.video + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated + '/blacklist'
       const fields = {}
       await makePostBodyRequest({
         url: servers[0].url,
@@ -103,7 +103,7 @@ describe('Test video blacklist API validators', function () {
     })
 
     it('Should fail with an invalid reason', async function () {
-      const path = basePath + servers[0].store.video.uuid + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated.uuid + '/blacklist'
       const fields = { reason: 'a'.repeat(305) }
 
       await makePostBodyRequest({ url: servers[0].url, path, token: servers[0].accessToken, fields })
@@ -123,7 +123,7 @@ describe('Test video blacklist API validators', function () {
     })
 
     it('Should succeed with the correct params', async function () {
-      const path = basePath + servers[0].store.video.uuid + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated.uuid + '/blacklist'
       const fields = {}
 
       await makePostBodyRequest({
@@ -158,13 +158,13 @@ describe('Test video blacklist API validators', function () {
     })
 
     it('Should fail with a non authenticated user', async function () {
-      const path = basePath + servers[0].store.video + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated + '/blacklist'
       const fields = {}
       await makePutBodyRequest({ url: servers[0].url, path, token: 'hello', fields, expectedStatus: HttpStatusCode.UNAUTHORIZED_401 })
     })
 
     it('Should fail with a non admin user', async function () {
-      const path = basePath + servers[0].store.video + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated + '/blacklist'
       const fields = {}
       await makePutBodyRequest({
         url: servers[0].url,
@@ -176,14 +176,14 @@ describe('Test video blacklist API validators', function () {
     })
 
     it('Should fail with an invalid reason', async function () {
-      const path = basePath + servers[0].store.video.uuid + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated.uuid + '/blacklist'
       const fields = { reason: 'a'.repeat(305) }
 
       await makePutBodyRequest({ url: servers[0].url, path, token: servers[0].accessToken, fields })
     })
 
     it('Should succeed with the correct params', async function () {
-      const path = basePath + servers[0].store.video.shortUUID + '/blacklist'
+      const path = basePath + servers[0].store.videoCreated.shortUUID + '/blacklist'
       const fields = { reason: 'hello' }
 
       await makePutBodyRequest({
@@ -199,24 +199,24 @@ describe('Test video blacklist API validators', function () {
   describe('When getting blacklisted video', function () {
 
     it('Should fail with a non authenticated user', async function () {
-      await servers[0].videos.get({ id: servers[0].store.video.uuid, expectedStatus: HttpStatusCode.UNAUTHORIZED_401 })
+      await servers[0].videos.get({ id: servers[0].store.videoCreated.uuid, expectedStatus: HttpStatusCode.UNAUTHORIZED_401 })
     })
 
     it('Should fail with another user', async function () {
       await servers[0].videos.getWithToken({
         token: userAccessToken2,
-        id: servers[0].store.video.uuid,
+        id: servers[0].store.videoCreated.uuid,
         expectedStatus: HttpStatusCode.FORBIDDEN_403
       })
     })
 
     it('Should succeed with the owner authenticated user', async function () {
-      const video = await servers[0].videos.getWithToken({ token: userAccessToken1, id: servers[0].store.video.uuid })
+      const video = await servers[0].videos.getWithToken({ token: userAccessToken1, id: servers[0].store.videoCreated.uuid })
       expect(video.blacklisted).to.be.true
     })
 
     it('Should succeed with an admin', async function () {
-      const video = servers[0].store.video
+      const video = servers[0].store.videoCreated
 
       for (const id of [ video.id, video.uuid, video.shortUUID ]) {
         const video = await servers[0].videos.getWithToken({ id, expectedStatus: HttpStatusCode.OK_200 })
@@ -228,11 +228,19 @@ describe('Test video blacklist API validators', function () {
   describe('When removing a video in blacklist', function () {
 
     it('Should fail with a non authenticated user', async function () {
-      await command.remove({ token: 'fake token', videoId: servers[0].store.video.uuid, expectedStatus: HttpStatusCode.UNAUTHORIZED_401 })
+      await command.remove({
+        token: 'fake token',
+        videoId: servers[0].store.videoCreated.uuid,
+        expectedStatus: HttpStatusCode.UNAUTHORIZED_401
+      })
     })
 
     it('Should fail with a non admin user', async function () {
-      await command.remove({ token: userAccessToken2, videoId: servers[0].store.video.uuid, expectedStatus: HttpStatusCode.FORBIDDEN_403 })
+      await command.remove({
+        token: userAccessToken2,
+        videoId: servers[0].store.videoCreated.uuid,
+        expectedStatus: HttpStatusCode.FORBIDDEN_403
+      })
     })
 
     it('Should fail with an incorrect id', async function () {
@@ -245,7 +253,7 @@ describe('Test video blacklist API validators', function () {
     })
 
     it('Should succeed with the correct params', async function () {
-      await command.remove({ videoId: servers[0].store.video.uuid, expectedStatus: HttpStatusCode.NO_CONTENT_204 })
+      await command.remove({ videoId: servers[0].store.videoCreated.uuid, expectedStatus: HttpStatusCode.NO_CONTENT_204 })
     })
   })
 

--- a/server/tests/api/live/live-constraints.ts
+++ b/server/tests/api/live/live-constraints.ts
@@ -4,7 +4,7 @@ import 'mocha'
 import * as chai from 'chai'
 import { VideoPrivacy } from '@shared/models'
 import {
-  checkLiveCleanup,
+  checkLiveCleanupAfterSave,
   cleanupTests,
   ConfigCommand,
   createMultipleServers,
@@ -43,7 +43,7 @@ describe('Test live constraints', function () {
       expect(video.duration).to.be.greaterThan(0)
     }
 
-    await checkLiveCleanup(servers[0], videoId, resolutions)
+    await checkLiveCleanupAfterSave(servers[0], videoId, resolutions)
   }
 
   async function waitUntilLivePublishedOnAllServers (videoId: string) {

--- a/server/tests/api/live/live-save-replay.ts
+++ b/server/tests/api/live/live-save-replay.ts
@@ -4,7 +4,7 @@ import 'mocha'
 import * as chai from 'chai'
 import { FfmpegCommand } from 'fluent-ffmpeg'
 import {
-  checkLiveCleanup,
+  checkLiveCleanupAfterSave,
   cleanupTests,
   ConfigCommand,
   createMultipleServers,
@@ -150,7 +150,7 @@ describe('Save replay setting', function () {
       await checkVideoState(liveVideoUUID, VideoState.LIVE_ENDED)
 
       // No resolutions saved since we did not save replay
-      await checkLiveCleanup(servers[0], liveVideoUUID, [])
+      await checkLiveCleanupAfterSave(servers[0], liveVideoUUID, [])
     })
 
     it('Should correctly terminate the stream on blacklist and delete the live', async function () {
@@ -179,7 +179,7 @@ describe('Save replay setting', function () {
 
       await wait(5000)
       await waitJobs(servers)
-      await checkLiveCleanup(servers[0], liveVideoUUID, [])
+      await checkLiveCleanupAfterSave(servers[0], liveVideoUUID, [])
     })
 
     it('Should correctly terminate the stream on delete and delete the video', async function () {
@@ -203,7 +203,7 @@ describe('Save replay setting', function () {
       await waitJobs(servers)
 
       await checkVideosExist(liveVideoUUID, false, HttpStatusCode.NOT_FOUND_404)
-      await checkLiveCleanup(servers[0], liveVideoUUID, [])
+      await checkLiveCleanupAfterSave(servers[0], liveVideoUUID, [])
     })
   })
 
@@ -259,7 +259,7 @@ describe('Save replay setting', function () {
     })
 
     it('Should have cleaned up the live files', async function () {
-      await checkLiveCleanup(servers[0], liveVideoUUID, [ 720 ])
+      await checkLiveCleanupAfterSave(servers[0], liveVideoUUID, [ 720 ])
     })
 
     it('Should correctly terminate the stream on blacklist and blacklist the saved replay video', async function () {
@@ -287,7 +287,7 @@ describe('Save replay setting', function () {
 
       await wait(5000)
       await waitJobs(servers)
-      await checkLiveCleanup(servers[0], liveVideoUUID, [ 720 ])
+      await checkLiveCleanupAfterSave(servers[0], liveVideoUUID, [ 720 ])
     })
 
     it('Should correctly terminate the stream on delete and delete the video', async function () {
@@ -310,7 +310,7 @@ describe('Save replay setting', function () {
       await waitJobs(servers)
 
       await checkVideosExist(liveVideoUUID, false, HttpStatusCode.NOT_FOUND_404)
-      await checkLiveCleanup(servers[0], liveVideoUUID, [])
+      await checkLiveCleanupAfterSave(servers[0], liveVideoUUID, [])
     })
   })
 

--- a/server/tests/api/moderation/abuses.ts
+++ b/server/tests/api/moderation/abuses.ts
@@ -64,8 +64,8 @@ describe('Test abuses', function () {
       const { data } = await servers[0].videos.list()
       expect(data.length).to.equal(2)
 
-      servers[0].store.video = data.find(video => video.name === 'my super name for server 1')
-      servers[1].store.video = data.find(video => video.name === 'my super name for server 2')
+      servers[0].store.videoCreated = data.find(video => video.name === 'my super name for server 1')
+      servers[1].store.videoCreated = data.find(video => video.name === 'my super name for server 2')
     })
 
     it('Should not have abuses', async function () {
@@ -80,7 +80,7 @@ describe('Test abuses', function () {
       this.timeout(15000)
 
       const reason = 'my super bad reason'
-      await commands[0].report({ videoId: servers[0].store.video.id, reason })
+      await commands[0].report({ videoId: servers[0].store.videoCreated.id, reason })
 
       // We wait requests propagation, even if the server 1 is not supposed to make a request to server 2
       await waitJobs(servers)
@@ -100,7 +100,7 @@ describe('Test abuses', function () {
         expect(abuse.reporterAccount.name).to.equal('root')
         expect(abuse.reporterAccount.host).to.equal(servers[0].host)
 
-        expect(abuse.video.id).to.equal(servers[0].store.video.id)
+        expect(abuse.video.id).to.equal(servers[0].store.videoCreated.id)
         expect(abuse.video.channel).to.exist
 
         expect(abuse.comment).to.be.null
@@ -127,7 +127,7 @@ describe('Test abuses', function () {
       this.timeout(10000)
 
       const reason = 'my super bad reason 2'
-      const videoId = await servers[0].videos.getId({ uuid: servers[1].store.video.uuid })
+      const videoId = await servers[0].videos.getId({ uuid: servers[1].store.videoCreated.uuid })
       await commands[0].report({ videoId, reason })
 
       // We wait requests propagation
@@ -146,7 +146,7 @@ describe('Test abuses', function () {
         expect(abuse1.reporterAccount.name).to.equal('root')
         expect(abuse1.reporterAccount.host).to.equal(servers[0].host)
 
-        expect(abuse1.video.id).to.equal(servers[0].store.video.id)
+        expect(abuse1.video.id).to.equal(servers[0].store.videoCreated.id)
         expect(abuse1.video.countReports).to.equal(1)
         expect(abuse1.video.nthReport).to.equal(1)
 
@@ -165,7 +165,7 @@ describe('Test abuses', function () {
         expect(abuse2.reporterAccount.name).to.equal('root')
         expect(abuse2.reporterAccount.host).to.equal(servers[0].host)
 
-        expect(abuse2.video.id).to.equal(servers[1].store.video.id)
+        expect(abuse2.video.id).to.equal(servers[1].store.videoCreated.id)
 
         expect(abuse2.comment).to.be.null
 
@@ -200,7 +200,7 @@ describe('Test abuses', function () {
       this.timeout(10000)
 
       {
-        const videoId = await servers[1].videos.getId({ uuid: servers[0].store.video.uuid })
+        const videoId = await servers[1].videos.getId({ uuid: servers[0].store.videoCreated.uuid })
         await commands[1].report({ videoId, reason: 'will mute this' })
         await waitJobs(servers)
 
@@ -288,7 +288,7 @@ describe('Test abuses', function () {
       await commands[0].report({ videoId: video3Id, reason: reason3 })
 
       const reason4 = 'my super bad reason 4'
-      await commands[0].report({ token: userAccessToken, videoId: servers[0].store.video.id, reason: reason4 })
+      await commands[0].report({ token: userAccessToken, videoId: servers[0].store.videoCreated.id, reason: reason4 })
 
       {
         const body = await commands[0].getAdminList()
@@ -301,7 +301,7 @@ describe('Test abuses', function () {
         expect(abuseVideo3.countReportsForReportee).to.equal(1, "wrong reports count for reporter on video 3 abuse")
         expect(abuseVideo3.countReportsForReporter).to.equal(3, "wrong reports count for reportee on video 3 abuse")
 
-        const abuseServer1 = abuses.find(a => a.video.id === servers[0].store.video.id)
+        const abuseServer1 = abuses.find(a => a.video.id === servers[0].store.videoCreated.id)
         expect(abuseServer1.countReportsForReportee).to.equal(3, "wrong reports count for reporter on video 1 abuse")
       }
     })
@@ -312,7 +312,7 @@ describe('Test abuses', function () {
       const reason5 = 'my super bad reason 5'
       const predefinedReasons5: AbusePredefinedReasonsString[] = [ 'violentOrRepulsive', 'captions' ]
       const createRes = await commands[0].report({
-        videoId: servers[0].store.video.id,
+        videoId: servers[0].store.videoCreated.id,
         reason: reason5,
         predefinedReasons: predefinedReasons5,
         startAt: 1,
@@ -402,11 +402,11 @@ describe('Test abuses', function () {
     before(async function () {
       this.timeout(50000)
 
-      servers[0].store.video = await servers[0].videos.quickUpload({ name: 'server 1' })
-      servers[1].store.video = await servers[1].videos.quickUpload({ name: 'server 2' })
+      servers[0].store.videoCreated = await servers[0].videos.quickUpload({ name: 'server 1' })
+      servers[1].store.videoCreated = await servers[1].videos.quickUpload({ name: 'server 2' })
 
-      await servers[0].comments.createThread({ videoId: servers[0].store.video.id, text: 'comment server 1' })
-      await servers[1].comments.createThread({ videoId: servers[1].store.video.id, text: 'comment server 2' })
+      await servers[0].comments.createThread({ videoId: servers[0].store.videoCreated.id, text: 'comment server 1' })
+      await servers[1].comments.createThread({ videoId: servers[1].store.videoCreated.id, text: 'comment server 2' })
 
       await waitJobs(servers)
     })
@@ -414,7 +414,7 @@ describe('Test abuses', function () {
     it('Should report abuse on a comment', async function () {
       this.timeout(15000)
 
-      const comment = await getComment(servers[0], servers[0].store.video.id)
+      const comment = await getComment(servers[0], servers[0].store.videoCreated.id)
 
       const reason = 'it is a bad comment'
       await commands[0].report({ commentId: comment.id, reason })
@@ -424,7 +424,7 @@ describe('Test abuses', function () {
 
     it('Should have 1 comment abuse on server 1 and 0 on server 2', async function () {
       {
-        const comment = await getComment(servers[0], servers[0].store.video.id)
+        const comment = await getComment(servers[0], servers[0].store.videoCreated.id)
         const body = await commands[0].getAdminList({ filter: 'comment' })
 
         expect(body.total).to.equal(1)
@@ -442,8 +442,8 @@ describe('Test abuses', function () {
         expect(abuse.comment.id).to.equal(comment.id)
         expect(abuse.comment.text).to.equal(comment.text)
         expect(abuse.comment.video.name).to.equal('server 1')
-        expect(abuse.comment.video.id).to.equal(servers[0].store.video.id)
-        expect(abuse.comment.video.uuid).to.equal(servers[0].store.video.uuid)
+        expect(abuse.comment.video.id).to.equal(servers[0].store.videoCreated.id)
+        expect(abuse.comment.video.uuid).to.equal(servers[0].store.videoCreated.uuid)
 
         expect(abuse.countReportsForReporter).to.equal(5)
         expect(abuse.countReportsForReportee).to.equal(5)
@@ -459,7 +459,7 @@ describe('Test abuses', function () {
     it('Should report abuse on a remote comment', async function () {
       this.timeout(10000)
 
-      const comment = await getComment(servers[0], servers[1].store.video.uuid)
+      const comment = await getComment(servers[0], servers[1].store.videoCreated.uuid)
 
       const reason = 'it is a really bad comment'
       await commands[0].report({ commentId: comment.id, reason })
@@ -468,7 +468,7 @@ describe('Test abuses', function () {
     })
 
     it('Should have 2 comment abuses on server 1 and 1 on server 2', async function () {
-      const commentServer2 = await getComment(servers[0], servers[1].store.video.id)
+      const commentServer2 = await getComment(servers[0], servers[1].store.videoCreated.id)
 
       {
         const body = await commands[0].getAdminList({ filter: 'comment' })
@@ -493,7 +493,7 @@ describe('Test abuses', function () {
         expect(abuse2.comment.id).to.equal(commentServer2.id)
         expect(abuse2.comment.text).to.equal(commentServer2.text)
         expect(abuse2.comment.video.name).to.equal('server 2')
-        expect(abuse2.comment.video.uuid).to.equal(servers[1].store.video.uuid)
+        expect(abuse2.comment.video.uuid).to.equal(servers[1].store.videoCreated.uuid)
 
         expect(abuse2.state.id).to.equal(AbuseState.PENDING)
         expect(abuse2.state.label).to.equal('Pending')
@@ -527,9 +527,9 @@ describe('Test abuses', function () {
     it('Should keep the comment abuse when deleting the comment', async function () {
       this.timeout(10000)
 
-      const commentServer2 = await getComment(servers[0], servers[1].store.video.id)
+      const commentServer2 = await getComment(servers[0], servers[1].store.videoCreated.id)
 
-      await servers[0].comments.delete({ videoId: servers[1].store.video.uuid, commentId: commentServer2.id })
+      await servers[0].comments.delete({ videoId: servers[1].store.videoCreated.uuid, commentId: commentServer2.id })
 
       await waitJobs(servers)
 
@@ -761,9 +761,9 @@ describe('Test abuses', function () {
     before(async function () {
       userAccessToken = await servers[0].users.generateUserAndToken('user_42')
 
-      await commands[0].report({ token: userAccessToken, videoId: servers[0].store.video.id, reason: 'user reason 1' })
+      await commands[0].report({ token: userAccessToken, videoId: servers[0].store.videoCreated.id, reason: 'user reason 1' })
 
-      const videoId = await servers[0].videos.getId({ uuid: servers[1].store.video.uuid })
+      const videoId = await servers[0].videos.getId({ uuid: servers[1].store.videoCreated.uuid })
       await commands[0].report({ token: userAccessToken, videoId, reason: 'user reason 2' })
     })
 
@@ -832,7 +832,7 @@ describe('Test abuses', function () {
     before(async function () {
       userToken = await servers[0].users.generateUserAndToken('user_43')
 
-      const body = await commands[0].report({ token: userToken, videoId: servers[0].store.video.id, reason: 'user 43 reason 1' })
+      const body = await commands[0].report({ token: userToken, videoId: servers[0].store.videoCreated.id, reason: 'user 43 reason 1' })
       abuseId = body.abuse.id
     })
 

--- a/server/tests/api/users/users-multiple-servers.ts
+++ b/server/tests/api/users/users-multiple-servers.ts
@@ -58,10 +58,10 @@ describe('Test users with multiple servers', function () {
       const { uuid } = await servers[0].videos.upload({ token: userAccessToken })
       videoUUID = uuid
 
+      await waitJobs(servers)
+
       await saveVideoInServers(servers, videoUUID)
     }
-
-    await waitJobs(servers)
   })
 
   it('Should be able to update my display name', async function () {

--- a/server/tests/api/videos/audio-only.ts
+++ b/server/tests/api/videos/audio-only.ts
@@ -2,7 +2,6 @@
 
 import 'mocha'
 import * as chai from 'chai'
-import { join } from 'path'
 import { getAudioStream, getVideoStreamSize } from '@server/helpers/ffprobe-utils'
 import { cleanupTests, createMultipleServers, doubleFollow, PeerTubeServer, setAccessTokensToServers, waitJobs } from '@shared/extra-utils'
 
@@ -11,6 +10,8 @@ const expect = chai.expect
 describe('Test audio only video transcoding', function () {
   let servers: PeerTubeServer[] = []
   let videoUUID: string
+  let webtorrentAudioFileUrl: string
+  let fragmentedAudioFileUrl: string
 
   before(async function () {
     this.timeout(120000)
@@ -63,13 +64,18 @@ describe('Test audio only video transcoding', function () {
         expect(files[1].resolution.id).to.equal(240)
         expect(files[2].resolution.id).to.equal(0)
       }
+
+      if (server.serverNumber === 1) {
+        webtorrentAudioFileUrl = video.files[2].fileUrl
+        fragmentedAudioFileUrl = video.streamingPlaylists[0].files[2].fileUrl
+      }
     }
   })
 
   it('0p transcoded video should not have video', async function () {
     const paths = [
-      servers[0].servers.buildDirectory(join('videos', videoUUID + '-0.mp4')),
-      servers[0].servers.buildDirectory(join('streaming-playlists', 'hls', videoUUID, videoUUID + '-0-fragmented.mp4'))
+      servers[0].servers.buildWebTorrentFilePath(webtorrentAudioFileUrl),
+      servers[0].servers.buildFragmentedFilePath(videoUUID, fragmentedAudioFileUrl)
     ]
 
     for (const path of paths) {

--- a/server/tests/api/videos/multiple-servers.ts
+++ b/server/tests/api/videos/multiple-servers.ts
@@ -13,6 +13,7 @@ import {
   dateIsValid,
   doubleFollow,
   PeerTubeServer,
+  saveVideoInServers,
   setAccessTokensToServers,
   testImage,
   wait,
@@ -661,19 +662,19 @@ describe('Test multiple servers', function () {
       }
     })
 
-    it('Should remove the videos 3 and 3-2 by asking server 3', async function () {
-      this.timeout(10000)
+    it('Should remove the videos 3 and 3-2 by asking server 3 and correctly delete files', async function () {
+      this.timeout(30000)
 
-      await servers[2].videos.remove({ id: toRemove[0].id })
-      await servers[2].videos.remove({ id: toRemove[1].id })
+      for (const id of [ toRemove[0].id, toRemove[1].id ]) {
+        await saveVideoInServers(servers, id)
 
-      await waitJobs(servers)
-    })
+        await servers[2].videos.remove({ id })
 
-    it('Should not have files of videos 3 and 3-2 on each server', async function () {
-      for (const server of servers) {
-        await checkVideoFilesWereRemoved(toRemove[0].uuid, server)
-        await checkVideoFilesWereRemoved(toRemove[1].uuid, server)
+        await waitJobs(servers)
+
+        for (const server of servers) {
+          await checkVideoFilesWereRemoved({ server, video: server.store.videoDetails })
+        }
       }
     })
 

--- a/server/tests/api/videos/resumable-upload.ts
+++ b/server/tests/api/videos/resumable-upload.ts
@@ -170,8 +170,13 @@ describe('Test resumable upload', function () {
 
       const size = 1000
 
+      // Content length check seems to have changed in v16
+      const expectedStatus = process.version.startsWith('v16')
+        ? HttpStatusCode.CONFLICT_409
+        : HttpStatusCode.BAD_REQUEST_400
+
       const contentRangeBuilder = (start: number) => `bytes ${start}-${start + size - 1}/${size}`
-      await sendChunks({ pathUploadId: uploadId, expectedStatus: HttpStatusCode.CONFLICT_409, contentRangeBuilder, contentLength: size })
+      await sendChunks({ pathUploadId: uploadId, expectedStatus, contentRangeBuilder, contentLength: size })
       await checkFileSize(uploadId, 0)
     })
   })

--- a/server/tests/api/videos/resumable-upload.ts
+++ b/server/tests/api/videos/resumable-upload.ts
@@ -99,8 +99,8 @@ describe('Test resumable upload', function () {
     this.timeout(30000)
 
     server = await createSingleServer(1)
-    await setAccessTokensToServers([server])
-    await setDefaultVideoChannel([server])
+    await setAccessTokensToServers([ server ])
+    await setDefaultVideoChannel([ server ])
 
     const body = await server.users.getMyInfo()
     rootId = body.id
@@ -170,13 +170,13 @@ describe('Test resumable upload', function () {
 
       const size = 1000
 
-      const contentRangeBuilder = start => `bytes ${start}-${start + size - 1}/${size}`
+      const contentRangeBuilder = (start: number) => `bytes ${start}-${start + size - 1}/${size}`
       await sendChunks({ pathUploadId: uploadId, expectedStatus: HttpStatusCode.CONFLICT_409, contentRangeBuilder, contentLength: size })
       await checkFileSize(uploadId, 0)
     })
   })
 
   after(async function () {
-    await cleanupTests([server])
+    await cleanupTests([ server ])
   })
 })

--- a/server/tests/api/videos/single-server.ts
+++ b/server/tests/api/videos/single-server.ts
@@ -199,9 +199,10 @@ describe('Test a single server', function () {
     })
 
     it('Should remove the video', async function () {
+      const video = await server.videos.get({ id: videoId })
       await server.videos.remove({ id: videoId })
 
-      await checkVideoFilesWereRemoved(videoUUID, server)
+      await checkVideoFilesWereRemoved({ video, server })
     })
 
     it('Should not have videos', async function () {

--- a/server/tests/api/videos/video-captions.ts
+++ b/server/tests/api/videos/video-captions.ts
@@ -178,9 +178,12 @@ describe('Test video captions', function () {
   })
 
   it('Should remove the video, and thus all video captions', async function () {
+    const video = await servers[0].videos.get({ id: videoUUID })
+    const { data: captions } = await servers[0].captions.list({ videoId: videoUUID })
+
     await servers[0].videos.remove({ id: videoUUID })
 
-    await checkVideoFilesWereRemoved(videoUUID, servers[0])
+    await checkVideoFilesWereRemoved({ server: servers[0], video, captions })
   })
 
   after(async function () {

--- a/server/tests/api/videos/video-change-ownership.ts
+++ b/server/tests/api/videos/video-change-ownership.ts
@@ -73,7 +73,7 @@ describe('Test video change ownership - nominal', function () {
       }
       const { id } = await servers[0].videos.upload({ token: firstUserToken, attributes })
 
-      servers[0].store.video = await servers[0].videos.get({ id })
+      servers[0].store.videoCreated = await servers[0].videos.get({ id })
     }
 
     {
@@ -109,7 +109,7 @@ describe('Test video change ownership - nominal', function () {
   it('Should send a request to change ownership of a video', async function () {
     this.timeout(15000)
 
-    await command.create({ token: firstUserToken, videoId: servers[0].store.video.id, username: secondUser })
+    await command.create({ token: firstUserToken, videoId: servers[0].store.videoCreated.id, username: secondUser })
   })
 
   it('Should only return a request to change ownership for the second user', async function () {
@@ -135,7 +135,7 @@ describe('Test video change ownership - nominal', function () {
   it('Should accept the same change ownership request without crashing', async function () {
     this.timeout(10000)
 
-    await command.create({ token: firstUserToken, videoId: servers[0].store.video.id, username: secondUser })
+    await command.create({ token: firstUserToken, videoId: servers[0].store.videoCreated.id, username: secondUser })
   })
 
   it('Should not create multiple change ownership requests while one is waiting', async function () {
@@ -163,7 +163,7 @@ describe('Test video change ownership - nominal', function () {
   it('Should send a new request to change ownership of a video', async function () {
     this.timeout(15000)
 
-    await command.create({ token: firstUserToken, videoId: servers[0].store.video.id, username: secondUser })
+    await command.create({ token: firstUserToken, videoId: servers[0].store.videoCreated.id, username: secondUser })
   })
 
   it('Should return two requests to change ownership for the second user', async function () {
@@ -207,7 +207,7 @@ describe('Test video change ownership - nominal', function () {
 
   it('Should have the channel of the video updated', async function () {
     for (const server of servers) {
-      const video = await server.videos.get({ id: servers[0].store.video.uuid })
+      const video = await server.videos.get({ id: servers[0].store.videoCreated.uuid })
 
       expect(video.name).to.equal('my super name')
       expect(video.channel.displayName).to.equal('Main second channel')
@@ -236,7 +236,7 @@ describe('Test video change ownership - nominal', function () {
     await waitJobs(servers)
 
     for (const server of servers) {
-      const video = await server.videos.get({ id: servers[0].store.video.uuid })
+      const video = await server.videos.get({ id: servers[0].store.videoCreated.uuid })
 
       expect(video.name).to.equal('my super name')
       expect(video.channel.displayName).to.equal('Main second channel')
@@ -282,13 +282,13 @@ describe('Test video change ownership - quota too small', function () {
     const { data } = await server.videos.list()
     expect(data.length).to.equal(1)
 
-    server.store.video = data.find(video => video.name === 'my super name')
+    server.store.videoCreated = data.find(video => video.name === 'my super name')
   })
 
   it('Should send a request to change ownership of a video', async function () {
     this.timeout(15000)
 
-    await server.changeOwnership.create({ token: firstUserToken, videoId: server.store.video.id, username: secondUser })
+    await server.changeOwnership.create({ token: firstUserToken, videoId: server.store.videoCreated.id, username: secondUser })
   })
 
   it('Should only return a request to change ownership for the second user', async function () {

--- a/server/tests/api/videos/video-hls.ts
+++ b/server/tests/api/videos/video-hls.ts
@@ -2,7 +2,8 @@
 
 import 'mocha'
 import * as chai from 'chai'
-import { join } from 'path'
+import { basename, join } from 'path'
+import { removeFragmentedMP4Ext, uuidRegex } from '@shared/core-utils'
 import {
   checkDirectoryIsEmpty,
   checkResolutionsInMasterPlaylist,
@@ -19,8 +20,6 @@ import {
 } from '@shared/extra-utils'
 import { HttpStatusCode, VideoStreamingPlaylistType } from '@shared/models'
 import { DEFAULT_AUDIO_RESOLUTION } from '../../../initializers/constants'
-import { uuidRegex } from '@shared/core-utils'
-import { basename } from 'path/posix'
 
 const expect = chai.expect
 
@@ -78,11 +77,13 @@ async function checkHlsPlaylist (servers: PeerTubeServer[], videoUUID: string, h
     // Check resolution playlists
     {
       for (const resolution of resolutions) {
+        const file = hlsFiles.find(f => f.resolution.id === resolution)
+        const playlistName = removeFragmentedMP4Ext(basename(file.fileUrl)) + '.m3u8'
+
         const subPlaylist = await server.streamingPlaylists.get({
-          url: `${baseUrl}/static/streaming-playlists/hls/${videoUUID}/${resolution}.m3u8`
+          url: `${baseUrl}/static/streaming-playlists/hls/${videoUUID}/${playlistName}`
         })
 
-        const file = hlsFiles.find(f => f.resolution.id === resolution)
         expect(subPlaylist).to.match(new RegExp(`${uuidRegex}-${resolution}-fragmented.mp4`))
         expect(subPlaylist).to.contain(basename(file.fileUrl))
       }

--- a/server/tests/cli/optimize-old-videos.ts
+++ b/server/tests/cli/optimize-old-videos.ts
@@ -2,7 +2,6 @@
 
 import 'mocha'
 import * as chai from 'chai'
-import { join } from 'path'
 import {
   cleanupTests,
   createMultipleServers,
@@ -86,7 +85,7 @@ describe('Test optimize old videos', function () {
 
         expect(file.size).to.be.below(8000000)
 
-        const path = servers[0].servers.buildDirectory(join('videos', video.uuid + '-' + file.resolution.id + '.mp4'))
+        const path = servers[0].servers.buildWebTorrentFilePath(file.fileUrl)
         const bitrate = await getVideoFileBitrate(path)
         const fps = await getVideoFileFPS(path)
         const resolution = await getVideoFileResolution(path)

--- a/server/tests/cli/prune-storage.ts
+++ b/server/tests/cli/prune-storage.ts
@@ -36,7 +36,7 @@ async function assertNotExists (server: PeerTubeServer, directory: string, subst
   }
 }
 
-async function assertCountAreOkay (servers: PeerTubeServer[]) {
+async function assertCountAreOkay (servers: PeerTubeServer[], videoServer2UUID: string) {
   for (const server of servers) {
     const videosCount = await countFiles(server, 'videos')
     expect(videosCount).to.equal(8)
@@ -53,11 +53,20 @@ async function assertCountAreOkay (servers: PeerTubeServer[]) {
     const avatarsCount = await countFiles(server, 'avatars')
     expect(avatarsCount).to.equal(2)
   }
+
+  // When we'll prune HLS directories too
+  // const hlsRootCount = await countFiles(servers[1], 'streaming-playlists/hls/')
+  // expect(hlsRootCount).to.equal(2)
+
+  // const hlsCount = await countFiles(servers[1], 'streaming-playlists/hls/' + videoServer2UUID)
+  // expect(hlsCount).to.equal(10)
 }
 
 describe('Test prune storage scripts', function () {
   let servers: PeerTubeServer[]
   const badNames: { [directory: string]: string[] } = {}
+
+  let videoServer2UUID: string
 
   before(async function () {
     this.timeout(120000)
@@ -68,7 +77,9 @@ describe('Test prune storage scripts', function () {
 
     for (const server of servers) {
       await server.videos.upload({ attributes: { name: 'video 1' } })
-      await server.videos.upload({ attributes: { name: 'video 2' } })
+
+      const { uuid } = await server.videos.upload({ attributes: { name: 'video 2' } })
+      if (server.serverNumber === 2) videoServer2UUID = uuid
 
       await server.users.updateMyAvatar({ fixture: 'avatar.png' })
 
@@ -112,7 +123,7 @@ describe('Test prune storage scripts', function () {
   })
 
   it('Should have the files on the disk', async function () {
-    await assertCountAreOkay(servers)
+    await assertCountAreOkay(servers, videoServer2UUID)
   })
 
   it('Should create some dirty files', async function () {
@@ -176,6 +187,28 @@ describe('Test prune storage scripts', function () {
 
         badNames['avatars'] = [ n1, n2 ]
       }
+
+      // When we'll prune HLS directories too
+      // {
+      //   const directory = join('streaming-playlists', 'hls')
+      //   const base = servers[1].servers.buildDirectory(directory)
+
+      //   const n1 = buildUUID()
+      //   await createFile(join(base, n1))
+      //   badNames[directory] = [ n1 ]
+      // }
+
+      // {
+      //   const directory = join('streaming-playlists', 'hls', videoServer2UUID)
+      //   const base = servers[1].servers.buildDirectory(directory)
+      //   const n1 = buildUUID() + '-240-fragmented-.mp4'
+      //   const n2 = buildUUID() + '-master.m3u8'
+
+      //   await createFile(join(base, n1))
+      //   await createFile(join(base, n2))
+
+      //   badNames[directory] = [ n1, n2 ]
+      // }
     }
   })
 
@@ -187,7 +220,7 @@ describe('Test prune storage scripts', function () {
   })
 
   it('Should have removed files', async function () {
-    await assertCountAreOkay(servers)
+    await assertCountAreOkay(servers, videoServer2UUID)
 
     for (const directory of Object.keys(badNames)) {
       for (const name of badNames[directory]) {

--- a/server/tests/cli/update-host.ts
+++ b/server/tests/cli/update-host.ts
@@ -108,21 +108,22 @@ describe('Test update host scripts', function () {
 
     for (const video of data) {
       const videoDetails = await server.videos.get({ id: video.id })
+      const files = videoDetails.files.concat(videoDetails.streamingPlaylists[0].files)
 
-      expect(videoDetails.files).to.have.lengthOf(4)
+      expect(files).to.have.lengthOf(8)
 
-      for (const file of videoDetails.files) {
+      for (const file of files) {
         expect(file.magnetUri).to.contain('localhost%3A9002%2Ftracker%2Fsocket')
-        expect(file.magnetUri).to.contain('localhost%3A9002%2Fstatic%2Fwebseed%2F')
+        expect(file.magnetUri).to.contain('localhost%3A9002%2Fstatic%2F')
 
-        const torrent = await parseTorrentVideo(server, videoDetails.uuid, file.resolution.id)
+        const torrent = await parseTorrentVideo(server, file)
         const announceWS = torrent.announce.find(a => a === 'ws://localhost:9002/tracker/socket')
         expect(announceWS).to.not.be.undefined
 
         const announceHttp = torrent.announce.find(a => a === 'http://localhost:9002/tracker/announce')
         expect(announceHttp).to.not.be.undefined
 
-        expect(torrent.urlList[0]).to.contain('http://localhost:9002/static/webseed')
+        expect(torrent.urlList[0]).to.contain('http://localhost:9002/static/')
       }
     }
   })

--- a/server/tests/plugins/plugin-helpers.ts
+++ b/server/tests/plugins/plugin-helpers.ts
@@ -232,7 +232,7 @@ describe('Test plugin helpers', function () {
       this.timeout(40000)
 
       // Should not throw -> video exists
-      await servers[0].videos.get({ id: videoUUID })
+      const video = await servers[0].videos.get({ id: videoUUID })
       // Should delete the video
       await servers[0].videos.view({ id: videoUUID })
 
@@ -246,7 +246,7 @@ describe('Test plugin helpers', function () {
         if (err.message.includes('exists')) throw err
       }
 
-      await checkVideoFilesWereRemoved(videoUUID, servers[0])
+      await checkVideoFilesWereRemoved({ server: servers[0], video })
     })
 
     it('Should have fetched the video by URL', async function () {

--- a/server/tests/plugins/plugin-transcoding.ts
+++ b/server/tests/plugins/plugin-transcoding.ts
@@ -2,7 +2,6 @@
 
 import 'mocha'
 import { expect } from 'chai'
-import { join } from 'path'
 import { getAudioStream, getVideoFileFPS, getVideoStreamFromFile } from '@server/helpers/ffprobe-utils'
 import {
   cleanupTests,
@@ -247,7 +246,9 @@ describe('Test transcoding plugins', function () {
       const videoUUID = (await server.videos.quickUpload({ name: 'video', fixture: 'video_very_short_240p.mp4' })).uuid
       await waitJobs([ server ])
 
-      const path = server.servers.buildDirectory(join('videos', videoUUID + '-240.mp4'))
+      const video = await server.videos.get({ id: videoUUID })
+
+      const path = server.servers.buildWebTorrentFilePath(video.files[0].fileUrl)
       const audioProbe = await getAudioStream(path)
       expect(audioProbe.audioStream.codec_name).to.equal('opus')
 

--- a/server/types/models/video/video-streaming-playlist.ts
+++ b/server/types/models/video/video-streaming-playlist.ts
@@ -39,5 +39,5 @@ export type MStreamingPlaylistRedundanciesOpt =
   PickWithOpt<VideoStreamingPlaylistModel, 'RedundancyVideos', MVideoRedundancyFileUrl[]>
 
 export function isStreamingPlaylist (value: MVideo | MStreamingPlaylistVideo): value is MStreamingPlaylistVideo {
-  return !!(value as MStreamingPlaylist).playlistUrl
+  return !!(value as MStreamingPlaylist).videoId
 }

--- a/shared/core-utils/miscs/index.ts
+++ b/shared/core-utils/miscs/index.ts
@@ -1,3 +1,4 @@
 export * from './date'
 export * from './miscs'
 export * from './types'
+export * from './regexp'

--- a/shared/core-utils/miscs/regexp.ts
+++ b/shared/core-utils/miscs/regexp.ts
@@ -1,1 +1,5 @@
 export const uuidRegex = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+export function removeFragmentedMP4Ext (path: string) {
+  return path.replace(/-fragmented.mp4$/i, '')
+}

--- a/shared/core-utils/miscs/regexp.ts
+++ b/shared/core-utils/miscs/regexp.ts
@@ -1,0 +1,1 @@
+export const uuidRegex = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'

--- a/shared/extra-utils/miscs/webtorrent.ts
+++ b/shared/extra-utils/miscs/webtorrent.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'fs-extra'
 import * as parseTorrent from 'parse-torrent'
-import { join } from 'path'
+import { basename, join } from 'path'
 import * as WebTorrent from 'webtorrent'
+import { VideoFile } from '@shared/models'
 import { PeerTubeServer } from '../server'
 
 let webtorrent: WebTorrent.Instance
@@ -15,8 +16,8 @@ function webtorrentAdd (torrent: string, refreshWebTorrent = false) {
   return new Promise<WebTorrent.Torrent>(res => webtorrent.add(torrent, res))
 }
 
-async function parseTorrentVideo (server: PeerTubeServer, videoUUID: string, resolution: number) {
-  const torrentName = videoUUID + '-' + resolution + '.torrent'
+async function parseTorrentVideo (server: PeerTubeServer, file: VideoFile) {
+  const torrentName = basename(file.torrentUrl)
   const torrentPath = server.servers.buildDirectory(join('torrents', torrentName))
 
   const data = await readFile(torrentPath)

--- a/shared/extra-utils/server/server.ts
+++ b/shared/extra-utils/server/server.ts
@@ -3,7 +3,7 @@ import { copy } from 'fs-extra'
 import { join } from 'path'
 import { root } from '@server/helpers/core-utils'
 import { randomInt } from '../../core-utils/miscs/miscs'
-import { VideoChannel } from '../../models/videos'
+import { Video, VideoChannel, VideoCreateResult, VideoDetails } from '../../models/videos'
 import { BulkCommand } from '../bulk'
 import { CLICommand } from '../cli'
 import { CustomPagesCommand } from '../custom-pages'
@@ -75,19 +75,9 @@ export class PeerTubeServer {
 
     channel?: VideoChannel
 
-    video?: {
-      id: number
-      uuid: string
-      shortUUID: string
-      name?: string
-      url?: string
-
-      account?: {
-        name: string
-      }
-
-      embedPath?: string
-    }
+    video?: Video
+    videoCreated?: VideoCreateResult
+    videoDetails?: VideoDetails
 
     videos?: { id: number, uuid: string }[]
   }

--- a/shared/extra-utils/server/servers-command.ts
+++ b/shared/extra-utils/server/servers-command.ts
@@ -1,7 +1,6 @@
 import { exec } from 'child_process'
 import { copy, ensureDir, readFile, remove } from 'fs-extra'
-import { join } from 'path'
-import { basename } from 'path/posix'
+import { basename, join } from 'path'
 import { root } from '@server/helpers/core-utils'
 import { HttpStatusCode } from '@shared/models'
 import { getFileSize, isGithubCI, wait } from '../miscs'

--- a/shared/extra-utils/server/servers-command.ts
+++ b/shared/extra-utils/server/servers-command.ts
@@ -1,6 +1,7 @@
 import { exec } from 'child_process'
 import { copy, ensureDir, readFile, remove } from 'fs-extra'
 import { join } from 'path'
+import { basename } from 'path/posix'
 import { root } from '@server/helpers/core-utils'
 import { HttpStatusCode } from '@shared/models'
 import { getFileSize, isGithubCI, wait } from '../miscs'
@@ -70,6 +71,14 @@ export class ServersCommand extends AbstractCommand {
 
   buildDirectory (directory: string) {
     return join(root(), 'test' + this.server.internalServerNumber, directory)
+  }
+
+  buildWebTorrentFilePath (fileUrl: string) {
+    return this.buildDirectory(join('videos', basename(fileUrl)))
+  }
+
+  buildFragmentedFilePath (videoUUID: string, fileUrl: string) {
+    return this.buildDirectory(join('streaming-playlists', 'hls', videoUUID, basename(fileUrl)))
   }
 
   async getServerFileSize (subPath: string) {

--- a/shared/extra-utils/videos/live.ts
+++ b/shared/extra-utils/videos/live.ts
@@ -76,7 +76,7 @@ async function waitUntilLivePublishedOnAllServers (servers: PeerTubeServer[], vi
   }
 }
 
-async function checkLiveCleanup (server: PeerTubeServer, videoUUID: string, resolutions: number[] = []) {
+async function checkLiveCleanupAfterSave (server: PeerTubeServer, videoUUID: string, resolutions: number[] = []) {
   const basePath = server.servers.buildDirectory('streaming-playlists')
   const hlsPath = join(basePath, 'hls', videoUUID)
 
@@ -93,12 +93,18 @@ async function checkLiveCleanup (server: PeerTubeServer, videoUUID: string, reso
   expect(files).to.have.lengthOf(resolutions.length * 2 + 2)
 
   for (const resolution of resolutions) {
-    expect(files).to.contain(`${videoUUID}-${resolution}-fragmented.mp4`)
-    expect(files).to.contain(`${resolution}.m3u8`)
+    const fragmentedFile = files.find(f => f.endsWith(`-${resolution}-fragmented.mp4`))
+    expect(fragmentedFile).to.exist
+
+    const playlistFile = files.find(f => f.endsWith(`${resolution}.m3u8`))
+    expect(playlistFile).to.exist
   }
 
-  expect(files).to.contain('master.m3u8')
-  expect(files).to.contain('segments-sha256.json')
+  const masterPlaylistFile = files.find(f => f.endsWith('-master.m3u8'))
+  expect(masterPlaylistFile).to.exist
+
+  const shaFile = files.find(f => f.endsWith('-segments-sha256.json'))
+  expect(shaFile).to.exist
 }
 
 export {
@@ -107,5 +113,5 @@ export {
   testFfmpegStreamError,
   stopFfmpeg,
   waitUntilLivePublishedOnAllServers,
-  checkLiveCleanup
+  checkLiveCleanupAfterSave
 }

--- a/shared/extra-utils/videos/streaming-playlists.ts
+++ b/shared/extra-utils/videos/streaming-playlists.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { basename } from 'path'
 import { sha256 } from '@server/helpers/core-utils'
 import { HttpStatusCode, VideoStreamingPlaylist } from '@shared/models'
 import { PeerTubeServer } from '../server'
@@ -16,7 +17,8 @@ async function checkSegmentHash (options: {
 
   const playlist = await command.get({ url: `${baseUrlPlaylist}/${videoUUID}/${resolution}.m3u8` })
 
-  const videoName = `${videoUUID}-${resolution}-fragmented.mp4`
+  const file = hlsPlaylist.files.find(f => f.resolution.id === resolution)
+  const videoName = basename(file.fileUrl)
 
   const matches = /#EXT-X-BYTERANGE:(\d+)@(\d+)/.exec(playlist)
 

--- a/shared/extra-utils/videos/streaming-playlists.ts
+++ b/shared/extra-utils/videos/streaming-playlists.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { basename } from 'path'
 import { sha256 } from '@server/helpers/core-utils'
+import { removeFragmentedMP4Ext } from '@shared/core-utils'
 import { HttpStatusCode, VideoStreamingPlaylist } from '@shared/models'
 import { PeerTubeServer } from '../server'
 
@@ -15,10 +16,10 @@ async function checkSegmentHash (options: {
   const { server, baseUrlPlaylist, baseUrlSegment, videoUUID, resolution, hlsPlaylist } = options
   const command = server.streamingPlaylists
 
-  const playlist = await command.get({ url: `${baseUrlPlaylist}/${videoUUID}/${resolution}.m3u8` })
-
   const file = hlsPlaylist.files.find(f => f.resolution.id === resolution)
   const videoName = basename(file.fileUrl)
+
+  const playlist = await command.get({ url: `${baseUrlPlaylist}/${videoUUID}/${removeFragmentedMP4Ext(videoName)}.m3u8` })
 
   const matches = /#EXT-X-BYTERANGE:(\d+)@(\d+)/.exec(playlist)
 


### PR DESCRIPTION
Breaks compatibility with PeerTube < 3.1

Use dedicated UUIDs for video and playlists files, so that they are immutable. Allows admins to easily use built-in nginx cache or CNDs.

Closes https://github.com/Chocobozzz/PeerTube/issues/4210

ping @kontrollanten 