### PR TITLE
Fix plugin storage return value when storing a Json array

### DIFF
--- a/server/models/server/plugin.ts
+++ b/server/models/server/plugin.ts
@@ -197,15 +197,11 @@ export class PluginModel extends Model<Partial<AttributesOnly<PluginModel>>> {
         if (!c) return undefined
         const value = c.value
 
-        if (typeof value === 'string' && value.startsWith('{')) {
-          try {
-            return JSON.parse(value)
-          } catch {
-            return value
-          }
+        try {
+          return JSON.parse(value)
+        } catch {
+          return value
         }
-
-        return c.value
       })
   }
 

--- a/server/tests/fixtures/peertube-plugin-test-six/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-six/main.js
@@ -11,9 +11,14 @@ async function register ({
   {
     await storageManager.storeData('superkey', { value: 'toto' })
     await storageManager.storeData('anotherkey', { value: 'toto2' })
+    await storageManager.storeData('storedArrayKey', ['toto', 'toto2'])
 
     const result = await storageManager.getData('superkey')
     logger.info('superkey stored value is %s', result.value)
+
+    const storedArrayValue = await storageManager.getData('storedArrayKey')
+    logger.info('storedArrayKey value type is %s', typeof storedArrayValue)
+    logger.info('storedArrayKey stored value is %s', storedArrayValue.join(', '))
   }
 
   {

--- a/server/tests/fixtures/peertube-plugin-test-six/main.js
+++ b/server/tests/fixtures/peertube-plugin-test-six/main.js
@@ -17,7 +17,7 @@ async function register ({
     logger.info('superkey stored value is %s', result.value)
 
     const storedArrayValue = await storageManager.getData('storedArrayKey')
-    logger.info('storedArrayKey value type is %s', typeof storedArrayValue)
+    logger.info('storedArrayKey isArray is %s', Array.isArray(storedArrayValue) ? 'true' : 'false')
     logger.info('storedArrayKey stored value is %s', storedArrayValue.join(', '))
   }
 

--- a/server/tests/plugins/plugin-storage.ts
+++ b/server/tests/plugins/plugin-storage.ts
@@ -27,9 +27,13 @@ describe('Test plugin storage', function () {
   })
 
   describe('DB storage', function () {
-
     it('Should correctly store a subkey', async function () {
       await server.servers.waitUntilLog('superkey stored value is toto')
+    })
+
+    it('Should correctly retrieve an array as array from the storage.', async function () {
+      await server.servers.waitUntilLog('storedArrayKey value type is array')
+      await server.servers.waitUntilLog('storedArrayKey stored value is toto, toto2')
     })
   })
 

--- a/server/tests/plugins/plugin-storage.ts
+++ b/server/tests/plugins/plugin-storage.ts
@@ -32,7 +32,7 @@ describe('Test plugin storage', function () {
     })
 
     it('Should correctly retrieve an array as array from the storage.', async function () {
-      await server.servers.waitUntilLog('storedArrayKey value type is array')
+      await server.servers.waitUntilLog('storedArrayKey isArray is true')
       await server.servers.waitUntilLog('storedArrayKey stored value is toto, toto2')
     })
   })


### PR DESCRIPTION
## Description

Fix plugin storage return value when storing a Json array.
We may as well entirely rely on `JSON.parse` which is foolproof.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite