### PR TITLE
Add Python symlink step for Gentoo

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -554,6 +554,12 @@ rc-service redis start
 rc-service postgresql-11 start
 ```
 
+6. Create Python version symlink for youtube-dl:
+
+```
+sudo ln -s /usr/bin/python3 /usr/bin/python
+```
+
 ## OpenBSD
 
 1. Install Packages:


### PR DESCRIPTION
## Description

Extra step for Gentoo to make youtube-dl function properly after first install.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/4430

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help (someone needs to confirm this works on an actual install of Gentoo)


