### PR TITLE
Add header Vary Accept-Language

### DIFF
--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -138,31 +138,31 @@ async function generateEmbedHtmlPage (req: express.Request, res: express.Respons
 async function generateWatchHtmlPage (req: express.Request, res: express.Response) {
   const html = await ClientHtml.getWatchHTMLPage(req.params.id + '', req, res)
 
-  return sendHTML(html, res)
+  return sendHTML(html, res, true)
 }
 
 async function generateWatchPlaylistHtmlPage (req: express.Request, res: express.Response) {
   const html = await ClientHtml.getWatchPlaylistHTMLPage(req.params.id + '', req, res)
 
-  return sendHTML(html, res)
+  return sendHTML(html, res, true)
 }
 
 async function generateAccountHtmlPage (req: express.Request, res: express.Response) {
   const html = await ClientHtml.getAccountHTMLPage(req.params.nameWithHost, req, res)
 
-  return sendHTML(html, res)
+  return sendHTML(html, res, true)
 }
 
 async function generateVideoChannelHtmlPage (req: express.Request, res: express.Response) {
   const html = await ClientHtml.getVideoChannelHTMLPage(req.params.nameWithHost, req, res)
 
-  return sendHTML(html, res)
+  return sendHTML(html, res, true)
 }
 
 async function generateActorHtmlPage (req: express.Request, res: express.Response) {
   const html = await ClientHtml.getActorHTMLPage(req.params.nameWithHost, req, res)
 
-  return sendHTML(html, res)
+  return sendHTML(html, res, true)
 }
 
 async function generateManifest (req: express.Request, res: express.Response) {

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -547,9 +547,12 @@ class ClientHtml {
   }
 }
 
-function sendHTML (html: string, res: express.Response) {
+function sendHTML (html: string, res: express.Response, localizedHTML: boolean = false) {
   res.set('Content-Type', 'text/html; charset=UTF-8')
-  res.set('Vary', 'Accept-Language')
+
+  if (localizedHTML) {
+    res.set('Vary', 'Accept-Language')
+  }
 
   return res.send(html)
 }
@@ -579,5 +582,5 @@ export {
 async function generateHTMLPage (req: express.Request, res: express.Response, paramLang?: string) {
   const html = await ClientHtml.getDefaultHTMLPage(req, res, paramLang)
 
-  return sendHTML(html, res)
+  return sendHTML(html, res, true)
 }

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -549,6 +549,7 @@ class ClientHtml {
 
 function sendHTML (html: string, res: express.Response) {
   res.set('Content-Type', 'text/html; charset=UTF-8')
+  res.set('Vary', 'Accept-Language')
 
   return res.send(html)
 }

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -75,7 +75,6 @@ server {
   }
 
   location / {
-    add_header Vary Accept-Language;
     try_files /dev/null @api;
   }
 

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -75,6 +75,7 @@ server {
   }
 
   location / {
+    add_header Vary Accept-Language;
     try_files /dev/null @api;
   }
 


### PR DESCRIPTION
## Description
Since PeerTube uses Accept-Language header to determine response language, the HTTP response should include the `Vary: Accept-Languge` header to ensure no cache will prevent language detection.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
solves #3647

## Has this been tested?
Yes, manually.