### PR TITLE
Update iframe allowfullscreen to current method

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -553,6 +553,7 @@
  * wakutiteo
  * wonderingdane
  * zeynepeliacik
+ * Nico Rikken
 
 
 # Design

--- a/client/src/assets/player/utils.ts
+++ b/client/src/assets/player/utils.ts
@@ -50,7 +50,7 @@ function buildVideoOrPlaylistEmbed (embedUrl: string, embedTitle: string) {
   iframe.height = '315'
   iframe.src = embedUrl
   iframe.frameBorder = '0'
-  iframe.allowFullscreen = true
+  iframe.allow = 'fullscreen'
   iframe.sandbox.add('allow-same-origin', 'allow-scripts', 'allow-popups')
 
   return iframe.outerHTML


### PR DESCRIPTION
The current PeerTube frontend generates iframe code that contains a old method
of allowing fullscreen: `allowfullscreen=""`. This method is surpassed by the
`allow="fullscreen"` property. This commit changes the rendered output to the
new code. I have tested it in Gitpod and the change worked as expected.

More documentation on this property:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allowfullscreen

Signed-off-by: Nico Rikken <nico@nicorikken.eu>