### PR TITLE
Fix typo for cli redundancy action

### DIFF
--- a/server/tools/peertube-redundancy.ts
+++ b/server/tools/peertube-redundancy.ts
@@ -12,7 +12,7 @@ import { assignToken, buildServer, getServerCredentials } from './cli'
 import bytes = require('bytes')
 
 program
-  .name('plugins')
+  .name('redundancy')
   .usage('[command] [options]')
 
 program


### PR DESCRIPTION
## Description

I think this is a copy/paste typo.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
