### PR TITLE
Add video caption created and deleted hooks

### DIFF
--- a/server/controllers/api/videos/captions.ts
+++ b/server/controllers/api/videos/captions.ts
@@ -12,6 +12,7 @@ import { federateVideoIfNeeded } from '../../../lib/activitypub/videos'
 import { asyncMiddleware, asyncRetryTransactionMiddleware, authenticate } from '../../../middlewares'
 import { addVideoCaptionValidator, deleteVideoCaptionValidator, listVideoCaptionsValidator } from '../../../middlewares/validators'
 import { VideoCaptionModel } from '../../../models/video/video-caption'
+import { Hooks } from '@server/lib/plugins/hooks'
 
 const reqVideoCaptionAdd = createReqFiles(
   [ 'captionfile' ],
@@ -75,6 +76,8 @@ async function addVideoCaption (req: express.Request, res: express.Response) {
     await federateVideoIfNeeded(video, false, t)
   })
 
+  Hooks.runAction('action:api.video-caption.created', { caption: videoCaption, req, res })
+
   return res.status(HttpStatusCode.NO_CONTENT_204).end()
 }
 
@@ -90,6 +93,8 @@ async function deleteVideoCaption (req: express.Request, res: express.Response) 
   })
 
   logger.info('Video caption %s of video %s deleted.', videoCaption.language, video.uuid)
+
+  Hooks.runAction('action:api.video-caption.deleted', { caption: videoCaption, req, res })
 
   return res.type('json').status(HttpStatusCode.NO_CONTENT_204).end()
 }

--- a/server/tests/fixtures/peertube-plugin-test/main.js
+++ b/server/tests/fixtures/peertube-plugin-test/main.js
@@ -13,6 +13,9 @@ async function register ({ registerHook, registerSetting, settingsManager, stora
     'action:api.video-comment-reply.created',
     'action:api.video-comment.deleted',
 
+    'action:api.video-caption.created',
+    'action:api.video-caption.deleted',
+
     'action:api.user.blocked',
     'action:api.user.unblocked',
     'action:api.user.registered',

--- a/server/tests/plugins/action-hooks.ts
+++ b/server/tests/plugins/action-hooks.ts
@@ -103,6 +103,20 @@ describe('Test plugin action hooks', function () {
     })
   })
 
+  describe('Captions hooks', function () {
+    it('Should run action:api.video-caption.created', async function () {
+      await servers[0].captions.add({ videoId: videoUUID, language: 'en', fixture: 'subtitle-good.srt' })
+
+      await checkHook('action:api.video-caption.created')
+    })
+
+    it('Should run action:api.video-caption.deleted', async function () {
+      await servers[0].captions.delete({ videoId: videoUUID, language: 'en' })
+
+      await checkHook('action:api.video-caption.deleted')
+    })
+  })
+
   describe('Users hooks', function () {
     let userId: number
 

--- a/shared/models/plugins/server/server-hook.model.ts
+++ b/shared/models/plugins/server/server-hook.model.ts
@@ -115,6 +115,11 @@ export const serverActionHookObject = {
   // Fired when a comment (thread or reply) is deleted
   'action:api.video-comment.deleted': true,
 
+  // Fired when a caption is created
+  'action:api.video-caption.created': true,
+  // Fired when a caption is deleted
+  'action:api.video-caption.deleted': true,
+
   // Fired when a user is blocked (banned)
   'action:api.user.blocked': true,
   // Fired when a user is unblocked (unbanned)


### PR DESCRIPTION
## Description

Add video caption `created` and `deleted` hooks.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite
