### PR TITLE
Update angular.es-ES.xlf

### DIFF
--- a/client/src/locale/angular.es-ES.xlf
+++ b/client/src/locale/angular.es-ES.xlf
@@ -5273,7 +5273,7 @@ color: red;
       </trans-unit>
       <trans-unit id="9012586956848595996" datatype="html">
         <source>EMAIL</source>
-        <target state="translated">ORREO ELECTRÓNICO</target>
+        <target state="translated">CORREO ELECTRÓNICO</target>
         <context-group purpose="location"><context context-type="sourcefile">src/app/+my-account/my-account-settings/my-account-settings.component.html</context><context context-type="linenumber">67</context></context-group>
       </trans-unit>
       <trans-unit id="7752239348028675311" datatype="html">


### PR DESCRIPTION
An update needed on weblate, to avoid reproduce this display i18n little bug ?

## Description
I think that this small problem of translation comes from weblate, I make the PR for explanation, and in case the imports i18n is finished, the Spanish language being translated has 100%.
A string on the right of the capture remains without translation. 

## Has this been tested?
- [x ] 🙋 No, because you have to make a decision about what to do.
- 
## Screenshots
![error-courrier-electronique](https://user-images.githubusercontent.com/52655832/145614713-2bb35998-c03d-4a5c-8b6a-b87b143d622b.png)
