### PR TITLE
Save temporary object storage files in tmp folder

### DIFF
--- a/server/lib/hls.ts
+++ b/server/lib/hls.ts
@@ -91,7 +91,7 @@ async function updateSha256VODSegments (video: MVideoWithFile, playlist: MStream
     })
   }
 
-  const outputPath = VideoPathManager.Instance.getFSHLSOutputPath(video, playlist.segmentsSha256Filename)
+  const outputPath = VideoPathManager.Instance.getFSHLSOutputPath(video, playlist.segmentsSha256Filename, playlist.storage)
   await outputJSON(outputPath, json)
 }
 

--- a/server/lib/job-queue/handlers/move-to-object-storage.ts
+++ b/server/lib/job-queue/handlers/move-to-object-storage.ts
@@ -67,7 +67,7 @@ async function moveHLSFiles (video: MVideoWithAllFiles) {
       // Resolution fragmented file
       const fileUrl = await storeHLSFile(playlist, video, file.filename)
 
-      const oldPath = join(getHLSDirectory(video), file.filename)
+      const oldPath = join(getHLSDirectory(video, file.storage), file.filename)
 
       await onFileMoved({ videoOrPlaylist: Object.assign(playlist, { Video: video }), file, fileUrl, oldPath })
     }
@@ -93,7 +93,7 @@ async function doAfterLastJob (video: MVideoWithAllFiles, isNewVideo: boolean) {
 
   // Remove empty hls video directory
   if (video.VideoStreamingPlaylists) {
-    await remove(getHLSDirectory(video))
+    await remove(getHLSDirectory(video, video.VideoStreamingPlaylists[0].storage))
   }
 
   await moveToNextState(video, isNewVideo)

--- a/server/lib/job-queue/handlers/video-live-ending.ts
+++ b/server/lib/job-queue/handlers/video-live-ending.ts
@@ -56,15 +56,15 @@ export {
 // ---------------------------------------------------------------------------
 
 async function saveLive (video: MVideo, live: MVideoLive, streamingPlaylist: MStreamingPlaylist) {
-  const replayDirectory = VideoPathManager.Instance.getFSHLSOutputPath(video, VIDEO_LIVE.REPLAY_DIRECTORY)
+  const replayDirectory = VideoPathManager.Instance.getFSHLSOutputPath(video, VIDEO_LIVE.REPLAY_DIRECTORY, streamingPlaylist.storage)
 
-  const rootFiles = await readdir(getLiveDirectory(video))
+  const rootFiles = await readdir(getLiveDirectory(video, streamingPlaylist.storage))
 
   const playlistFiles = rootFiles.filter(file => {
     return file.endsWith('.m3u8') && file !== streamingPlaylist.playlistFilename
   })
 
-  await cleanupTMPLiveFiles(getLiveDirectory(video))
+  await cleanupTMPLiveFiles(getLiveDirectory(video, streamingPlaylist.storage))
 
   await live.destroy()
 

--- a/server/lib/live/live-utils.ts
+++ b/server/lib/live/live-utils.ts
@@ -10,7 +10,7 @@ function buildConcatenatedName (segmentOrPlaylistPath: string) {
 }
 
 async function cleanupLive (video: MVideo, streamingPlaylist: MStreamingPlaylist) {
-  const hlsDirectory = getLiveDirectory(video)
+  const hlsDirectory = getLiveDirectory(video, streamingPlaylist.storage)
 
   await remove(hlsDirectory)
 

--- a/server/lib/live/shared/muxing-session.ts
+++ b/server/lib/live/shared/muxing-session.ts
@@ -282,7 +282,7 @@ class MuxingSession extends EventEmitter {
   }
 
   private async prepareDirectories () {
-    const outPath = getLiveDirectory(this.videoLive.Video)
+    const outPath = getLiveDirectory(this.videoLive.Video, this.streamingPlaylist.storage)
     await ensureDir(outPath)
 
     const replayDirectory = join(outPath, VIDEO_LIVE.REPLAY_DIRECTORY)

--- a/server/lib/object-storage/videos.ts
+++ b/server/lib/object-storage/videos.ts
@@ -5,9 +5,10 @@ import { MStreamingPlaylist, MVideoFile, MVideoUUID } from '@server/types/models
 import { getHLSDirectory } from '../paths'
 import { generateHLSObjectBaseStorageKey, generateHLSObjectStorageKey, generateWebTorrentObjectStorageKey } from './keys'
 import { lTags, makeAvailable, removeObject, removePrefix, storeObject } from './shared'
+import { VideoStorage } from '@shared/models'
 
 function storeHLSFile (playlist: MStreamingPlaylist, video: MVideoUUID, filename: string) {
-  const baseHlsDirectory = getHLSDirectory(video)
+  const baseHlsDirectory = getHLSDirectory(video, VideoStorage.OBJECT_STORAGE)
 
   return storeObject({
     inputPath: join(baseHlsDirectory, filename),

--- a/server/lib/paths.ts
+++ b/server/lib/paths.ts
@@ -4,6 +4,7 @@ import { CONFIG } from '@server/initializers/config'
 import { HLS_REDUNDANCY_DIRECTORY, HLS_STREAMING_PLAYLIST_DIRECTORY } from '@server/initializers/constants'
 import { isStreamingPlaylist, MStreamingPlaylistVideo, MVideo, MVideoFile, MVideoUUID } from '@server/types/models'
 import { removeFragmentedMP4Ext } from '@shared/core-utils'
+import { VideoStorage } from '@shared/models'
 
 // ################## Video file name ##################
 
@@ -17,11 +18,11 @@ function generateHLSVideoFilename (resolution: number) {
 
 // ################## Streaming playlist ##################
 
-function getLiveDirectory (video: MVideoUUID) {
-  return getHLSDirectory(video)
+function getLiveDirectory (video: MVideoUUID, storage: VideoStorage) {
+  return getHLSDirectory(video, storage)
 }
 
-function getHLSDirectory (video: MVideoUUID) {
+function getHLSDirectory (video: MVideoUUID, storage: VideoStorage) {
   return join(HLS_STREAMING_PLAYLIST_DIRECTORY, video.uuid)
 }
 

--- a/server/lib/transcoding/video-transcoding.ts
+++ b/server/lib/transcoding/video-transcoding.ts
@@ -332,10 +332,10 @@ async function generateHlsPlaylistCommon (options: {
   const videoFilePath = VideoPathManager.Instance.getFSVideoFileOutputPath(playlist, newVideoFile)
 
   // Move files from tmp transcoded directory to the appropriate place
-  await ensureDir(VideoPathManager.Instance.getFSHLSOutputPath(video))
+  await ensureDir(VideoPathManager.Instance.getFSHLSOutputPath(video, undefined, playlist.storage))
 
   // Move playlist file
-  const resolutionPlaylistPath = VideoPathManager.Instance.getFSHLSOutputPath(video, resolutionPlaylistFilename)
+  const resolutionPlaylistPath = VideoPathManager.Instance.getFSHLSOutputPath(video, resolutionPlaylistFilename, playlist.storage)
   await move(resolutionPlaylistFileTranscodePath, resolutionPlaylistPath, { overwrite: true })
   // Move video file
   await move(join(videoTranscodedBasePath, videoFilename), videoFilePath, { overwrite: true })

--- a/server/lib/video-path-manager.ts
+++ b/server/lib/video-path-manager.ts
@@ -16,8 +16,8 @@ class VideoPathManager {
 
   private constructor () {}
 
-  getFSHLSOutputPath (video: MVideoUUID, filename?: string) {
-    const base = getHLSDirectory(video)
+  getFSHLSOutputPath (video: MVideoUUID, filename?: string, storage?: VideoStorage) {
+    const base = getHLSDirectory(video, storage)
     if (!filename) return base
 
     return join(base, filename)
@@ -37,7 +37,7 @@ class VideoPathManager {
     if (videoFile.isHLS()) {
       const video = extractVideo(videoOrPlaylist)
 
-      return join(getHLSDirectory(video), videoFile.filename)
+      return join(getHLSDirectory(video, videoFile.storage), videoFile.filename)
     }
 
     return join(CONFIG.STORAGE.VIDEOS_DIR, videoFile.filename)
@@ -76,7 +76,7 @@ class VideoPathManager {
 
     if (videoFile.storage === VideoStorage.FILE_SYSTEM) {
       return this.makeAvailableFactory(
-        () => join(getHLSDirectory(playlist.Video), filename),
+        () => join(getHLSDirectory(playlist.Video, videoFile.storage), filename),
         false,
         cb
       )
@@ -92,7 +92,7 @@ class VideoPathManager {
   async makeAvailablePlaylistFile <T> (playlist: MStreamingPlaylistVideo, filename: string, cb: MakeAvailableCB<T>) {
     if (playlist.storage === VideoStorage.FILE_SYSTEM) {
       return this.makeAvailableFactory(
-        () => join(getHLSDirectory(playlist.Video), filename),
+        () => join(getHLSDirectory(playlist.Video, playlist.storage), filename),
         false,
         cb
       )

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1703,7 +1703,7 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
   async removeStreamingPlaylistFiles (streamingPlaylist: MStreamingPlaylist, isRedundancy = false) {
     const directoryPath = isRedundancy
       ? getHLSRedundancyDirectory(this)
-      : getHLSDirectory(this)
+      : getHLSDirectory(this, streamingPlaylist.storage)
 
     await remove(directoryPath)
 


### PR DESCRIPTION
## Description
When uploading files and object storage is enabled, store the files in the tmp folder. This is untested and will not solve non-HLS videos, it's just a draft proposal.

## Related issues
closes #4467

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->