### PR TITLE
Add account setup message to welcome alert after signup

### DIFF
--- a/client/src/app/+signup/shared/signup-success.component.html
+++ b/client/src/app/+signup/shared/signup-success.component.html
@@ -13,4 +13,8 @@
   <p i18n>
     If you need help to use PeerTube, you can have a look at the <a href="https://docs.joinpeertube.org/use-setup-account" target="_blank" rel="noopener noreferrer">documentation</a>.
   </p>
+
+  <p i18n>
+    To help moderators and other users to know <strong>who you are</strong>, don't forget to <a routerLink="/my-account/settings">set up your account profile</a> by adding an <strong>avatar</strong> and a <strong>description</strong>.
+  </p>
 </div>


### PR DESCRIPTION
## Description

This PR follows the discussion https://github.com/Chocobozzz/PeerTube/pull/4352#issuecomment-907118886

To avoid breaking the message before clicking on the documentation link, the message is the last one.
Also, this is a `routerLink` navigation to avoid displaying the warning setup modal on the new page.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/3331

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code

## Screenshots

<!-- delete if not relevant -->
![Screenshot 2021-08-27 at 15-05-24 Register - PeerTube](https://user-images.githubusercontent.com/1877318/131132658-61d5719c-6f0f-46e6-9f15-a217db21c347.png)
