### PR TITLE
Add python-exec to Gentoo dependencies

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -519,6 +519,7 @@ dev-db/redis
 dev-vcs/git
 app-arch/unzip
 dev-lang/python
+dev-lang/python-exec
 www-servers/nginx
 
 # Optional, client for Let’s Encrypt:
@@ -559,7 +560,7 @@ rc-service postgresql-11 start
 6. Create Python version symlink for youtube-dl:
 
 ```
-sudo ln -s /usr/bin/python3 /usr/bin/python
+emerge -1 python-exec
 ```
 
 ## OpenBSD


### PR DESCRIPTION
## Description

Added python-exec package to symlink Python versions for a more optimal way to set this up on Gentoo.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/4430

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->


