### PR TITLE
Handle video file move in a job

### DIFF
--- a/server/controllers/api/videos/live.ts
+++ b/server/controllers/api/videos/live.ts
@@ -98,6 +98,7 @@ async function addLiveVideo (req: express.Request, res: express.Response) {
 
   const [ thumbnailModel, previewModel ] = await buildVideoThumbnailsFromReq({
     video,
+    // @ts-expect-error
     files: req.files,
     fallback: type => {
       return updateVideoMiniatureFromExisting({

--- a/server/controllers/api/videos/update.ts
+++ b/server/controllers/api/videos/update.ts
@@ -60,9 +60,11 @@ export async function updateVideo (req: express.Request, res: express.Response) 
   const wasConfidentialVideo = videoInstance.isConfidential()
   const hadPrivacyForFederation = videoInstance.hasPrivacyForFederation()
 
+  // @ts-expect-error
+  const files: { [fieldname: string]: Express.Multer.File[] } = req.files
   const [ thumbnailModel, previewModel ] = await buildVideoThumbnailsFromReq({
     video: videoInstance,
-    files: req.files,
+    files,
     fallback: () => Promise.resolve(undefined),
     automaticallyGenerated: false
   })

--- a/server/controllers/api/videos/upload.ts
+++ b/server/controllers/api/videos/upload.ts
@@ -132,19 +132,13 @@ export async function addVideoResumable (_req: express.Request, res: express.Res
 
 async function addVideo (options: {
   res: express.Response
-  videoPhysicalFile: express.VideoUploadFile
   videoInfo: VideoCreate
   files: express.UploadFiles
 }) {
-  const { res, videoPhysicalFile, videoInfo, files } = options
+  const { res, videoInfo, files } = options
   const video = res.locals.video
   const videoFile = res.locals.videoFile
   const user = res.locals.oauth.token.User
-  const destination = getVideoFilePath(video, videoFile)
-
-  // This is important in case if there is another attempt in the retry process
-  videoPhysicalFile.filename = getVideoFilePath(video, videoFile)
-  videoPhysicalFile.path = destination
 
   const [ thumbnailModel, previewModel ] = await buildVideoThumbnailsFromReq({
     video,

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -147,7 +147,8 @@ const JOB_ATTEMPTS: { [id in JobType]: number } = {
   'videos-views': 1,
   'activitypub-refresher': 1,
   'video-redundancy': 1,
-  'video-live-ending': 1
+  'video-live-ending': 1,
+  'video-process': 1
 }
 // Excluded keys are jobs that can be configured by admins
 const JOB_CONCURRENCY: { [id in Exclude<JobType, 'video-transcoding' | 'video-import'>]: number } = {
@@ -162,7 +163,8 @@ const JOB_CONCURRENCY: { [id in Exclude<JobType, 'video-transcoding' | 'video-im
   'videos-views': 1,
   'activitypub-refresher': 1,
   'video-redundancy': 1,
-  'video-live-ending': 10
+  'video-live-ending': 10,
+  'video-process': 1
 }
 const JOB_TTL: { [id in JobType]: number } = {
   'activitypub-http-broadcast': 60000 * 10, // 10 minutes
@@ -178,7 +180,8 @@ const JOB_TTL: { [id in JobType]: number } = {
   'videos-views': undefined, // Unlimited
   'activitypub-refresher': 60000 * 10, // 10 minutes
   'video-redundancy': 1000 * 3600 * 3, // 3 hours
-  'video-live-ending': 1000 * 60 * 10 // 10 minutes
+  'video-live-ending': 1000 * 60 * 10, // 10 minutes
+  'video-process': 1000 * 3600 // 1 hour
 }
 const REPEAT_JOBS: { [ id: string ]: EveryRepeatOptions | CronRepeatOptions } = {
   'videos-views': {
@@ -412,7 +415,8 @@ const VIDEO_STATES: { [ id in VideoState ]: string } = {
   [VideoState.TO_TRANSCODE]: 'To transcode',
   [VideoState.TO_IMPORT]: 'To import',
   [VideoState.WAITING_FOR_LIVE]: 'Waiting for livestream',
-  [VideoState.LIVE_ENDED]: 'Livestream ended'
+  [VideoState.LIVE_ENDED]: 'Livestream ended',
+  [VideoState.TO_PROCESS]: 'To process'
 }
 
 const VIDEO_IMPORT_STATES: { [ id in VideoImportState ]: string } = {

--- a/server/lib/job-queue/handlers/video-file-process.ts
+++ b/server/lib/job-queue/handlers/video-file-process.ts
@@ -1,0 +1,170 @@
+import { retryTransactionWrapper } from '@server/helpers/database-utils'
+import { getDurationFromVideoFile, getMetadataFromFile, getVideoFileFPS, getVideoFileResolution } from '@server/helpers/ffprobe-utils'
+import { logger } from '@server/helpers/logger'
+import { createTorrentAndSetInfoHash } from '@server/helpers/webtorrent'
+import { CONFIG } from '@server/initializers/config'
+import { DEFAULT_AUDIO_RESOLUTION } from '@server/initializers/constants'
+import { sequelizeTypescript } from '@server/initializers/database'
+import { getLocalVideoActivityPubUrl } from '@server/lib/activitypub/url'
+import { federateVideoIfNeeded } from '@server/lib/activitypub/videos'
+import { Notifier } from '@server/lib/notifier'
+import { Hooks } from '@server/lib/plugins/hooks'
+import { generateVideoMiniature } from '@server/lib/thumbnail'
+import { addOptimizeOrMergeAudioJob, buildVideoThumbnailsFromReq } from '@server/lib/video'
+import { autoBlacklistVideoIfNeeded } from '@server/lib/video-blacklist'
+import { generateVideoFilename, getVideoFilePath } from '@server/lib/video-paths'
+import { VideoModel } from '@server/models/video/video'
+import { VideoFileModel } from '@server/models/video/video-file'
+import { MUserAccountUrl, MVideo, MVideoFile, MVideoFullLight } from '@server/types/models'
+import { getLowercaseExtension } from '@server/helpers/core-utils'
+import { VideoState } from '@shared/models'
+import * as Bull from 'bull'
+import { move } from 'fs-extra'
+import express = require('express')
+import { UserModel } from '@server/models/user/user'
+import { VideoProcessPayload } from '@shared/models/server/job.model'
+
+async function processVideoProcess (job: Bull.Job) {
+  const { videoPhysicalFile, previewFilePath, videoId, userId } = job.data as VideoProcessPayload
+  const user: MUserAccountUrl = await UserModel.loadForMeAPI(userId)
+  const video = await VideoModel.loadAndPopulateAccountAndServerAndTags(videoId)
+
+  const videoFile = await moveVideoFile({
+    video,
+    videoPhysicalFile
+  })
+
+  video.duration = await getDurationFromVideoFile(videoPhysicalFile.path)
+
+  await handleVideoFile({
+    previewFilePath,
+    videoFile,
+    video,
+    user
+  })
+}
+
+export {
+  processVideoProcess
+}
+
+async function moveVideoFile ({
+  video,
+  videoPhysicalFile
+}) {
+  const videoFile = await buildNewFile(video, videoPhysicalFile)
+
+  const destination = getVideoFilePath(video, videoFile)
+  await move(videoPhysicalFile.path, destination)
+
+  return videoFile
+}
+
+async function buildNewFile (video: MVideo, videoPhysicalFile: express.VideoUploadFile) {
+  const videoFile = new VideoFileModel({
+    extname: getLowercaseExtension(videoPhysicalFile.filename),
+    size: videoPhysicalFile.size,
+    videoStreamingPlaylistId: null,
+    metadata: await getMetadataFromFile(videoPhysicalFile.path)
+  })
+
+  if (videoFile.isAudio()) {
+    videoFile.resolution = DEFAULT_AUDIO_RESOLUTION
+  } else {
+    videoFile.fps = await getVideoFileFPS(videoPhysicalFile.path)
+    videoFile.resolution = (await getVideoFileResolution(videoPhysicalFile.path)).videoFileResolution
+  }
+
+  videoFile.filename = generateVideoFilename(video, false, videoFile.resolution, videoFile.extname)
+
+  return videoFile
+}
+
+async function handleVideoFile ({
+  previewFilePath,
+  videoFile,
+  video,
+  user
+}) {
+  const files = previewFilePath
+    ? {
+      previewfile: [
+        {
+          path: previewFilePath
+        }
+      ]
+    }
+    : {}
+  const [ thumbnailModel, previewModel ] = await buildVideoThumbnailsFromReq({
+    video,
+    files,
+    fallback: type => generateVideoMiniature({ video, videoFile, type })
+  })
+
+  await sequelizeTypescript.transaction(async t => {
+    const sequelizeOptions = { transaction: t }
+    await video.addAndSaveThumbnail(thumbnailModel, t)
+    await video.addAndSaveThumbnail(previewModel, t)
+    video.url = getLocalVideoActivityPubUrl(video) // We use the UUID, so set the URL after building the object
+
+    video.state = CONFIG.TRANSCODING.ENABLED
+      ? VideoState.TO_TRANSCODE
+      : VideoState.PUBLISHED
+
+    videoFile.videoId = video.id
+    await videoFile.save(sequelizeOptions)
+
+    video.VideoFiles = [ videoFile ]
+
+    // Channel has a new content, set as updated
+    await video.VideoChannel.setAsUpdated(t)
+
+    await autoBlacklistVideoIfNeeded({
+      video,
+      user,
+      isRemote: false,
+      isNew: true,
+      transaction: t
+    })
+  })
+
+  createTorrentFederate(video, videoFile)
+
+  if (video.state === VideoState.TO_TRANSCODE) {
+    await addOptimizeOrMergeAudioJob(video, videoFile, user)
+  }
+
+  Hooks.runAction('action:api.video.uploaded', { video: video })
+}
+
+function createTorrentFederate (video: MVideoFullLight, videoFile: MVideoFile): void {
+  // Create the torrent file in async way because it could be long
+  createTorrentAndSetInfoHashAsync(video, videoFile)
+    .catch(err => logger.error('Cannot create torrent file for video %s', video.url, { err }))
+    .then(() => VideoModel.loadAndPopulateAccountAndServerAndTags(video.id))
+    .then(refreshedVideo => {
+      if (!refreshedVideo) return
+
+      // Only federate and notify after the torrent creation
+      Notifier.Instance.notifyOnNewVideoIfNeeded(refreshedVideo)
+
+      return retryTransactionWrapper(() => {
+        return sequelizeTypescript.transaction(t => federateVideoIfNeeded(refreshedVideo, true, t))
+      })
+    })
+    .catch(err => logger.error('Cannot federate or notify video creation %s', video.url, { err }))
+}
+
+async function createTorrentAndSetInfoHashAsync (video: MVideo, fileArg: MVideoFile) {
+  await createTorrentAndSetInfoHash(video, fileArg)
+
+  // Refresh videoFile because the createTorrentAndSetInfoHash could be long
+  const refreshedFile = await VideoFileModel.loadWithVideo(fileArg.id)
+  // File does not exist anymore, remove the generated torrent
+  if (!refreshedFile) return fileArg.removeTorrent()
+
+  refreshedFile.infoHash = fileArg.infoHash
+  refreshedFile.torrentFilename = fileArg.torrentFilename
+
+  return refreshedFile.save()
+}

--- a/server/lib/job-queue/job-queue.ts
+++ b/server/lib/job-queue/job-queue.ts
@@ -34,6 +34,8 @@ import { processVideoImport } from './handlers/video-import'
 import { processVideoLiveEnding } from './handlers/video-live-ending'
 import { processVideoTranscoding } from './handlers/video-transcoding'
 import { processVideosViews } from './handlers/video-views'
+import { processVideoProcess } from './handlers/video-file-process'
+import { VideoProcessPayload } from '../../../shared/models/server/job.model'
 
 type CreateJobArgument =
   { type: 'activitypub-http-broadcast', payload: ActivitypubHttpBroadcastPayload } |
@@ -45,6 +47,7 @@ type CreateJobArgument =
   { type: 'video-transcoding', payload: VideoTranscodingPayload } |
   { type: 'email', payload: EmailPayload } |
   { type: 'video-import', payload: VideoImportPayload } |
+  { type: 'video-process', payload: VideoProcessPayload } |
   { type: 'activitypub-refresher', payload: RefreshPayload } |
   { type: 'videos-views', payload: {} } |
   { type: 'video-live-ending', payload: VideoLiveEndingPayload } |
@@ -62,6 +65,7 @@ const handlers: { [id in JobType]: (job: Bull.Job) => Promise<any> } = {
   'activitypub-http-fetcher': processActivityPubHttpFetcher,
   'activitypub-cleaner': processActivityPubCleaner,
   'activitypub-follow': processActivityPubFollow,
+  'video-process': processVideoProcess,
   'video-file-import': processVideoFileImport,
   'video-transcoding': processVideoTranscoding,
   'email': processEmail,
@@ -83,6 +87,7 @@ const jobTypes: JobType[] = [
   'video-transcoding',
   'video-file-import',
   'video-import',
+  'video-process',
   'videos-views',
   'activitypub-refresher',
   'video-redundancy',

--- a/server/lib/video.ts
+++ b/server/lib/video.ts
@@ -1,4 +1,3 @@
-import { UploadFiles } from 'express'
 import { Transaction } from 'sequelize/types'
 import { DEFAULT_AUDIO_RESOLUTION, JOB_PRIORITY } from '@server/initializers/constants'
 import { sequelizeTypescript } from '@server/initializers/database'
@@ -35,7 +34,11 @@ function buildLocalVideoFromReq (videoInfo: VideoCreate, channelId: number): Fil
 
 async function buildVideoThumbnailsFromReq (options: {
   video: MVideoThumbnail
-  files: UploadFiles
+  files: {
+    [fieldname: string]: {
+      path: string
+    }[]
+  }
   fallback: (type: ThumbnailType) => Promise<MThumbnail>
   automaticallyGenerated?: boolean
 }) {
@@ -52,6 +55,7 @@ async function buildVideoThumbnailsFromReq (options: {
     }
   ].map(p => {
     const fields = files?.[p.fieldName]
+    console.log(files, fields)
 
     if (fields) {
       return updateVideoMiniatureFromExisting({

--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -601,6 +601,7 @@ export async function isVideoAccepted (
   return true
 }
 
+// Remove!!!!
 async function addDurationToVideo (videoFile: { path: string, duration?: number }) {
   const duration: number = await getDurationFromVideoFile(videoFile.path)
 

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -40,7 +40,6 @@ import { ThumbnailType } from '../../../shared/models/videos/thumbnail.type'
 import { VideoFilter } from '../../../shared/models/videos/video-query.type'
 import { VideoStreamingPlaylistType } from '../../../shared/models/videos/video-streaming-playlist.type'
 import { peertubeTruncate } from '../../helpers/core-utils'
-import { isActivityPubUrlValid } from '../../helpers/custom-validators/activitypub/misc'
 import { isBooleanValid } from '../../helpers/custom-validators/misc'
 import {
   isVideoDescriptionValid,
@@ -525,8 +524,8 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
   @Column
   isLive: boolean
 
-  @AllowNull(false)
-  @Is('VideoUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'url'))
+  @AllowNull(true)
+  // @Is('VideoUrl', value => throwIfNotValid(value, isActivityPubUrlValid, 'url'))
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.URL.max))
   url: string
 

--- a/server/typings/express/index.d.ts
+++ b/server/typings/express/index.d.ts
@@ -105,6 +105,9 @@ declare module 'express' {
       videoAll?: MVideoFullLight
       onlyImmutableVideo?: MVideoImmutable
       onlyVideo?: MVideoThumbnail
+
+      video?: MVideoFullLight
+
       videoId?: MVideoId
 
       videoLive?: MVideoLive

--- a/shared/models/server/job.model.ts
+++ b/shared/models/server/job.model.ts
@@ -1,6 +1,7 @@
 import { ContextType } from '../activitypub/context'
 import { VideoResolution } from '../videos/video-resolution.enum'
 import { SendEmailOptions } from './emailer.model'
+import express = require('express')
 
 export type JobState = 'active' | 'completed' | 'failed' | 'waiting' | 'delayed' | 'paused'
 
@@ -14,6 +15,7 @@ export type JobType =
   | 'video-transcoding'
   | 'email'
   | 'video-import'
+  | 'video-process'
   | 'videos-views'
   | 'activitypub-refresher'
   | 'video-redundancy'
@@ -88,6 +90,14 @@ export type VideoImportTorrentPayload = {
   videoImportId: number
 }
 export type VideoImportPayload = VideoImportYoutubeDLPayload | VideoImportTorrentPayload
+
+export type VideoProcessPayload = {
+  previewFilePath: string
+  videoFilePath: string
+  videoId: number
+  videoPhysicalFile: express.VideoUploadFile
+  userId: number
+}
 
 export type VideoRedundancyPayload = {
   videoId: number

--- a/shared/models/videos/video-state.enum.ts
+++ b/shared/models/videos/video-state.enum.ts
@@ -3,5 +3,6 @@ export const enum VideoState {
   TO_TRANSCODE = 2,
   TO_IMPORT = 3,
   WAITING_FOR_LIVE = 4,
-  LIVE_ENDED = 5
+  LIVE_ENDED = 5,
+  TO_PROCESS = 6
 }


### PR DESCRIPTION
## Description
This is a proposal that shows how heavy tasks during file upload is handled in a job instead of during the HTTP request. This will make PeerTube scale better when an instance grows big and a lot of file uploads are done simultaneously. It will also create a better user experience since the user can leave the video creation before all the video process are done, which is not the case today. And it will also solve issues when using S3 video storage where it can take 10 minutes for a file move to S3 to finish.

@Chocobozzz Should I go further with this? Do you have any preferences regarding how it should be handled?

## Related issues
#4147 
#3661 

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->