### PR TITLE
Fix undefined this.user.videoChannels on production build

### DIFF
--- a/client/src/app/shared/shared-main/misc/channels-setup-message.component.ts
+++ b/client/src/app/shared/shared-main/misc/channels-setup-message.component.ts
@@ -16,14 +16,10 @@ export class ChannelsSetupMessageComponent implements OnInit {
     private authService: AuthService
   ) {}
 
-  get userInformationLoaded () {
-    return this.authService.userInformationLoaded
-  }
-
   get hasChannelNotConfigured () {
-    return this.user.videoChannels
-      .filter((channel: VideoChannel) => (!channel.avatar || !channel.description))
-      .length > 0
+    if (!this.user.videoChannels) return
+
+    return this.user.videoChannels.filter((channel: VideoChannel) => (!channel.avatar || !channel.description)).length > 0
   }
 
   ngOnInit () {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Check if `this.user.videoChannels` not undefined in the getter `hasChannelNotConfigured` to avoid errors until user information fully loaded.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Resolves https://github.com/Chocobozzz/PeerTube/issues/4379

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code


## Screenshots

<!-- delete if not relevant -->
