### PR TITLE
Added "zxx" (no linguistic content) in available video languages

### DIFF
--- a/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
+++ b/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
@@ -178,10 +178,11 @@ export class VideoEditComponent implements OnInit, OnDestroy {
       .subscribe(res => {
         this.videoLanguages = res.languages
           .map(l => {
-            if (l.id === 'zxx') return { ...l, group: $localize`Special values`, groupOrder: -1 }
+            if (l.id === 'zxx') return { ...l, group: $localize`Other`, groupOrder: 1 }
+
             return res.about.instance.languages.includes(l.id)
               ? { ...l, group: $localize`Instance languages`, groupOrder: 0 }
-              : { ...l, group: $localize`All languages`, groupOrder: 1 }
+              : { ...l, group: $localize`All languages`, groupOrder: 2 }
           })
           .sort((a, b) => a.groupOrder - b.groupOrder)
       })

--- a/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
+++ b/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
@@ -178,7 +178,7 @@ export class VideoEditComponent implements OnInit, OnDestroy {
       .subscribe(res => {
         this.videoLanguages = res.languages
           .map(l => {
-            if (l.id === "zxx") return { ...l, group: $localize`Special values`, groupOrder: -1}
+            if (l.id === 'zxx') return { ...l, group: $localize`Special values`, groupOrder: -1 }
             return res.about.instance.languages.includes(l.id)
               ? { ...l, group: $localize`Instance languages`, groupOrder: 0 }
               : { ...l, group: $localize`All languages`, groupOrder: 1 }

--- a/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
+++ b/client/src/app/+videos/+video-edit/shared/video-edit.component.ts
@@ -178,6 +178,7 @@ export class VideoEditComponent implements OnInit, OnDestroy {
       .subscribe(res => {
         this.videoLanguages = res.languages
           .map(l => {
+            if (l.id === "zxx") return { ...l, group: $localize`Special values`, groupOrder: -1}
             return res.about.instance.languages.includes(l.id)
               ? { ...l, group: $localize`Instance languages`, groupOrder: 0 }
               : { ...l, group: $localize`All languages`, groupOrder: 1 }

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -1075,7 +1075,9 @@ function buildLanguages () {
     epo: true, // Esperanto
     tlh: true, // Klingon
     jbo: true, // Lojban
-    avk: true // Kotava
+    avk: true, // Kotava
+
+    zxx: true  // No linguistic content (ISO-639-2)
   }
 
   // Only add ISO639-1 languages and some sign languages (ISO639-3)

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -1077,7 +1077,7 @@ function buildLanguages () {
     jbo: true, // Lojban
     avk: true, // Kotava
 
-    zxx: true  // No linguistic content (ISO-639-2)
+    zxx: true // No linguistic content (ISO-639-2)
   }
 
   // Only add ISO639-1 languages and some sign languages (ISO639-3)


### PR DESCRIPTION
## Description

It adds `zxx` as part of the available "language codes" in the backend. `zxx` is the ISO-639 code for the absence of linguistic content, according to Wikipedia (https://en.wikipedia.org/wiki/ISO_639): 

> No linguistic information at all (added 2006-01-11). The content (e.g. graphics, photos or audio/video records not including text in a human language, or technical metadata and most programming source code) is usable as is with any language and should not be translated (except for its description possibly associated in separate contents, or for non-essential fragments of the content).

As this "language" also appeared in the group "All languages" in the forms, I had to create a dedicated group for it. Feel free to suggest better names 😉.

## Related issues

Closes https://github.com/Chocobozzz/PeerTube/issues/1489

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

In the video-edit form:

![image](https://user-images.githubusercontent.com/20014332/145713560-54d7c075-5c18-4254-928e-7f1145b0d542.png)

![image](https://user-images.githubusercontent.com/20014332/145713566-83515c2f-4044-4064-8d25-4e4cfb829c26.png)

When watching the video : 
![image](https://user-images.githubusercontent.com/20014332/145713593-204968e3-c5e5-415b-a5c7-7f0331852832.png)
