### PR TITLE
Add warning and update privacy on share playlist

### DIFF
--- a/client/src/app/shared/shared-share-modal/video-share.component.html
+++ b/client/src/app/shared/shared-share-modal/video-share.component.html
@@ -11,71 +11,76 @@
       <div class="title-page title-page-single" i18n *ngIf="video">Share the playlist</div>
 
 
-      <div *ngIf="isPrivatePlaylist()" class="form-group">
-        <p>
-          <my-global-icon iconName="alert" aria-hidden="true"></my-global-icon>
-          This playlist is private, you can update it's privacy 
-          <a class="update" [routerLink]="[ '/my-library/video-playlists/update', playlist.uuid ]" target="_blank" rel="noreferrer">
-            Here
-          </a>
-        </p>
-        <hr>
+      <div *ngIf="isPrivatePlaylist()" class="alert-private alert alert-warning">
+        <div i18n>This playlist is private so you won't be able to share it with external users</div>
+
+        <a i18n class="peertube-button-link orange-button" [routerLink]="[ '/my-library/video-playlists/update', playlist.uuid ]" target="_blank" rel="noopener noreferrer">
+          Update playlist privacy
+        </a>
       </div>
 
-        <div ngbNav #nav="ngbNav" class="nav-tabs" [(activeId)]="activePlaylistId">
+      <div ngbNav #nav="ngbNav" class="nav-tabs" [(activeId)]="activePlaylistId">
 
-          <ng-container ngbNavItem="url">
-            <a ngbNavLink i18n>URL</a>
+        <ng-container ngbNavItem="url">
+          <a ngbNavLink i18n>URL</a>
 
-            <ng-template ngbNavContent>
-              <div class="nav-content">
-                  
-                <my-input-toggle-hidden [value]="getPlaylistUrl()" [withToggle]="false" [withCopy]="true" [show]="true" [readonly]="true"></my-input-toggle-hidden>
+          <ng-template ngbNavContent>
+            <div class="nav-content">
+
+              <my-input-toggle-hidden [value]="getPlaylistUrl()" [withToggle]="false" [withCopy]="true" [show]="true" [readonly]="true"></my-input-toggle-hidden>
+            </div>
+          </ng-template>
+        </ng-container>
+
+        <ng-container ngbNavItem="qrcode">
+          <a ngbNavLink i18n>QR-Code</a>
+
+          <ng-template ngbNavContent>
+            <div class="nav-content">
+              <qrcode [qrdata]="getPlaylistUrl()" [size]="256" level="Q"></qrcode>
+            </div>
+          </ng-template>
+        </ng-container>
+
+        <ng-container ngbNavItem="embed">
+          <a ngbNavLink i18n>Embed</a>
+
+          <ng-template ngbNavContent>
+            <div class="nav-content">
+              <my-input-toggle-hidden [value]="getPlaylistIframeCode()" [withToggle]="false" [withCopy]="true" [show]="true" [readonly]="true"></my-input-toggle-hidden>
+
+              <div i18n *ngIf="notSecure()" class="alert alert-warning">
+                The url is not secured (no HTTPS), so the embed video won't work on HTTPS websites (web browsers block non secured HTTP requests on HTTPS websites).
               </div>
-            </ng-template>
-          </ng-container>
+            </div>
+          </ng-template>
+        </ng-container>
 
-          <ng-container ngbNavItem="qrcode">
-            <a ngbNavLink i18n>QR-Code</a>
+      </div>
 
-            <ng-template ngbNavContent>
-              <div class="nav-content">
-                <qrcode [qrdata]="getPlaylistUrl()" [size]="256" level="Q"></qrcode>
-              </div>
-            </ng-template>
-          </ng-container>
+      <div [ngbNavOutlet]="nav"></div>
 
-          <ng-container ngbNavItem="embed">
-            <a ngbNavLink i18n>Embed</a>
+      <div class="filters">
 
-            <ng-template ngbNavContent>
-              <div class="nav-content">
-                <my-input-toggle-hidden [value]="getPlaylistIframeCode()" [withToggle]="false" [withCopy]="true" [show]="true" [readonly]="true"></my-input-toggle-hidden>
-
-                <div i18n *ngIf="notSecure()" class="alert alert-warning">
-                  The url is not secured (no HTTPS), so the embed video won't work on HTTPS websites (web browsers block non secured HTTP requests on HTTPS websites).
-                </div>
-              </div>
-            </ng-template>
-          </ng-container>
-
+        <div class="form-group" *ngIf="video">
+          <my-peertube-checkbox inputName="includeVideoInPlaylist" [(ngModel)]="includeVideoInPlaylist" i18n-labelText
+            labelText="Share the playlist at this video position"></my-peertube-checkbox>
         </div>
 
-        <div [ngbNavOutlet]="nav"></div>
-
-        <div class="filters">
-
-          <div class="form-group" *ngIf="video">
-            <my-peertube-checkbox inputName="includeVideoInPlaylist" [(ngModel)]="includeVideoInPlaylist" i18n-labelText
-              labelText="Share the playlist at this video position"></my-peertube-checkbox>
-          </div>
-
-        </div>
+      </div>
     </div>
 
 
     <div class="video" *ngIf="video">
       <div class="title-page title-page-single" *ngIf="playlist" i18n>Share the video</div>
+
+      <div *ngIf="isPrivateVideo()" class="alert-private alert alert-warning">
+        <div i18n>This video is private so you won't be able to share it with external users</div>
+
+        <a i18n class="peertube-button-link orange-button" [routerLink]="[ '/videos/', 'update', video.shortUUID ]" target="_blank" rel="noopener noreferrer">
+          Update video privacy
+        </a>
+      </div>
 
       <div ngbNav #nav="ngbNav" class="nav-tabs" [(activeId)]="activeVideoId">
 

--- a/client/src/app/shared/shared-share-modal/video-share.component.scss
+++ b/client/src/app/shared/shared-share-modal/video-share.component.scss
@@ -82,7 +82,8 @@ my-input-toggle-hidden {
   }
 }
 
-a.update {
-  @include peertube-button;
-  @include orange-button;
+.alert-private {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }

--- a/client/src/app/shared/shared-share-modal/video-share.component.ts
+++ b/client/src/app/shared/shared-share-modal/video-share.component.ts
@@ -3,7 +3,7 @@ import { VideoDetails } from '@app/shared/shared-main'
 import { VideoPlaylist } from '@app/shared/shared-video-playlist'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { buildPlaylistLink, buildVideoLink, decoratePlaylistLink, decorateVideoLink } from '@shared/core-utils'
-import { VideoCaption, VideoPlaylistPrivacy } from '@shared/models'
+import { VideoCaption, VideoPlaylistPrivacy, VideoPrivacy } from '@shared/models'
 import { buildVideoOrPlaylistEmbed } from '../../../assets/player/utils'
 
 type Customizations = {
@@ -124,6 +124,10 @@ export class VideoShareComponent {
 
   isLocalVideo () {
     return this.video.isLocal
+  }
+
+  isPrivateVideo () {
+    return this.video.privacy.id === VideoPrivacy.PRIVATE
   }
 
   isPrivatePlaylist () {


### PR DESCRIPTION
## Description

This PR intends to solve the issue [#3976](https://github.com/Chocobozzz/PeerTube/issues/3976)

The feature that is implemented warns the users about the playlist being on private mode and also allows them to directly update the privacy to Public. In order to immediately be able to share the playlist.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

Issue #3976 

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

See a video of how is working here:

https://user-images.githubusercontent.com/11297071/137899180-8a29100e-2b7f-40bf-aa4d-81ac8dab7839.mp4

<!-- delete if not relevant -->
