### PR TITLE
Allow setting path-style access for object storage

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -123,6 +123,10 @@ object_storage:
     # You can also use AWS_SECRET_ACCESS_KEY env variable
     secret_access_key: ''
 
+  # Reference buckets via path rather than subdomain
+  # (i.e. "my-endpoint.com/bucket" instead of "bucket.my-endpoint.com")
+  force_path_style: false
+
   # Maximum amount to upload in one request to object storage
   max_upload_part: 2GB
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -121,6 +121,10 @@ object_storage:
     # You can also use AWS_SECRET_ACCESS_KEY env variable
     secret_access_key: ''
 
+  # Reference buckets via path rather than subdomain
+  # (i.e. "my-endpoint.com/bucket" instead of "bucket.my-endpoint.com")
+  force_path_style: false
+
   # Maximum amount to upload in one request to object storage
   max_upload_part: 2GB
 

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -91,6 +91,7 @@ const CONFIG = {
       ACCESS_KEY_ID: config.get<string>('object_storage.credentials.access_key_id'),
       SECRET_ACCESS_KEY: config.get<string>('object_storage.credentials.secret_access_key')
     },
+    FORCE_PATH_STYLE: config.get<boolean>('object_storage.force_path_style'),
     VIDEOS: {
       BUCKET_NAME: config.get<string>('object_storage.videos.bucket_name'),
       PREFIX: config.get<string>('object_storage.videos.prefix'),

--- a/server/lib/object-storage/shared/client.ts
+++ b/server/lib/object-storage/shared/client.ts
@@ -26,7 +26,8 @@ function getClient () {
         accessKeyId: OBJECT_STORAGE.CREDENTIALS.ACCESS_KEY_ID,
         secretAccessKey: OBJECT_STORAGE.CREDENTIALS.SECRET_ACCESS_KEY
       }
-      : undefined
+      : undefined,
+    forcePathStyle: CONFIG.OBJECT_STORAGE.FORCE_PATH_STYLE
   })
 
   logger.info('Initialized S3 client %s with region %s.', getEndpoint(), OBJECT_STORAGE.REGION, lTags())

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -54,6 +54,8 @@ object_storage:
 
   region: "PEERTUBE_OBJECT_STORAGE_REGION"
 
+  force_path_style: "PEERTUBE_OBJECT_STORAGE_FORCE_PATH_STYLE"
+
   max_upload_part:
     __name: "PEERTUBE_OBJECT_STORAGE_MAX_UPLOAD_PART"
     __format: "json"


### PR DESCRIPTION
## Description

Not every S3 setup allows referencing buckets by subdomain. When hosting your own minio instance or another custom S3 service, you might need to use path-style bucket access instead.

The PR adds a `force_path_style` configuration option which sets the [according option in the S3 SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#forcepathstyle). 

## Related issues

See the original object storage implementation in #4290.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help 

I had difficulties running the tests. It seems there is more prerequisites needed than what is documented.