### PR TITLE
Fix broken delete buttons of admin federation lists

### DIFF
--- a/client/src/app/+admin/follows/followers-list/followers-list.component.scss
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.scss
@@ -23,8 +23,5 @@ a {
 }
 
 my-delete-button {
-  ::ng-deep .button-label {
-    @include ellipsis;
-    width: 70px;
-  }
+  max-width: 130px;
 }

--- a/client/src/app/+admin/follows/followers-list/followers-list.component.scss
+++ b/client/src/app/+admin/follows/followers-list/followers-list.component.scss
@@ -21,3 +21,10 @@ a {
     @include margin-right(10px);
   }
 }
+
+my-delete-button {
+  ::ng-deep .button-label {
+    @include ellipsis;
+    width: 70px;
+  }
+}

--- a/client/src/app/+admin/follows/following-list/following-list.component.html
+++ b/client/src/app/+admin/follows/following-list/following-list.component.html
@@ -38,7 +38,7 @@
   <ng-template pTemplate="body" let-follow>
     <tr>
       <td class="action-cell">
-        <my-delete-button label="Unfollow" i18n-label (click)="removeFollowing(follow)"></my-delete-button>
+        <my-delete-button label (click)="removeFollowing(follow)"></my-delete-button>
       </td>
       <td>
         <a [href]="follow.following.url" i18n-title title="Open instance in a new tab" target="_blank" rel="noopener noreferrer">

--- a/client/src/app/+admin/follows/following-list/following-list.component.scss
+++ b/client/src/app/+admin/follows/following-list/following-list.component.scss
@@ -19,3 +19,10 @@ a {
 .follow-button {
   @include create-button;
 }
+
+my-delete-button {
+  ::ng-deep .button-label {
+    @include ellipsis;
+    width: 70px;
+  }
+}

--- a/client/src/app/+admin/follows/following-list/following-list.component.scss
+++ b/client/src/app/+admin/follows/following-list/following-list.component.scss
@@ -21,8 +21,5 @@ a {
 }
 
 my-delete-button {
-  ::ng-deep .button-label {
-    @include ellipsis;
-    width: 70px;
-  }
+  max-width: 130px;
 }

--- a/client/src/app/shared/shared-main/buttons/button.component.scss
+++ b/client/src/app/shared/shared-main/buttons/button.component.scss
@@ -13,6 +13,7 @@
 
 :host {
   outline: none;
+  display: inline-block;
 }
 
 my-small-loader ::ng-deep .root {
@@ -31,6 +32,8 @@ span[class$=-button] {
 .action-button {
   @include peertube-button-link;
   @include button-with-icon(21px);
+
+  width: 100%; // useful for ellipsis, allow to define a max-width on host component
 }
 
 .orange-button {
@@ -51,6 +54,10 @@ span[class$=-button] {
 .grey-button-link {
   @include peertube-button-link;
   @include grey-button;
+}
+
+.button-label {
+  @include ellipsis;
 }
 
 // In a table, try to minimize the space taken by this button


### PR DESCRIPTION
## Description
Fixes broken my-delete buttons into admin federation lists depending on language.
Use  the generic label «Remove » on following list to keep consistency with follower list.

## Related issues

Resolves https://github.com/Chocobozzz/PeerTube/issues/3953

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code

## Screenshots

![Screenshot 2021-09-06 at 14-26-55 Suivant - PeerTube](https://user-images.githubusercontent.com/1877318/132218005-a8267d03-8a1d-4736-a0d1-ae150ce8eac9.png)
<!-- delete if not relevant -->
