### PR TITLE
scripts/test: make MacOS compatible

### DIFF
--- a/scripts/clean/server/test.sh
+++ b/scripts/clean/server/test.sh
@@ -20,9 +20,9 @@ dropRedis () {
   port=$((9000+$1))
   host="localhost"
 
-  redis-cli -h "$host" KEYS "bull-localhost:$port*" | grep -v empty | xargs --no-run-if-empty redis-cli -h "$host" DEL
-  redis-cli -h "$host" KEYS "redis-localhost:$port*" | grep -v empty | xargs --no-run-if-empty redis-cli -h "$host" DEL
-  redis-cli -h "$host" KEYS "*redis-localhost:$port-" | grep -v empty | xargs --no-run-if-empty redis-cli -h "$host" DEL
+  redis-cli -h "$host" KEYS "bull-localhost:$port*" | grep -v empty | xargs -r redis-cli -h "$host" DEL
+  redis-cli -h "$host" KEYS "redis-localhost:$port*" | grep -v empty | xargs -r redis-cli -h "$host" DEL
+  redis-cli -h "$host" KEYS "*redis-localhost:$port-" | grep -v empty | xargs -r redis-cli -h "$host" DEL
 }
 
 seq=$(seq 1 6)


### PR DESCRIPTION
Add support for running tests with GNU xargs (which are used by MacOS).

```
man xargs:
     -r      Compatibility with GNU xargs.  The GNU version of xargs runs the utility argument at least once, even if xargs input is empty, and it supports a -r option to inhibit this
             behavior.  The FreeBSD version of xargs does not run the utility argument on empty input, but it supports the -r option for command-line compatibility with GNU xargs, but the
             -r option does nothing in the FreeBSD version of xargs.
```
