### PR TITLE
add option to always show channel display name

### DIFF
--- a/client/src/app/+videos/+video-watch/shared/metadata/video-avatar-channel.component.html
+++ b/client/src/app/+videos/+video-watch/shared/metadata/video-avatar-channel.component.html
@@ -1,11 +1,20 @@
-<div class="wrapper" [ngClass]="{ 'generic-channel': genericChannel }">
+<div class="wrapper">
   <my-actor-avatar
-    class="channel" [channel]="video.channel"
-    [internalHref]="[ '/c', video.byVideoChannel ]" [title]="channelLinkTitle"
+    *ngIf="showChannel"
+    class="channel"
+    [class.main-avatar]="showChannel"
+    [channel]="video.channel"
+    [internalHref]="[ '/c', video.byVideoChannel ]"
+    [title]="channelLinkTitle"
   ></my-actor-avatar>
 
   <my-actor-avatar
-    class="account" [account]="video.account"
-    [internalHref]="[ '/a', video.byAccount ]" [title]="accountLinkTitle">
+    *ngIf="showAccount"
+    class="account"
+    [class.main-avatar]="!showChannel"
+    [class.second-avatar]="showChannel"
+    [account]="video.account"
+    [internalHref]="[ '/a', video.byAccount ]"
+    [title]="accountLinkTitle">
   </my-actor-avatar>
 </div>

--- a/client/src/app/+videos/+video-watch/shared/metadata/video-avatar-channel.component.scss
+++ b/client/src/app/+videos/+video-watch/shared/metadata/video-avatar-channel.component.scss
@@ -20,23 +20,11 @@
   position: relative;
   margin-bottom: 5px;
 
-  &.generic-channel {
-    .account {
-      @include main();
-    }
-
-    .channel {
-      display: none !important;
-    }
+  .main-avatar {
+    @include main();
   }
 
-  &:not(.generic-channel) {
-    .account {
-      @include secondary();
-    }
-
-    .channel {
-      @include main();
-    }
+  .second-avatar {
+    @include secondary();
   }
 }

--- a/client/src/app/+videos/+video-watch/shared/metadata/video-avatar-channel.component.ts
+++ b/client/src/app/+videos/+video-watch/shared/metadata/video-avatar-channel.component.ts
@@ -10,7 +10,8 @@ export class VideoAvatarChannelComponent implements OnInit {
   @Input() video: Video
   @Input() byAccount: string
 
-  @Input() genericChannel: boolean
+  @Input() showAccount: boolean
+  @Input() showChannel: boolean
 
   channelLinkTitle = ''
   accountLinkTitle = ''

--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -60,19 +60,19 @@
 
           <div class="pt-3 border-top video-info-channel d-flex">
             <div class="video-info-channel-left d-flex">
-              <my-video-avatar-channel [video]="video" [genericChannel]="isChannelDisplayNameGeneric()"></my-video-avatar-channel>
+              <my-video-avatar-channel [video]="video" [showAccount]="!onlyShowAuthorChannel" [showChannel]="!isChannelDisplayNameGeneric() || onlyShowAuthorChannel"></my-video-avatar-channel>
 
               <div class="video-info-channel-left-links ml-1">
-                <ng-container *ngIf="!isChannelDisplayNameGeneric()">
-                  <a [routerLink]="[ '/c', video.byVideoChannel ]" i18n-title title="Channel page">
+                <ng-container *ngIf="!isChannelDisplayNameGeneric() || onlyShowAuthorChannel">
+                  <a [routerLink]="[ '/c', video.byVideoChannel ]" i18n-title title="Channel page" [class.single-link]="onlyShowAuthorChannel">
                     {{ video.channel.displayName }}
                   </a>
-                  <a [routerLink]="[ '/a', video.byAccount ]" i18n-title title="Account page">
+                  <a [routerLink]="[ '/a', video.byAccount ]" i18n-title title="Account page" *ngIf="!onlyShowAuthorChannel">
                     <span i18n>By {{ video.byAccount }}</span>
                   </a>
                 </ng-container>
 
-                <ng-container *ngIf="isChannelDisplayNameGeneric()">
+                <ng-container *ngIf="isChannelDisplayNameGeneric() && !onlyShowAuthorChannel">
                   <a [routerLink]="[ '/a', video.byAccount ]" class="single-link" i18n-title title="Account page">
                     <span i18n>{{ video.byAccount }}</span>
                   </a>

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -67,6 +67,8 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
   remoteServerDown = false
 
+  onlyShowAuthorChannel: boolean
+
   private nextVideoUUID = ''
   private nextVideoTitle = ''
 
@@ -115,6 +117,8 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
   ngOnInit () {
     this.serverConfig = this.serverService.getHTMLConfig()
+
+    this.onlyShowAuthorChannel = this.serverConfig.instance.onlyShowAuthorChannel
 
     PeertubePlayerManager.initState()
 

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.html
@@ -39,10 +39,10 @@
           </span>
 
           <a tabindex="-1" *ngIf="displayOptions.by && displayOwnerAccount()" class="video-miniature-account" [routerLink]="[ '/c', video.byVideoChannel ]">
-            {{ video.byAccount }}
+            {{ serverConfig.instance.showAuthorDisplayNameInMiniatures ? video.account.displayName : video.byAccount }}
           </a>
           <a tabindex="-1" *ngIf="displayOptions.by && displayOwnerVideoChannel()" class="video-miniature-channel" [routerLink]="[ '/c', video.byVideoChannel ]">
-            {{ video.byVideoChannel }}
+            {{ serverConfig.instance.showAuthorDisplayNameInMiniatures ? video.channel.displayName : video.byVideoChannel }}
           </a>
 
           <div class="video-info-privacy">

--- a/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
+++ b/client/src/app/shared/shared-video-miniature/video-miniature.component.ts
@@ -240,6 +240,11 @@ export class VideoMiniatureComponent implements OnInit {
   }
 
   private setUpBy () {
+    if (this.serverConfig.instance.onlyShowAuthorChannel === true) {
+      this.ownerDisplayType = 'videoChannel'
+      return
+    }
+
     const accountName = this.video.account.name
 
     // If the video channel name is an UUID (not really displayable, we changed this behaviour in v1.0.0-beta.12)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -399,6 +399,9 @@ instance:
   terms: 'No terms for now.' # Support markdown
   code_of_conduct: '' # Supports markdown
 
+  only_show_channel_author: false
+  show_author_display_name_in_miniatures: false
+
   # Who moderates the instance? What is the policy regarding NSFW videos? Political videos? etc
   moderation_information: '' # Supports markdown
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -409,6 +409,9 @@ instance:
   terms: 'No terms for now.' # Support markdown
   code_of_conduct: '' # Supports markdown
 
+  only_show_channel_author: false
+  show_author_display_name_in_miniatures: false
+
   # Who moderates the instance? What is the policy regarding NSFW videos? Political videos? etc
   moderation_information: '' # Supports markdown
 

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -334,7 +334,10 @@ const CONFIG = {
     },
     get ROBOTS () { return config.get<string>('instance.robots') },
     get SECURITYTXT () { return config.get<string>('instance.securitytxt') },
-    get SECURITYTXT_CONTACT () { return config.get<string>('admin.email') }
+    get SECURITYTXT_CONTACT () { return config.get<string>('admin.email') },
+
+    get ONLY_SHOW_CHANNEL_AUTHOR () { return config.get<boolean>('instance.only_show_channel_author') },
+    get SHOW_AUTHOR_DISPLAY_NAME_IN_MINIATURES () { return config.get<boolean>('instance.show_author_display_name_in_miniatures') }
   },
   SERVICES: {
     TWITTER: {

--- a/server/lib/server-config-manager.ts
+++ b/server/lib/server-config-manager.ts
@@ -51,7 +51,9 @@ class ServerConfigManager {
         customizations: {
           javascript: CONFIG.INSTANCE.CUSTOMIZATIONS.JAVASCRIPT,
           css: CONFIG.INSTANCE.CUSTOMIZATIONS.CSS
-        }
+        },
+        onlyShowAuthorChannel: CONFIG.INSTANCE.ONLY_SHOW_CHANNEL_AUTHOR,
+        showAuthorDisplayNameInMiniatures: CONFIG.INSTANCE.SHOW_AUTHOR_DISPLAY_NAME_IN_MINIATURES
       },
       search: {
         remoteUri: {

--- a/shared/models/server/server-config.model.ts
+++ b/shared/models/server/server-config.model.ts
@@ -43,6 +43,8 @@ export interface ServerConfig {
       javascript: string
       css: string
     }
+    onlyShowAuthorChannel: boolean
+    showAuthorDisplayNameInMiniatures: boolean
   }
 
   search: {


### PR DESCRIPTION
## Description
Adds following configuration options:

```
instance.onlyShowAuthorChannel
instance.showAuthorDisplayNameInMiniatures
```

### Todo
* Show avatar in video miniatures.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #4040


<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots
![image](https://user-images.githubusercontent.com/6680299/133974605-7a639e06-73d5-4139-b2ef-bfbb0642034f.png)
![image](https://user-images.githubusercontent.com/6680299/133975909-b38ecf71-25f4-4fa1-a0fd-38a9bee713ce.png)

<!-- delete if not relevant -->
