### PR TITLE
Add plugin helper function to get videos storage path

### DIFF
--- a/server/lib/plugins/plugin-helpers-builder.ts
+++ b/server/lib/plugins/plugin-helpers-builder.ts
@@ -148,6 +148,10 @@ function buildConfigHelpers () {
 
     getServerConfig () {
       return ServerConfigManager.Instance.getServerConfig()
+    },
+
+    getVideosStoragePath () {
+      return CONFIG.STORAGE.VIDEOS_DIR
     }
   }
 }

--- a/server/tests/fixtures/peertube-plugin-test-four/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-four/main.js
@@ -76,6 +76,12 @@ async function register ({
       return res.json({ serverConfig })
     })
 
+    router.get('/videos-storage-path', async (req, res) => {
+      const videosStoragePath = await peertubeHelpers.config.getVideosStoragePath()
+
+      return res.json({ videosStoragePath })
+    })
+
     router.get('/static-route', async (req, res) => {
       const staticRoute = peertubeHelpers.plugin.getBaseStaticRoute()
 

--- a/server/tests/plugins/plugin-helpers.ts
+++ b/server/tests/plugins/plugin-helpers.ts
@@ -73,6 +73,17 @@ describe('Test plugin helpers', function () {
       expect(res.body.serverConfig).to.exist
       expect(res.body.serverConfig.instance.name).to.equal('PeerTube')
     })
+
+    it('Should have the correct config', async function () {
+      const res = await makeGetRequest({
+        url: servers[0].url,
+        path: '/plugins/test-four/router/videos-storage-path',
+        expectedStatus: HttpStatusCode.OK_200
+      })
+
+      expect(res.body.videosStoragePath).to.exist
+      expect(res.body.videosStoragePath).to.equal('storage/videos/')
+    })
   })
 
   describe('Server', function () {

--- a/server/types/plugins/register-server-option.model.ts
+++ b/server/types/plugins/register-server-option.model.ts
@@ -41,6 +41,8 @@ export type PeerTubeHelpers = {
     getWebserverUrl: () => string
 
     getServerConfig: () => Promise<ServerConfig>
+
+    getVideosStoragePath: () => string
   }
 
   moderation: {


### PR DESCRIPTION
## Description

Add plugin helper function to get videos storage path `CONFIG.STORAGE.VIDEOS_DIR`.
At the moment, a plugin doesn't have a clue on where a video is actually stored and the video file isn't accessible deterministically.

I actually exposed only the videos storage path but maybe other storage info should be exposed.
OR maybe none of the storage informations should leak to the plugin.

About the naming you might `getVideosdirectoryPath` instead of `getVideosStoragePath`, your call.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite

