### PR TITLE
Alert user for low quota and video auto-block on upload page

### DIFF
--- a/client/src/app/+about/about-instance/about-instance.component.html
+++ b/client/src/app/+about/about-instance/about-instance.component.html
@@ -4,7 +4,7 @@
     <div class="about-instance-title">
       <h1 i18n class="title">About {{ instanceName }}</h1>
 
-      <a routerLink="/about/contact" i18n *ngIf="isContactFormEnabled" class="contact-admin">Contact administrator</a>
+      <a routerLink="/about/contact" i18n *ngIf="isContactFormEnabled" class="contact-admin">Contact us</a>
     </div>
 
     <div class="instance-badges" *ngIf="categories.length !== 0 || languages.length !== 0">

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.html
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.html
@@ -1,6 +1,6 @@
 <ng-template #modal>
   <div class="modal-header">
-    <h1 i18n class="modal-title">Contact instance administrators</h1>
+    <h1 i18n class="modal-title">Contact the administrator(s)<p class="modal-subtitle">{{ instanceName }}</p></h1>
     <my-global-icon iconName="cross" aria-label="Close" tabindex="0" role="button" (click)="hide()" (keydown.enter)="hide()"></my-global-icon>
   </div>
 

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.html
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.html
@@ -1,6 +1,6 @@
 <ng-template #modal>
   <div class="modal-header">
-    <h1 i18n class="modal-title">Contact {{ instanceName }} administrator</h1>
+    <h1 i18n class="modal-title">Contact instance administrators</h1>
     <my-global-icon iconName="cross" aria-label="Close" tabindex="0" role="button" (click)="hide()" (keydown.enter)="hide()"></my-global-icon>
   </div>
 

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.scss
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.scss
@@ -1,6 +1,12 @@
 @use '_variables' as *;
 @use '_mixins' as *;
 
+.modal-subtitle {
+  font-size: 16px;
+  line-height: 1rem;
+  margin-bottom: 0;
+}
+
 .modal-body {
   text-align: left;
 }

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.ts
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.ts
@@ -42,10 +42,6 @@ export class ContactAdminModalComponent extends FormReactive implements OnInit {
     super()
   }
 
-  get instanceName () {
-    return this.serverConfig.instance.name
-  }
-
   ngOnInit () {
     this.serverConfig = this.serverService.getHTMLConfig()
 

--- a/client/src/app/+about/about-instance/contact-admin-modal.component.ts
+++ b/client/src/app/+about/about-instance/contact-admin-modal.component.ts
@@ -42,6 +42,10 @@ export class ContactAdminModalComponent extends FormReactive implements OnInit {
     super()
   }
 
+  get instanceName () {
+    return this.serverConfig.instance.name
+  }
+
   ngOnInit () {
     this.serverConfig = this.serverService.getHTMLConfig()
 

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,10 +1,18 @@
-<div *ngIf="user.isUploadDisabled()" class="no-upload">
+<div *ngIf="user.isUploadDisabled()" class="upload-messages upload-disabled">
   <div class="alert alert-warning">
     <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
     <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
     <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
   </div>
   <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
+</div>
+
+<div *ngIf="!user.isUploadDisabled() && user.isAutoBlocked()" class="upload-messages auto-blocked">
+  <div class="alert alert-warning">
+    <div i18n>Uploaded videos are reviewed before publishing for your account. If you want to add videos without moderation review, an admin must turn off your videos auto-block.</div>
+    <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
+    <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
+  </div>
 </div>
 
 <div *ngIf="!user.isUploadDisabled()" class="margin-content">

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,26 +1,28 @@
-<ng-template [ngIf]="user.isUploadDisabled()">
+<ng-template #AlertButtons>
+  <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
+  <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
+</ng-template>
+
+<ng-container *ngIf="user.isUploadDisabled()">
   <div class="upload-message upload-disabled alert alert-warning">
     <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
-    <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
-    <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
+    <ng-template [ngTemplateOutlet]="AlertButtons"></ng-template>
   </div>
 
   <div class="upload-image">
     <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
   </div>
-</ng-template>
+</ng-container>
 
-<ng-template [ngIf]="!user.isUploadDisabled()">
+<ng-container *ngIf="!user.isUploadDisabled()">
   <div *ngIf="user.isAutoBlocked()" class="upload-message auto-blocked alert alert-warning">
     <div i18n>Uploaded videos are reviewed before publishing for your account. If you want to add videos without moderation review, an admin must turn off your videos auto-block.</div>
-    <a i18n routerLink="/about/instance" *ngIf="!user.hasNoQuotaLeft() && !isContactFormEnabled" class="about-link">Read instance rules for help</a>
-    <a i18n routerLink="/about/contact" *ngIf="!user.hasNoQuotaLeft() && isContactFormEnabled" class="contact-link">Contact us</a>
+    <ng-template [ngTemplateOutlet]="AlertButtons" *ngIf="!user.hasNoQuotaLeft()"></ng-template>
   </div>
 
   <div *ngIf="user.hasNoQuotaLeft()" class="upload-message quota-left alert alert-warning">
     <div i18n>If you want to add more videos, an admin must increase your quota.</div>
-    <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
-    <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
+    <ng-template [ngTemplateOutlet]="AlertButtons"></ng-template>
   </div>
 
   <div *ngIf="isRootUser()" class="upload-message root-user alert alert-warning" i18n>
@@ -28,7 +30,7 @@
     <br />
     Instead, <a routerLink="/admin/users">create a dedicated account</a> to upload your videos.
   </div>
-</ng-template>
+</ng-container>
 
 <div *ngIf="!user.isUploadDisabled()" class="margin-content">
   <my-user-quota *ngIf="!isInSecondStep() || secondStepType === 'go-live'" [user]="user" [userInformationLoaded]="userInformationLoaded"></my-user-quota>

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,7 +1,8 @@
 <div *ngIf="user.isUploadDisabled()" class="no-upload">
   <div class="alert alert-warning">
     <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
-    <a i18n routerLink="/about/instance" class="about-link">Read instance rules for help</a>
+    <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
+    <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
   </div>
   <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
 </div>

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -5,7 +5,7 @@
 
 <ng-container *ngIf="user.isUploadDisabled()">
   <div class="upload-message upload-disabled alert alert-warning">
-    <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
+    <div>{{ uploadMessages.noQuota }}</div>
     <ng-template [ngTemplateOutlet]="AlertButtons"></ng-template>
   </div>
 
@@ -16,17 +16,17 @@
 
 <ng-container *ngIf="!user.isUploadDisabled()">
   <div *ngIf="user.isAutoBlocked()" class="upload-message auto-blocked alert alert-warning">
-    <div i18n><strong>Uploaded videos are reviewed before publishing for your account</strong>. If you want to add videos without moderation review, an admin must turn off your videos auto-block.</div>
+    <div>{{ uploadMessages.autoBlock }}</div>
     <ng-template [ngTemplateOutlet]="AlertButtons" *ngIf="!user.hasNoQuotaLeft() && !user.hasNoQuotaLeftDaily()"></ng-template>
   </div>
 
   <div *ngIf="user.hasNoQuotaLeft()" class="upload-message quota-daily-left alert alert-warning">
-    <div i18n><strong>Your daily video quota is insufficient</strong>. If you want to add more videos, you must wait for 24 hours or an admin must increase your quota.</div>
+    <div>{{ uploadMessages.quotaLeftDaily }}</div>
     <ng-template [ngTemplateOutlet]="AlertButtons" *ngIf="!user.hasNoQuotaLeft()"></ng-template>
   </div>
 
   <div *ngIf="user.hasNoQuotaLeft()" class="upload-message quota-left alert alert-warning">
-    <div i18n><strong>Your video quota is insufficient</strong>. If you want to add more videos, an admin must increase your quota.</div>
+    <div>{{ uploadMessages.quotaLeft }}</div>
     <ng-template [ngTemplateOutlet]="AlertButtons"></ng-template>
   </div>
 

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -16,12 +16,17 @@
 
 <ng-container *ngIf="!user.isUploadDisabled()">
   <div *ngIf="user.isAutoBlocked()" class="upload-message auto-blocked alert alert-warning">
-    <div i18n>Uploaded videos are reviewed before publishing for your account. If you want to add videos without moderation review, an admin must turn off your videos auto-block.</div>
+    <div i18n><strong>Uploaded videos are reviewed before publishing for your account</strong>. If you want to add videos without moderation review, an admin must turn off your videos auto-block.</div>
+    <ng-template [ngTemplateOutlet]="AlertButtons" *ngIf="!user.hasNoQuotaLeft() && !user.hasNoQuotaLeftDaily()"></ng-template>
+  </div>
+
+  <div *ngIf="user.hasNoQuotaLeft()" class="upload-message quota-daily-left alert alert-warning">
+    <div i18n><strong>Your daily video quota is insufficient</strong>. If you want to add more videos, you must wait for 24 hours or an admin must increase your quota.</div>
     <ng-template [ngTemplateOutlet]="AlertButtons" *ngIf="!user.hasNoQuotaLeft()"></ng-template>
   </div>
 
   <div *ngIf="user.hasNoQuotaLeft()" class="upload-message quota-left alert alert-warning">
-    <div i18n>If you want to add more videos, an admin must increase your quota.</div>
+    <div i18n><strong>Your video quota is insufficient</strong>. If you want to add more videos, an admin must increase your quota.</div>
     <ng-template [ngTemplateOutlet]="AlertButtons"></ng-template>
   </div>
 

--- a/client/src/app/+videos/+video-edit/video-add.component.html
+++ b/client/src/app/+videos/+video-edit/video-add.component.html
@@ -1,27 +1,36 @@
-<div *ngIf="user.isUploadDisabled()" class="upload-messages upload-disabled">
-  <div class="alert alert-warning">
+<ng-template [ngIf]="user.isUploadDisabled()">
+  <div class="upload-message upload-disabled alert alert-warning">
     <div i18n>Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.</div>
     <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
     <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
   </div>
-  <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
-</div>
 
-<div *ngIf="!user.isUploadDisabled() && user.isAutoBlocked()" class="upload-messages auto-blocked">
-  <div class="alert alert-warning">
+  <div class="upload-image">
+    <img src="/client/assets/images/mascot/defeated.svg" alt="defeated mascot">
+  </div>
+</ng-template>
+
+<ng-template [ngIf]="!user.isUploadDisabled()">
+  <div *ngIf="user.isAutoBlocked()" class="upload-message auto-blocked alert alert-warning">
     <div i18n>Uploaded videos are reviewed before publishing for your account. If you want to add videos without moderation review, an admin must turn off your videos auto-block.</div>
+    <a i18n routerLink="/about/instance" *ngIf="!user.hasNoQuotaLeft() && !isContactFormEnabled" class="about-link">Read instance rules for help</a>
+    <a i18n routerLink="/about/contact" *ngIf="!user.hasNoQuotaLeft() && isContactFormEnabled" class="contact-link">Contact us</a>
+  </div>
+
+  <div *ngIf="user.hasNoQuotaLeft()" class="upload-message quota-left alert alert-warning">
+    <div i18n>If you want to add more videos, an admin must increase your quota.</div>
     <a i18n routerLink="/about/instance" *ngIf="!isContactFormEnabled" class="about-link">Read instance rules for help</a>
     <a i18n routerLink="/about/contact" *ngIf="isContactFormEnabled" class="contact-link">Contact us</a>
   </div>
-</div>
 
-<div *ngIf="!user.isUploadDisabled()" class="margin-content">
-  <div class="alert alert-warning" *ngIf="isRootUser()" i18n>
+  <div *ngIf="isRootUser()" class="upload-message root-user alert alert-warning" i18n>
     We recommend you to not use the <strong>root</strong> user to publish your videos, since it's the super-admin account of your instance.
     <br />
     Instead, <a routerLink="/admin/users">create a dedicated account</a> to upload your videos.
   </div>
+</ng-template>
 
+<div *ngIf="!user.isUploadDisabled()" class="margin-content">
   <my-user-quota *ngIf="!isInSecondStep() || secondStepType === 'go-live'" [user]="user" [userInformationLoaded]="userInformationLoaded"></my-user-quota>
 
   <div class="title-page title-page-single" *ngIf="isInSecondStep()">

--- a/client/src/app/+videos/+video-edit/video-add.component.scss
+++ b/client/src/app/+videos/+video-edit/video-add.component.scss
@@ -6,7 +6,7 @@ $border-type: solid;
 $border-color: #EAEAEA;
 $nav-link-height: 40px;
 
-.no-upload {
+.upload-messages {
   height: 100%;
   width: 100%;
   text-align: center;

--- a/client/src/app/+videos/+video-edit/video-add.component.scss
+++ b/client/src/app/+videos/+video-edit/video-add.component.scss
@@ -11,7 +11,8 @@ $nav-link-height: 40px;
   width: 100%;
   text-align: center;
 
-  .about-link {
+  .about-link,
+  .contact-link {
     @include peertube-button-link;
     @include orange-button;
 

--- a/client/src/app/+videos/+video-edit/video-add.component.scss
+++ b/client/src/app/+videos/+video-edit/video-add.component.scss
@@ -6,10 +6,15 @@ $border-type: solid;
 $border-color: #EAEAEA;
 $nav-link-height: 40px;
 
-.upload-messages {
-  height: 100%;
+.upload-message {
   width: 100%;
   text-align: center;
+  font-size: 15px;
+  margin-bottom: 0;
+
+  &:last-child {
+    margin-bottom: 1rem;
+  }
 
   .about-link,
   .contact-link {
@@ -19,6 +24,11 @@ $nav-link-height: 40px;
     height: fit-content;
     margin-top: 10px;
   }
+}
+
+.upload-image {
+  width: 100%;
+  text-align: center;
 
   img {
     margin-top: 10px;
@@ -37,10 +47,6 @@ $nav-link-height: 40px;
 
 .margin-content {
   padding-top: 20px;
-}
-
-.alert {
-  font-size: 15px;
 }
 
 ::ng-deep .video-add-nav {

--- a/client/src/app/+videos/+video-edit/video-add.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add.component.ts
@@ -71,7 +71,7 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
     // eslint-disable-next-line max-len
     const autoBlock = $localize`Uploaded videos are reviewed before publishing for your account. If you want to add videos without moderation review, an admin must turn off your videos auto-block.`
     // eslint-disable-next-line max-len
-    const quotaLeftDaily = $localize`Your daily video quota is insufficient. If you want to add more videos, you must wait for 24 hours or an admin must increase your quota.`
+    const quotaLeftDaily = $localize`Your daily video quota is insufficient. If you want to add more videos, you must wait for 24 hours or an admin must increase your daily quota.`
     // eslint-disable-next-line max-len
     const quotaLeft = $localize`Your video quota is insufficient. If you want to add more videos, an admin must increase your quota.`
 

--- a/client/src/app/+videos/+video-edit/video-add.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add.component.ts
@@ -27,9 +27,9 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
   activeNav: string
 
   uploadMessages: {
-    noQuota: string,
-    autoBlock: string,
-    quotaLeftDaily: string,
+    noQuota: string
+    autoBlock: string
+    quotaLeftDaily: string
     quotaLeft: string
   }
 
@@ -66,11 +66,20 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
   }
 
   private async buildUploadMessages () {
+    // eslint-disable-next-line max-len
+    const noQuota = $localize`Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.`
+    // eslint-disable-next-line max-len
+    const autoBlock = $localize`Uploaded videos are reviewed before publishing for your account. If you want to add videos without moderation review, an admin must turn off your videos auto-block.`
+    // eslint-disable-next-line max-len
+    const quotaLeftDaily = $localize`Your daily video quota is insufficient. If you want to add more videos, you must wait for 24 hours or an admin must increase your quota.`
+    // eslint-disable-next-line max-len
+    const quotaLeft = $localize`Your video quota is insufficient. If you want to add more videos, an admin must increase your quota.`
+
     const uploadMessages = {
-      noQuota: $localize`Sorry, the upload feature is disabled for your account. If you want to add videos, an admin must unlock your quota.`,
-      autoBlock: $localize`Uploaded videos are reviewed before publishing for your account. If you want to add videos without moderation review, an admin must turn off your videos auto-block.`,
-      quotaLeftDaily: $localize`Your daily video quota is insufficient. If you want to add more videos, you must wait for 24 hours or an admin must increase your quota.`,
-      quotaLeft: $localize`Your video quota is insufficient. If you want to add more videos, an admin must increase your quota.`
+      noQuota,
+      autoBlock,
+      quotaLeftDaily,
+      quotaLeft
     }
 
     this.uploadMessages = await this.hooks.wrapObject(uploadMessages, 'common', 'filter:upload-page.alert-messages.edit.result')

--- a/client/src/app/+videos/+video-edit/video-add.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add.component.ts
@@ -35,6 +35,10 @@ export class VideoAddComponent implements OnInit, CanComponentDeactivate {
     private router: Router
   ) {}
 
+  get isContactFormEnabled () {
+    return this.serverConfig.email.enabled && this.serverConfig.contactForm.enabled
+  }
+
   get userInformationLoaded () {
     return this.auth.userInformationLoaded
   }

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -137,4 +137,15 @@ export class User implements UserServerModel {
   isAutoBlocked () {
     return this.role === UserRole.USER && this.adminFlags !== UserAdminFlag.BYPASS_VIDEO_AUTO_BLACKLIST
   }
+
+  hasNoQuotaLeft () {
+    // unlimited videoQuota
+    if (this.videoQuota === -1) return false
+
+    // no more videoQuota
+    if (!this.videoQuotaUsed) return true
+
+    // videoQuota left lower than 10%
+    return this.videoQuotaUsed > this.videoQuota * 0.9
+  }
 }

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -133,4 +133,8 @@ export class User implements UserServerModel {
   isUploadDisabled () {
     return this.videoQuota === 0 || this.videoQuotaDaily === 0
   }
+
+  isAutoBlocked () {
+    return this.role === UserRole.USER && this.adminFlags !== UserAdminFlag.BYPASS_VIDEO_AUTO_BLACKLIST
+  }
 }

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -148,4 +148,15 @@ export class User implements UserServerModel {
     // videoQuota left lower than 10%
     return this.videoQuotaUsed > this.videoQuota * 0.9
   }
+
+  hasNoQuotaLeftDaily () {
+    // unlimited videoQuotaDaily
+    if (this.videoQuotaDaily === -1) return false
+
+    // no more videoQuotaDaily
+    if (!this.videoQuotaUsedDaily) return true
+
+    // videoQuotaDaily left lower than 10%
+    return this.videoQuotaUsedDaily > this.videoQuotaDaily * 0.9
+  }
 }

--- a/server/models/user/user.ts
+++ b/server/models/user/user.ts
@@ -958,7 +958,7 @@ export class UserModel extends Model<Partial<AttributesOnly<UserModel>>> {
   }
 
   toMeFormattedJSON (this: MMyUserFormattable): MyUser {
-    const formatted = this.toFormattedJSON()
+    const formatted = this.toFormattedJSON({ withAdminFlags: true })
 
     const specialPlaylists = this.Account.VideoPlaylists
                                  .map(p => ({ id: p.id, name: p.name, type: p.type }))

--- a/server/tests/api/users/users.ts
+++ b/server/tests/api/users/users.ts
@@ -290,7 +290,7 @@ describe('Test users', function () {
         expect(user.account.description).to.be.null
       }
 
-      expect(userMe.adminFlags).to.be.undefined
+      expect(userMe.adminFlags).to.equal(UserAdminFlag.BYPASS_VIDEO_AUTO_BLACKLIST)
       expect(userGet.adminFlags).to.equal(UserAdminFlag.BYPASS_VIDEO_AUTO_BLACKLIST)
 
       expect(userMe.specialPlaylists).to.have.lengthOf(1)

--- a/shared/models/plugins/client/client-hook.model.ts
+++ b/shared/models/plugins/client/client-hook.model.ts
@@ -58,6 +58,9 @@ export const clientFilterHookObject = {
   // Filter left menu links
   'filter:left-menu.links.create.result': true,
 
+  // Filter upload page alert messages
+  'filter:upload-page.alert-messages.edit.result': true,
+
   // Filter videojs options built for PeerTube player
   'filter:internal.player.videojs.options.result': true
 }


### PR DESCRIPTION
## Description

This PR introduces:

1. Display alerts on the top of the upload page when the user has for its account
- quota left lower than 10%
- video review turned on 

2. Display `Contact us` button in alerts of upload page when contact form is enabled

3. Shorter text for the contact button of the about page:

`Contact us` instead of `Contact administrator` as it's more explicit for a call-to-action button, and an instance can be maintained by more than one admin
![image](https://user-images.githubusercontent.com/1877318/129984276-2c325ee4-6e10-4ba1-ab1c-21655ccc4f84.png)

**For the french translation I suggest «`Nous contacter`» instead of «~`Contact de l'administrateur`~**».
![image](https://user-images.githubusercontent.com/1877318/129984635-61652f47-21d6-4b06-8f89-609aacdd199a.png)


## Related issues

Fixes https://github.com/Chocobozzz/PeerTube/issues/4335 and https://github.com/Chocobozzz/PeerTube/issues/4333

## Has this been tested?

- [x] :+1: yes, I edited the test suite

## Screenshots

### Video review turned on with contact form disabled

![auto-block-classic](https://user-images.githubusercontent.com/1877318/129985087-99fadadf-b476-41cd-b6cd-03e9ca0e5c49.png)

### Video review turned on with contact form enabled

![auto-block-contact](https://user-images.githubusercontent.com/1877318/129985089-4c4fa742-ff1e-415f-ac0a-1ed6ca535a12.png)


### Quota left under 10% with contact form disabled

![quota-left-classic](https://user-images.githubusercontent.com/1877318/129985096-488e5fda-4310-4265-bb3d-e2cfcfc2d8cf.png)

### Quota left under 10% with contact form enabled

![quota-left-contact](https://user-images.githubusercontent.com/1877318/129985097-539a3b89-6053-41e6-8cc5-d3f22adcd06f.png)

### No quota with contact form disabled

![no-quota-classic](https://user-images.githubusercontent.com/1877318/129985094-ddc9be96-a6d8-48ba-81e9-19b7a8f8e8c4.png)


### No quota with contact form enabled

![no-quota-contact](https://user-images.githubusercontent.com/1877318/129985095-11f1333e-505a-494b-bd7f-eac52f9994da.png)

### Video review turned on + quota left under 10%

![both-alert-classic](https://user-images.githubusercontent.com/1877318/129985093-6b3f7eed-90bb-4f46-99eb-45595b3161fd.png)
