### PR TITLE
Trigger rebuild of Gitpod's image for PeerTube

### DIFF
--- a/support/docker/gitpod/Dockerfile
+++ b/support/docker/gitpod/Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-postgres
 
 # Gitpod will not rebuild PeerTube's dev image unless *some* change is made to this Dockerfile.
 # To trigger a rebuild, simply increase this counter:
-ENV TRIGGER_REBUILD 1
+ENV TRIGGER_REBUILD 2
 
 # Install PeerTube's dependencies.
 RUN sudo apt-get update -q && sudo apt-get install -qy \


### PR DESCRIPTION
## Description

Gitpod's docker image for PeerTube hasn't been rebuilt for some time, and started to have compatibility issues between dependencies and the node engine. Triggering this rebuild should force Gitpod to rebuild the image with node v16.13.0 instead of node v12.20.0.

## Related issues

None.

## Has this been tested?

- [x] 🙅 no, because this PR does not update server code

But in fact, yes : I did trigger a rebuild of the image on my fork, and it's working great!