### PR TITLE
Standard output type syslog is obsolete in systemd

### DIFF
--- a/support/systemd/peertube.service
+++ b/support/systemd/peertube.service
@@ -10,8 +10,6 @@ User=peertube
 Group=peertube
 ExecStart=/usr/bin/node dist/server
 WorkingDirectory=/var/www/peertube/peertube-latest
-StandardOutput=syslog
-StandardError=syslog
 SyslogIdentifier=peertube
 Restart=always
 


### PR DESCRIPTION


## Description

removing the setting
StandardOutput
StandardError

## Related issues
Standard output type syslog is obsolete in systemd

## Has this been tested?
no, because this PR does not update server code