### PR TITLE
add ...playlist.elements.loaded hook

### DIFF
--- a/client/src/app/+videos/+video-watch/shared/playlist/video-watch-playlist.component.ts
+++ b/client/src/app/+videos/+video-watch/shared/playlist/video-watch-playlist.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { Router } from '@angular/router'
-import { AuthService, ComponentPagination, LocalStorageService, Notifier, SessionStorageService, UserService } from '@app/core'
+import { AuthService, ComponentPagination, HooksService, LocalStorageService, Notifier, SessionStorageService, UserService } from '@app/core'
 import { VideoPlaylist, VideoPlaylistElement, VideoPlaylistService } from '@app/shared/shared-video-playlist'
 import { peertubeLocalStorage, peertubeSessionStorage } from '@root-helpers/peertube-web-storage'
 import { VideoPlaylistPrivacy } from '@shared/models'
@@ -34,6 +34,7 @@ export class VideoWatchPlaylistComponent {
   currentPlaylistPosition: number
 
   constructor (
+    private hooks: HooksService,
     private userService: UserService,
     private auth: AuthService,
     private notifier: Notifier,
@@ -88,8 +89,8 @@ export class VideoWatchPlaylistComponent {
 
   loadPlaylistElements (playlist: VideoPlaylist, redirectToFirst = false, position?: number) {
     this.videoPlaylist.getPlaylistVideos(playlist.uuid, this.playlistPagination)
-        .subscribe(({ total, data }) => {
-          this.playlistElements = this.playlistElements.concat(data)
+        .subscribe(({ total, data: playlistElements }) => {
+          this.playlistElements = this.playlistElements.concat(playlistElements)
           this.playlistPagination.totalItems = total
 
           const firstAvailableVideo = this.playlistElements.find(e => !!e.video)
@@ -111,6 +112,10 @@ export class VideoWatchPlaylistComponent {
             }
             this.router.navigate([], extras)
           }
+
+          this.hooks.runAction('action:video-watch-playlist.elements.loaded', 'video-watch', {
+            playlistElements
+          })
         })
   }
 

--- a/shared/models/plugins/client/client-hook.model.ts
+++ b/shared/models/plugins/client/client-hook.model.ts
@@ -81,6 +81,8 @@ export const clientActionHookObject = {
   'action:video-watch.video-threads.loaded': true,
   // Fired when a user click on 'View x replies' and they're loaded
   'action:video-watch.video-thread-replies.loaded': true,
+  // Fired when video watch playlist elements are loaded
+  'action:video-watch-playlist.elements.loaded': true,
 
   // Fired when the video edit page (upload, URL/torrent import, update) is being initialized
   'action:video-edit.init': true,


### PR DESCRIPTION
## Description
Adds a `action:video-watch-playlist.elements.loaded` hook so that plugins can listen for when video watch playlist elements are loaded.

## Related issues
closes #4385

## Has this been tested?

- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

I couldn't find any client tests for similar hooks. Maybe there's no need to test it more than manual testing?
