### PR TITLE
Changed label of "sort by views" to "sort by recent views"

### DIFF
--- a/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
@@ -45,7 +45,7 @@
     >
       <ng-option i18n value="-publishedAt">Sort by <strong>"Recently Added"</strong></ng-option>
 
-      <ng-option i18n *ngIf="isTrendingSortEnabled('most-viewed')" value="-trending">Sort by <strong>"Views"</strong></ng-option>
+      <ng-option i18n *ngIf="isTrendingSortEnabled('most-viewed')" value="-trending">Sort by <strong>"Recent Views"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('hot')" value="-hot">Sort by <strong>"Hot"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('best')" value="-best">Sort by <strong>"Best"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('most-liked')" value="-likes">Sort by <strong>"Likes"</strong></ng-option>


### PR DESCRIPTION
## Description

As requested in the issue, I changed the sort by "Views" to sort by "Recent Views" to better reflect the fact that we're still using the trending algorithm that relies on the recent views of the video.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/4421

## Has this been tested?

- [x] 🙅 no, because this PR does not update server code

## Screenshots

![image](https://user-images.githubusercontent.com/20014332/138557763-7c3ea55a-dd7d-4dc7-895d-9ac8637298ce.png)
