### PR TITLE
Apply import interval only when reasonable

### DIFF
--- a/server/tools/peertube-import-videos.ts
+++ b/server/tools/peertube-import-videos.ts
@@ -95,14 +95,15 @@ async function run (url: string, username: string, password: string) {
 
   log.info('Will download and upload %d videos.\n', infoArray.length)
 
+  let skipInterval = 1;
   for (const [ index, info ] of infoArray.entries()) {
     try {
-      if (index > 0 && options.waitInterval) {
+      if (index > 0 && options.waitInterval && !skipInterval) {
         log.info("Wait for %d seconds before continuing.", options.waitInterval / 1000)
         await wait(options.waitInterval)
       }
 
-      await processVideo({
+      skipInterval = await processVideo({
         cwd: options.tmpdir,
         url,
         username,
@@ -134,12 +135,12 @@ async function processVideo (parameters: {
 
   if (options.since && videoInfo.originallyPublishedAt && videoInfo.originallyPublishedAt.getTime() < options.since.getTime()) {
     log.info('Video "%s" has been published before "%s", don\'t upload it.\n', videoInfo.name, formatDate(options.since))
-    return
+    return 1
   }
 
   if (options.until && videoInfo.originallyPublishedAt && videoInfo.originallyPublishedAt.getTime() > options.until.getTime()) {
     log.info('Video "%s" has been published after "%s", don\'t upload it.\n', videoInfo.name, formatDate(options.until))
-    return
+    return 1
   }
 
   const server = buildServer(url)
@@ -155,7 +156,7 @@ async function processVideo (parameters: {
 
   if (data.find(v => v.name === videoInfo.name)) {
     log.info('Video "%s" already exists, don\'t reupload it.\n', videoInfo.name)
-    return
+    return 1
   }
 
   const path = join(cwd, sha256(videoInfo.url) + '.mp4')
@@ -184,6 +185,8 @@ async function processVideo (parameters: {
   } catch (err) {
     log.error(err.message)
   }
+
+  return 0;
 }
 
 async function uploadVideoOnPeerTube (parameters: {

--- a/server/tools/peertube-import-videos.ts
+++ b/server/tools/peertube-import-videos.ts
@@ -95,7 +95,7 @@ async function run (url: string, username: string, password: string) {
 
   log.info('Will download and upload %d videos.\n', infoArray.length)
 
-  let skipInterval = 1;
+  let skipInterval = true
   for (const [ index, info ] of infoArray.entries()) {
     try {
       if (index > 0 && options.waitInterval && !skipInterval) {
@@ -135,12 +135,12 @@ async function processVideo (parameters: {
 
   if (options.since && videoInfo.originallyPublishedAt && videoInfo.originallyPublishedAt.getTime() < options.since.getTime()) {
     log.info('Video "%s" has been published before "%s", don\'t upload it.\n', videoInfo.name, formatDate(options.since))
-    return 1
+    return true
   }
 
   if (options.until && videoInfo.originallyPublishedAt && videoInfo.originallyPublishedAt.getTime() > options.until.getTime()) {
     log.info('Video "%s" has been published after "%s", don\'t upload it.\n', videoInfo.name, formatDate(options.until))
-    return 1
+    return true
   }
 
   const server = buildServer(url)
@@ -156,7 +156,7 @@ async function processVideo (parameters: {
 
   if (data.find(v => v.name === videoInfo.name)) {
     log.info('Video "%s" already exists, don\'t reupload it.\n', videoInfo.name)
-    return 1
+    return true
   }
 
   const path = join(cwd, sha256(videoInfo.url) + '.mp4')
@@ -186,7 +186,7 @@ async function processVideo (parameters: {
     log.error(err.message)
   }
 
-  return 0;
+  return false
 }
 
 async function uploadVideoOnPeerTube (parameters: {


### PR DESCRIPTION
## Description

When importing videos from another service, an interval can be applied between each download.  
It only really makes sense to apply this interval when the last attempted download actually happened, and not when it was skipped.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and **may** still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Note

I originally had to edit code in `dist/` directly, as I needed the functionality immediately.  
I have tested it only manually and it appears to behave as I would expect.

I am not an experienced `type/javascript` programmer and would like to confirm that the fix is as you might expect or want it to be.  
The problem is trivial, but is the solutions satisfactory?