### PR TITLE
Update RHEL8 Python symlink

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -360,7 +360,7 @@ sudo dnf install nginx postgresql postgresql-server postgresql-contrib openssl g
 6. You'll need a symlink for python3 to python for youtube-dl to work
 
 ```
-sudo ln -s /usr/bin/python3 /usr/bin/python
+sudo alternatives --set python3 /usr/bin/python
 ```
 
 7. Initialize the PostgreSQL database:


### PR DESCRIPTION
## Description

One shouldn't do manual symlinking on the root filesystem, as they might not be persistent with a distro upgrade. After the recent improvement in the guide for Gentoo, I looked into it and this is the recommended way for RHEL8.

See comment: https://github.com/Chocobozzz/PeerTube/issues/4430#issuecomment-937323619 