### PR TITLE
Added Markdown formatting in playlist descriptions

### DIFF
--- a/client/src/app/+my-library/my-video-playlists/my-video-playlist-edit.component.html
+++ b/client/src/app/+my-library/my-video-playlists/my-video-playlist-edit.component.html
@@ -41,11 +41,11 @@
         </div>
 
         <div class="form-group">
-          <label i18n for="description">Description</label>
-          <textarea
+          <label i18n for="description">Description</label><my-help helpType="markdownText"></my-help>
+          <my-markdown-textarea
             id="description" formControlName="description"
-            class="form-control" [ngClass]="{ 'input-error': formErrors['description'] }"
-          ></textarea>
+            [ngClass]="{ 'input-error': formErrors['description'] }"
+          ></my-markdown-textarea>
           <div *ngIf="formErrors.description" class="form-error">
             {{ formErrors.description }}
           </div>

--- a/client/src/app/+my-library/my-video-playlists/my-video-playlist-edit.component.scss
+++ b/client/src/app/+my-library/my-video-playlists/my-video-playlist-edit.component.scss
@@ -16,12 +16,6 @@ input[type=text] {
   display: block;
 }
 
-textarea {
-  @include peertube-textarea(500px, 150px);
-
-  display: block;
-}
-
 .peertube-select-container {
   @include peertube-select-container(340px);
 }

--- a/client/src/app/shared/shared-video-playlist/video-playlist-miniature.component.html
+++ b/client/src/app/shared/shared-video-playlist/video-playlist-miniature.component.html
@@ -32,6 +32,6 @@
       <span i18n class="updated-at">Updated {{ playlist.updatedAt | myFromNow }}</span>
     </div>
 
-    <div *ngIf="displayDescription" class="video-info-description">{{ playlist.description }}</div>
+    <div *ngIf="displayDescription" class="video-info-description" [innerHTML]="playlistDescription"></div>
   </div>
 </div>

--- a/client/src/app/shared/shared-video-playlist/video-playlist-miniature.component.ts
+++ b/client/src/app/shared/shared-video-playlist/video-playlist-miniature.component.ts
@@ -1,6 +1,7 @@
 import { LinkType } from 'src/types/link.type'
 import { Component, Input, OnInit } from '@angular/core'
 import { VideoPlaylist } from './video-playlist.model'
+import { MarkdownService } from '@app/core'
 
 @Component({
   selector: 'my-video-playlist-miniature',
@@ -22,9 +23,17 @@ export class VideoPlaylistMiniatureComponent implements OnInit {
   routerLink: any
   playlistHref: string
   playlistTarget: string
+  playlistDescription: string
 
-  ngOnInit () {
+  constructor (
+    private markdownService: MarkdownService
+  ) {}
+
+  async ngOnInit () {
     this.buildPlaylistUrl()
+    if (this.displayDescription) {
+      this.playlistDescription = await this.markdownService.textMarkdownToHTML(this.playlist.description)
+    }
   }
 
   buildPlaylistUrl () {


### PR DESCRIPTION
## Description

Added Markdown formatting to the playlist descriptions. The playlist editor now has a "markdown help" and a description field as `my-markdown-textarea`. And all places where playlist descriptions are displayed now display the proper text if Markdown formatting was used (this includes new lines).

See the screenshots.

## Related issues

Implements https://github.com/Chocobozzz/PeerTube/issues/3627

## Has this been tested?

- [x] 🙅 no, because this PR does not update server code

## Screenshots

Playlist Editor

![image](https://user-images.githubusercontent.com/20014332/138573002-a1a55858-fac0-4a30-b6dc-221da99ab3e9.png)

"My Playlists" view

![image](https://user-images.githubusercontent.com/20014332/138573013-3a5feea7-56aa-4c36-ad73-cd8dc8b77e95.png)

"My Library/Video Playlists" view

![image](https://user-images.githubusercontent.com/20014332/138573027-d33a0250-454e-4b6c-bfb1-36fa1fcffd8c.png)
