### PR TITLE
Use pathname of embed url to prevent querystring or hash

### DIFF
--- a/server/middlewares/validators/oembed.ts
+++ b/server/middlewares/validators/oembed.ts
@@ -67,7 +67,7 @@ const oembedValidator = [
 
     const startIsOk = isVideo || isPlaylist
 
-    const matches = watchRegex.exec(url)
+    const matches = watchRegex.exec(new URL(url).pathname)
 
     if (startIsOk === false || matches === null) {
       return res.fail({


### PR DESCRIPTION
## Description

Ignores querystring or hash in URL to match video id properly (last part after the last slash)

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/4424

