### PR TITLE
Add missing start and count parameters to playlist video list API endpoint documentation

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -3115,6 +3115,8 @@ paths:
         - Video Playlists
       parameters:
         - $ref: '#/components/parameters/playlistId'
+        - $ref: '#/components/parameters/start'
+        - $ref: '#/components/parameters/count'
       responses:
         '200':
           description: successful operation


### PR DESCRIPTION
## Description
The documentation for `/api/v1/video-playlists/{playlistId}/videos` was missing the `start` and `count` parameters for the pagination. They have been present ever since the original implementation in 418d092afa as far as I can tell.

## Related issues
None

## Has this been tested?
- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->