### PR TITLE
Launch yarn before linking to new peertube version

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -68,11 +68,13 @@ cd $PEERTUBE_PATH/versions
 unzip -o "peertube-${VERSION}.zip"
 rm -f "peertube-${VERSION}.zip"
 
-# Upgrade Scripts
+# Launch yarn to check if we have all required dependencies
+cd "$PEERTUBE_PATH/versions/peertube-${VERSION}"
+NOCLIENT=1 yarn install --production --pure-lockfile
+
+# Switch to latest code version
 rm -rf $PEERTUBE_PATH/peertube-latest
 ln -s "$PEERTUBE_PATH/versions/peertube-${VERSION}" $PEERTUBE_PATH/peertube-latest
-cd $PEERTUBE_PATH/peertube-latest
-NOCLIENT=1 yarn install --production --pure-lockfile
 cp $PEERTUBE_PATH/peertube-latest/config/default.yaml $PEERTUBE_PATH/config/default.yaml
 
 echo "Differences in configuration files..."


### PR DESCRIPTION
## Description

If yarn fails because we don't have the correct nodejs version, we want to know earlier, so that we can upgrade nodejs without having a non-working half-installed peertube instance.

## Related issues

I got an issue on latest upgrade of Peertube, because I was still on nodejs 10. The `yarn` command failed, and I thought that I didn't need to upgrade node immediately, but could wait one more day. I was mistaken :( 
This problem was seen on https://github.com/osm-fr/infrastructure/issues/330. 

## Has this been tested?

Note that I didn't yet tested the change on the upgrade script, but firstly want to make that you agree that we can run `yarn` on the version path instead of running in the production path.

- [x] 🙅 no, because this PR does not update server code