### PR TITLE
Fix test documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,7 +85,7 @@ to install the dependencies.
 $ git clone https://github.com/Chocobozzz/PeerTube
 $ cd PeerTube
 $ git remote add me git@github.com:YOUR_GITHUB_USERNAME/PeerTube.git
-$ yarn install --pure-lockfile
+$ yarn install --pure-lockfile --production=false
 ```
 
 Note that development is done on the `develop` branch. If you want to hack on

--- a/support/doc/development/tests.md
+++ b/support/doc/development/tests.md
@@ -2,6 +2,12 @@
 
 ## Preparation
 
+Install devDepedencies:
+
+```bash
+yarn install --pure-lockfile --production=false
+```
+
 Prepare PostgreSQL user so PeerTube can delete/create the test databases:
 
 ```bash
@@ -42,7 +48,7 @@ $ npm run test # See scripts/test.sh to run a particular suite
 Most of tests can be runned using:
 
 ```bash
-TS_NODE_TRANSPILE_ONLY=true mocha -- --timeout 30000 --exit -r ts-node/register -r tsconfig-paths/register --bail server/tests/api/videos/video-transcoder.ts
+TS_NODE_TRANSPILE_ONLY=true npx mocha -- --timeout 30000 --exit -r ts-node/register -r tsconfig-paths/register --bail server/tests/api/videos/video-transcoder.ts
 ```
 
 `server/tests/api/activitypub` tests will need different options:

--- a/support/doc/development/tests.md
+++ b/support/doc/development/tests.md
@@ -2,7 +2,7 @@
 
 ## Preparation
 
-Install devDepedencies:
+If you not already installed devDependencies:
 
 ```bash
 yarn install --pure-lockfile --production=false


### PR DESCRIPTION
## Description

The previous documentation only mentioned `yarn install --pure-lock`. But in order to develop or launch unit tests, it is required to also install devDependencies (`yarn install --pure-lock --production=false`).

If you don't do this, unit tests won't launch (because mocha and ts-node will be missing).

I also changed the command for launching only some unit tests: using «npx mocha» instead of «mocha», so that it uses the local version (no need to install mocha globally, and no risk to have the wrong mocha version).