### PR TITLE
Allow configuration to be static/readonly

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -63,7 +63,7 @@
     <div class="col-md-7 col-xl-5"></div>
     <div class="col-md-5 col-xl-5">
 
-      <div class="form-error submit-error" i18n *ngIf="!form.valid">
+      <div class="form-error submit-error" i18n *ngIf="!form.valid && serverConfig.allowEdits">
         There are errors in the form:
 
         <ul>
@@ -77,7 +77,11 @@
         You cannot allow live replay if you don't enable transcoding.
       </span>
 
-      <input (click)="formValidated()" type="submit" i18n-value value="Update configuration" [disabled]="!form.valid || !hasConsistentOptions()">
+      <span i18n *ngIf="!serverConfig.allowEdits">
+        You cannot change the server configuration because it's managed externally.
+      </span>
+
+      <input (click)="formValidated()" type="submit" i18n-value value="Update configuration" [disabled]="!form.valid || !hasConsistentOptions() || !serverConfig.allowEdits">
     </div>
   </div>
 </form>

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
@@ -258,6 +258,9 @@ export class EditCustomConfigComponent extends FormReactive implements OnInit {
 
     this.loadConfigAndUpdateForm()
     this.loadCategoriesAndLanguages()
+    if (!this.serverConfig.allowEdits) {
+      this.form.disable()
+    }
   }
 
   async formValidated () {

--- a/client/src/app/shared/shared-forms/markdown-textarea.component.html
+++ b/client/src/app/shared/shared-forms/markdown-textarea.component.html
@@ -2,6 +2,7 @@
   <textarea #textarea
     [(ngModel)]="content" (ngModelChange)="onModelChange()"
     class="form-control" [ngClass]="classes"
+    [attr.disabled]="disabled"
     [ngStyle]="{ height: textareaHeight }"
     [id]="name" [name]="name">
   </textarea>
@@ -25,11 +26,11 @@
     </ng-container>
 
     <my-button
-      *ngIf="!isMaximized" [title]="maximizeInText" className="maximize-button" icon="fullscreen" (click)="onMaximizeClick()"
+      *ngIf="!isMaximized" [title]="maximizeInText" className="maximize-button" icon="fullscreen" (click)="onMaximizeClick()" [disabled]="disabled"
     ></my-button>
 
     <my-button
-      *ngIf="isMaximized" [title]="maximizeOutText" className="maximize-button" icon="exit-fullscreen" (click)="onMaximizeClick()"
+      *ngIf="isMaximized" [title]="maximizeOutText" className="maximize-button" icon="exit-fullscreen" (click)="onMaximizeClick()" [disabled]="disabled"
     ></my-button>
   </div>
 

--- a/client/src/app/shared/shared-forms/markdown-textarea.component.ts
+++ b/client/src/app/shared/shared-forms/markdown-textarea.component.ts
@@ -45,6 +45,7 @@ export class MarkdownTextareaComponent implements ControlValueAccessor, OnInit {
   previewHTML: SafeHtml | string = ''
 
   isMaximized = false
+  disabled = false
 
   maximizeInText = $localize`Maximize editor`
   maximizeOutText = $localize`Exit maximized editor`
@@ -106,6 +107,10 @@ export class MarkdownTextareaComponent implements ControlValueAccessor, OnInit {
     } else {
       this.lockBodyScroll()
     }
+  }
+
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled
   }
 
   private lockBodyScroll () {

--- a/client/src/app/shared/shared-forms/select/select-checkbox.component.html
+++ b/client/src/app/shared/shared-forms/select/select-checkbox.component.html
@@ -7,6 +7,7 @@
   [multiple]="true"
   [searchable]="true"
   [closeOnSelect]="false"
+  [disabled]="disabled"
 
   bindValue="id"
   bindLabel="label"

--- a/client/src/app/shared/shared-forms/select/select-checkbox.component.ts
+++ b/client/src/app/shared/shared-forms/select/select-checkbox.component.ts
@@ -24,6 +24,8 @@ export class SelectCheckboxComponent implements OnInit, ControlValueAccessor {
   @Input() maxSelectedItems: number
   @Input() placeholder: string
 
+  disabled = false
+
   ngOnInit () {
     if (!this.placeholder) this.placeholder = $localize`Add a new option`
   }
@@ -60,6 +62,10 @@ export class SelectCheckboxComponent implements OnInit, ControlValueAccessor {
 
   onModelChange () {
     this.propagateChange(this.selectedItems)
+  }
+
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled
   }
 
   compareFn (item: SelectOptionsItem, selected: ItemSelectCheckboxValue) {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,5 +1,7 @@
 # /!\ YOU SHOULD NOT UPDATE THIS FILE, USE production.yaml instead /!\ #
 
+allow_webadmin_config: true
+
 listen:
   hostname: '127.0.0.1'
   port: 9000

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -11,7 +11,7 @@ import { objectConverter } from '../../helpers/core-utils'
 import { CONFIG, reloadConfig } from '../../initializers/config'
 import { ClientHtml } from '../../lib/client-html'
 import { asyncMiddleware, authenticate, ensureUserHasRight, openapiOperationDoc } from '../../middlewares'
-import { customConfigUpdateValidator } from '../../middlewares/validators/config'
+import { customConfigUpdateValidator, ensureConfigIsEditable } from '../../middlewares/validators/config'
 
 const configRouter = express.Router()
 
@@ -38,6 +38,7 @@ configRouter.put('/custom',
   openapiOperationDoc({ operationId: 'putCustomConfig' }),
   authenticate,
   ensureUserHasRight(UserRight.MANAGE_CONFIGURATION),
+  ensureConfigIsEditable,
   customConfigUpdateValidator,
   asyncMiddleware(updateCustomConfig)
 )
@@ -46,6 +47,7 @@ configRouter.delete('/custom',
   openapiOperationDoc({ operationId: 'delCustomConfig' }),
   authenticate,
   ensureUserHasRight(UserRight.MANAGE_CONFIGURATION),
+  ensureConfigIsEditable,
   asyncMiddleware(deleteCustomConfig)
 )
 

--- a/server/lib/server-config-manager.ts
+++ b/server/lib/server-config-manager.ts
@@ -42,6 +42,7 @@ class ServerConfigManager {
     const defaultTheme = getThemeOrDefault(CONFIG.THEME.DEFAULT, DEFAULT_THEME_NAME)
 
     return {
+      allowEdits: CONFIG.ALLOW_WEBADMIN_CONFIG,
       instance: {
         name: CONFIG.INSTANCE.NAME,
         shortDescription: CONFIG.INSTANCE.SHORT_DESCRIPTION,

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -201,6 +201,199 @@ function checkUpdatedConfig (data: CustomConfig) {
   expect(data.broadcastMessage.dismissable).to.be.true
 }
 
+const newCustomConfig: CustomConfig = {
+  instance: {
+    name: 'PeerTube updated',
+    shortDescription: 'my short description',
+    description: 'my super description',
+    terms: 'my super terms',
+    codeOfConduct: 'my super coc',
+
+    creationReason: 'my super creation reason',
+    moderationInformation: 'my super moderation information',
+    administrator: 'Kuja',
+    maintenanceLifetime: 'forever',
+    businessModel: 'my super business model',
+    hardwareInformation: '2vCore 3GB RAM',
+
+    languages: [ 'en', 'es' ],
+    categories: [ 1, 2 ],
+
+    isNSFW: true,
+    defaultNSFWPolicy: 'blur' as 'blur',
+
+    defaultClientRoute: '/videos/recently-added',
+
+    customizations: {
+      javascript: 'alert("coucou")',
+      css: 'body { background-color: red; }'
+    }
+  },
+  theme: {
+    default: 'default'
+  },
+  services: {
+    twitter: {
+      username: '@Kuja',
+      whitelisted: true
+    }
+  },
+  cache: {
+    previews: {
+      size: 2
+    },
+    captions: {
+      size: 3
+    },
+    torrents: {
+      size: 4
+    }
+  },
+  signup: {
+    enabled: false,
+    limit: 5,
+    requiresEmailVerification: false,
+    minimumAge: 10
+  },
+  admin: {
+    email: 'superadmin1@example.com'
+  },
+  contactForm: {
+    enabled: false
+  },
+  user: {
+    videoQuota: 5242881,
+    videoQuotaDaily: 318742
+  },
+  transcoding: {
+    enabled: true,
+    allowAdditionalExtensions: true,
+    allowAudioFiles: true,
+    threads: 1,
+    concurrency: 3,
+    profile: 'vod_profile',
+    resolutions: {
+      '0p': false,
+      '240p': false,
+      '360p': true,
+      '480p': true,
+      '720p': false,
+      '1080p': false,
+      '1440p': false,
+      '2160p': false
+    },
+    webtorrent: {
+      enabled: true
+    },
+    hls: {
+      enabled: false
+    }
+  },
+  live: {
+    enabled: true,
+    allowReplay: true,
+    maxDuration: 5000,
+    maxInstanceLives: -1,
+    maxUserLives: 10,
+    transcoding: {
+      enabled: true,
+      threads: 4,
+      profile: 'live_profile',
+      resolutions: {
+        '240p': true,
+        '360p': true,
+        '480p': true,
+        '720p': true,
+        '1080p': true,
+        '1440p': true,
+        '2160p': true
+      }
+    }
+  },
+  import: {
+    videos: {
+      concurrency: 4,
+      http: {
+        enabled: false
+      },
+      torrent: {
+        enabled: false
+      }
+    }
+  },
+  trending: {
+    videos: {
+      algorithms: {
+        enabled: [ 'best', 'hot', 'most-viewed', 'most-liked' ],
+        default: 'hot'
+      }
+    }
+  },
+  autoBlacklist: {
+    videos: {
+      ofUsers: {
+        enabled: true
+      }
+    }
+  },
+  followers: {
+    instance: {
+      enabled: false,
+      manualApproval: true
+    }
+  },
+  followings: {
+    instance: {
+      autoFollowBack: {
+        enabled: true
+      },
+      autoFollowIndex: {
+        enabled: true,
+        indexUrl: 'https://updated.example.com'
+      }
+    }
+  },
+  broadcastMessage: {
+    enabled: true,
+    level: 'error',
+    message: 'super bad message',
+    dismissable: true
+  },
+  search: {
+    remoteUri: {
+      anonymous: true,
+      users: true
+    },
+    searchIndex: {
+      enabled: true,
+      url: 'https://search.joinpeertube.org',
+      disableLocalSearch: true,
+      isDefaultSearch: true
+    }
+  }
+}
+
+describe('Test static config', function () {
+  let server: PeerTubeServer = null
+
+  before(async function () {
+    this.timeout(30000)
+
+    server = await createSingleServer(1, { allow_webadmin_config: false })
+    await setAccessTokensToServers([ server ])
+  })
+
+  it('Should tell the client that edits are not allowed', async function () {
+    const data = await server.config.getConfig()
+
+    expect(data.allowEdits).to.be.false
+  })
+
+  it('Should error when client tries to update', async function () {
+    await server.config.updateCustomConfig({ newCustomConfig, expectedStatus: 405 })
+  })
+})
+
 describe('Test config', function () {
   let server: PeerTubeServer = null
 
@@ -252,177 +445,6 @@ describe('Test config', function () {
   })
 
   it('Should update the customized configuration', async function () {
-    const newCustomConfig: CustomConfig = {
-      instance: {
-        name: 'PeerTube updated',
-        shortDescription: 'my short description',
-        description: 'my super description',
-        terms: 'my super terms',
-        codeOfConduct: 'my super coc',
-
-        creationReason: 'my super creation reason',
-        moderationInformation: 'my super moderation information',
-        administrator: 'Kuja',
-        maintenanceLifetime: 'forever',
-        businessModel: 'my super business model',
-        hardwareInformation: '2vCore 3GB RAM',
-
-        languages: [ 'en', 'es' ],
-        categories: [ 1, 2 ],
-
-        isNSFW: true,
-        defaultNSFWPolicy: 'blur' as 'blur',
-
-        defaultClientRoute: '/videos/recently-added',
-
-        customizations: {
-          javascript: 'alert("coucou")',
-          css: 'body { background-color: red; }'
-        }
-      },
-      theme: {
-        default: 'default'
-      },
-      services: {
-        twitter: {
-          username: '@Kuja',
-          whitelisted: true
-        }
-      },
-      cache: {
-        previews: {
-          size: 2
-        },
-        captions: {
-          size: 3
-        },
-        torrents: {
-          size: 4
-        }
-      },
-      signup: {
-        enabled: false,
-        limit: 5,
-        requiresEmailVerification: false,
-        minimumAge: 10
-      },
-      admin: {
-        email: 'superadmin1@example.com'
-      },
-      contactForm: {
-        enabled: false
-      },
-      user: {
-        videoQuota: 5242881,
-        videoQuotaDaily: 318742
-      },
-      transcoding: {
-        enabled: true,
-        allowAdditionalExtensions: true,
-        allowAudioFiles: true,
-        threads: 1,
-        concurrency: 3,
-        profile: 'vod_profile',
-        resolutions: {
-          '0p': false,
-          '240p': false,
-          '360p': true,
-          '480p': true,
-          '720p': false,
-          '1080p': false,
-          '1440p': false,
-          '2160p': false
-        },
-        webtorrent: {
-          enabled: true
-        },
-        hls: {
-          enabled: false
-        }
-      },
-      live: {
-        enabled: true,
-        allowReplay: true,
-        maxDuration: 5000,
-        maxInstanceLives: -1,
-        maxUserLives: 10,
-        transcoding: {
-          enabled: true,
-          threads: 4,
-          profile: 'live_profile',
-          resolutions: {
-            '240p': true,
-            '360p': true,
-            '480p': true,
-            '720p': true,
-            '1080p': true,
-            '1440p': true,
-            '2160p': true
-          }
-        }
-      },
-      import: {
-        videos: {
-          concurrency: 4,
-          http: {
-            enabled: false
-          },
-          torrent: {
-            enabled: false
-          }
-        }
-      },
-      trending: {
-        videos: {
-          algorithms: {
-            enabled: [ 'best', 'hot', 'most-viewed', 'most-liked' ],
-            default: 'hot'
-          }
-        }
-      },
-      autoBlacklist: {
-        videos: {
-          ofUsers: {
-            enabled: true
-          }
-        }
-      },
-      followers: {
-        instance: {
-          enabled: false,
-          manualApproval: true
-        }
-      },
-      followings: {
-        instance: {
-          autoFollowBack: {
-            enabled: true
-          },
-          autoFollowIndex: {
-            enabled: true,
-            indexUrl: 'https://updated.example.com'
-          }
-        }
-      },
-      broadcastMessage: {
-        enabled: true,
-        level: 'error',
-        message: 'super bad message',
-        dismissable: true
-      },
-      search: {
-        remoteUri: {
-          anonymous: true,
-          users: true
-        },
-        searchIndex: {
-          enabled: true,
-          url: 'https://search.joinpeertube.org',
-          disableLocalSearch: true,
-          isDefaultSearch: true
-        }
-      }
-    }
     await server.config.updateCustomConfig({ newCustomConfig })
 
     const data = await server.config.getCustomConfig()

--- a/shared/models/server/server-config.model.ts
+++ b/shared/models/server/server-config.model.ts
@@ -30,6 +30,7 @@ export interface RegisteredIdAndPassAuthConfig {
 }
 
 export interface ServerConfig {
+  allowEdits: boolean
   serverVersion: string
   serverCommit?: string
 

--- a/support/docker/production/Dockerfile.buster
+++ b/support/docker/production/Dockerfile.buster
@@ -33,7 +33,8 @@ RUN mkdir /data /config
 RUN chown -R peertube:peertube /data /config
 
 ENV NODE_ENV production
-ENV NODE_CONFIG_DIR /config
+ENV NODE_CONFIG_DIR /app/config:/app/support/docker/production/config:/config
+ENV PEERTUBE_LOCAL_CONFIG /config
 
 VOLUME /data
 VOLUME /config

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -1,3 +1,7 @@
+allow_webadmin_config: 
+  __name: "PEERTUBE_ALLOW_WEBADMIN_CONFIG"
+  __format: "json"
+
 webserver:
   hostname: "PEERTUBE_WEBSERVER_HOSTNAME"
   port:

--- a/support/docker/production/entrypoint.sh
+++ b/support/docker/production/entrypoint.sh
@@ -1,15 +1,8 @@
 #!/bin/sh
 set -e
 
-# Populate config directory
-if [ -z "$(ls -A /config)" ]; then
-    cp /app/support/docker/production/config/* /config
-fi
 
-# Always copy default and custom env configuration file, in cases where new keys were added
-cp /app/config/default.yaml /config
-cp /app/support/docker/production/config/custom-environment-variables.yaml /config
-find /config ! -user peertube -exec chown peertube:peertube {} \;
+find /config ! -user peertube -exec chown peertube:peertube {} \; || true
 
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`


### PR DESCRIPTION
## Description

Adds support for multiple configuration directories and adds multiple configuration directories in the Dockerfile to support the same default.yaml functionality as before. Also adds the `PEERTUBE_ALLOW_WEBADMIN_CONFIG` environment variable to `custom-environment-variables.yaml` so it can be easily set via Docker. This configuration option disables the admin view to change the configuration and makes it read only (see screenshot below).

This functionality is useful for people who do all configuration statically and mount it at /config in the container. This folder is now only used for user configuration because the files that were previously copied there now stay in the app directories.

## Related issues

Fixes #3754

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

![image](https://user-images.githubusercontent.com/1576660/128603508-b12239dd-c4ba-4cc3-8673-7eecbf2a606d.png)