### PR TITLE
Add config option to disable video history for new users

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-basic-configuration.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-basic-configuration.component.html
@@ -235,6 +235,15 @@
 
           <div *ngIf="formErrors.user.videoQuotaDaily" class="form-error">{{ formErrors.user.videoQuotaDaily }}</div>
         </div>
+
+        <ng-container formGroupName="history">
+          <div class="form-group">
+            <my-peertube-checkbox
+              inputName="userHistoryEnabledByDefault" formControlName="enabledByDefault"
+              i18n-labelText labelText="Enable user video history for new users"
+            ></my-peertube-checkbox>
+          </div>
+        </ng-container>
       </ng-container>
 
     </div>

--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.ts
@@ -162,7 +162,10 @@ export class EditCustomConfigComponent extends FormReactive implements OnInit {
       },
       user: {
         videoQuota: USER_VIDEO_QUOTA_VALIDATOR,
-        videoQuotaDaily: USER_VIDEO_QUOTA_DAILY_VALIDATOR
+        videoQuotaDaily: USER_VIDEO_QUOTA_DAILY_VALIDATOR,
+        history: {
+          enabledByDefault: null
+        }
       },
       videoChannels: {
         maxPerUser: MAX_VIDEO_CHANNELS_PER_USER_VALIDATOR

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -319,6 +319,9 @@ user:
   # -1 == unlimited
   video_quota: -1
   video_quota_daily: -1
+  # Whether video history should be enabled by default for new users or not
+  history:
+    enabled_by_default: true
 
 video_channels:
   max_per_user: 20 # Allows each user to create up to 20 video channels.

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -327,6 +327,9 @@ user:
   # -1 == unlimited
   video_quota: -1
   video_quota_daily: -1
+  # Whether video history should be enabled by default for new users or not
+  history:
+    enabled_by_default: true
 
 video_channels:
   max_per_user: 20 # Allows each user to create up to 20 video channels.

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -206,7 +206,10 @@ function customConfig (): CustomConfig {
     },
     user: {
       videoQuota: CONFIG.USER.VIDEO_QUOTA,
-      videoQuotaDaily: CONFIG.USER.VIDEO_QUOTA_DAILY
+      videoQuotaDaily: CONFIG.USER.VIDEO_QUOTA_DAILY,
+      history: {
+        enabledByDefault: CONFIG.USER.HISTORY.ENABLED_BY_DEFAULT
+      }
     },
     videoChannels: {
       maxPerUser: CONFIG.VIDEO_CHANNELS.MAX_PER_USER

--- a/server/controllers/api/users/index.ts
+++ b/server/controllers/api/users/index.ts
@@ -188,6 +188,7 @@ async function createUser (req: express.Request, res: express.Response) {
     role: body.role,
     videoQuota: body.videoQuota,
     videoQuotaDaily: body.videoQuotaDaily,
+    videosHistoryEnabled: CONFIG.USER.HISTORY.ENABLED_BY_DEFAULT,
     adminFlags: body.adminFlags || UserAdminFlag.NONE
   }) as MUser
 

--- a/server/controllers/api/users/index.ts
+++ b/server/controllers/api/users/index.ts
@@ -238,6 +238,7 @@ async function registerUser (req: express.Request, res: express.Response) {
     role: UserRole.USER,
     videoQuota: CONFIG.USER.VIDEO_QUOTA,
     videoQuotaDaily: CONFIG.USER.VIDEO_QUOTA_DAILY,
+    videosHistoryEnabled: CONFIG.USER.HISTORY.ENABLED_BY_DEFAULT,
     emailVerified: CONFIG.SIGNUP.REQUIRES_EMAIL_VERIFICATION ? false : null
   })
 

--- a/server/controllers/static.ts
+++ b/server/controllers/static.ts
@@ -275,7 +275,10 @@ async function generateNodeinfo (req: express.Request, res: express.Response) {
         },
         user: {
           videoQuota: CONFIG.USER.VIDEO_QUOTA,
-          videoQuotaDaily: CONFIG.USER.VIDEO_QUOTA_DAILY
+          videoQuotaDaily: CONFIG.USER.VIDEO_QUOTA_DAILY,
+          history: {
+            enabledByDefault: CONFIG.USER.HISTORY.ENABLED_BY_DEFAULT
+          }
         },
         trending: {
           videos: {

--- a/server/initializers/checker-before-init.ts
+++ b/server/initializers/checker-before-init.ts
@@ -18,7 +18,7 @@ function checkMissedConfig () {
     'storage.avatars', 'storage.videos', 'storage.logs', 'storage.previews', 'storage.thumbnails', 'storage.torrents', 'storage.cache',
     'storage.redundancy', 'storage.tmp', 'storage.streaming_playlists', 'storage.plugins',
     'log.level',
-    'user.video_quota', 'user.video_quota_daily',
+    'user.video_quota', 'user.video_quota_daily', 'user.history.enabled_by_default',
     'video_channels.max_per_user',
     'csp.enabled', 'csp.report_only', 'csp.report_uri',
     'security.frameguard.enabled',

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -256,7 +256,10 @@ const CONFIG = {
   },
   USER: {
     get VIDEO_QUOTA () { return parseBytes(config.get<number>('user.video_quota')) },
-    get VIDEO_QUOTA_DAILY () { return parseBytes(config.get<number>('user.video_quota_daily')) }
+    get VIDEO_QUOTA_DAILY () { return parseBytes(config.get<number>('user.video_quota_daily')) },
+    HISTORY: {
+      get ENABLED_BY_DEFAULT () { return config.get<boolean>('user.history.enabled_by_default') }
+    }
   },
   VIDEO_CHANNELS: {
     get MAX_PER_USER () { return config.get<number>('video_channels.max_per_user') }

--- a/server/lib/server-config-manager.ts
+++ b/server/lib/server-config-manager.ts
@@ -204,7 +204,10 @@ class ServerConfigManager {
       },
       user: {
         videoQuota: CONFIG.USER.VIDEO_QUOTA,
-        videoQuotaDaily: CONFIG.USER.VIDEO_QUOTA_DAILY
+        videoQuotaDaily: CONFIG.USER.VIDEO_QUOTA_DAILY,
+        history: {
+          enabledByDefault: CONFIG.USER.HISTORY.ENABLED_BY_DEFAULT
+        }
       },
       videoChannels: {
         maxPerUser: CONFIG.VIDEO_CHANNELS.MAX_PER_USER

--- a/server/middlewares/validators/config.ts
+++ b/server/middlewares/validators/config.ts
@@ -37,6 +37,7 @@ const customConfigUpdateValidator = [
 
   body('user.videoQuota').custom(isUserVideoQuotaValid).withMessage('Should have a valid video quota'),
   body('user.videoQuotaDaily').custom(isUserVideoQuotaDailyValid).withMessage('Should have a valid daily video quota'),
+  body('user.history.enabledByDefault').isBoolean().withMessage('Should have a valid enabled by default history boolean'),
 
   body('videoChannels.maxPerUser').isInt().withMessage("Should have a valid maximum amount of video channels per user"),
 

--- a/server/tests/api/check-params/config.ts
+++ b/server/tests/api/check-params/config.ts
@@ -91,7 +91,10 @@ describe('Test config API validators', function () {
     },
     user: {
       videoQuota: 5242881,
-      videoQuotaDaily: 318742
+      videoQuotaDaily: 318742,
+      history: {
+        enabledByDefault: true
+      }
     },
     videoChannels: {
       maxPerUser: 20

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -60,6 +60,7 @@ function checkInitialConfig (server: PeerTubeServer, data: CustomConfig) {
 
   expect(data.user.videoQuota).to.equal(5242880)
   expect(data.user.videoQuotaDaily).to.equal(-1)
+  expect(data.user.history.enabledByDefault).to.be.false
 
   expect(data.videoChannels.maxPerUser).to.equal(20)
 
@@ -162,6 +163,7 @@ function checkUpdatedConfig (data: CustomConfig) {
 
   expect(data.user.videoQuota).to.equal(5242881)
   expect(data.user.videoQuotaDaily).to.equal(318742)
+  expect(data.user.history.enabledByDefault).to.be.false
 
   expect(data.videoChannels.maxPerUser).to.equal(24)
 
@@ -289,7 +291,10 @@ const newCustomConfig: CustomConfig = {
   },
   user: {
     videoQuota: 5242881,
-    videoQuotaDaily: 318742
+    videoQuotaDaily: 318742,
+    history: {
+      enabledByDefault: false
+    }
   },
   videoChannels: {
     maxPerUser: 24

--- a/shared/extra-utils/server/config-command.ts
+++ b/shared/extra-utils/server/config-command.ts
@@ -231,7 +231,10 @@ export class ConfigCommand extends AbstractCommand {
       },
       user: {
         videoQuota: 5242881,
-        videoQuotaDaily: 318742
+        videoQuotaDaily: 318742,
+        history: {
+          enabledByDefault: true
+        }
       },
       videoChannels: {
         maxPerUser: 20

--- a/shared/models/server/custom-config.model.ts
+++ b/shared/models/server/custom-config.model.ts
@@ -98,6 +98,9 @@ export interface CustomConfig {
   user: {
     videoQuota: number
     videoQuotaDaily: number
+    history: {
+      enabledByDefault: boolean
+    }
   }
 
   videoChannels: {

--- a/shared/models/server/server-config.model.ts
+++ b/shared/models/server/server-config.model.ts
@@ -227,6 +227,9 @@ export interface ServerConfig {
   user: {
     videoQuota: number
     videoQuotaDaily: number
+    history: {
+      enabledByDefault: boolean
+    }
   }
 
   videoChannels: {


### PR DESCRIPTION
## Description

I added a config option (`user.history.enabled_by_default`) and a checkbox in the web config editor that allows admins to enable/disable video history by default for new users.

## Related issues

Closes #1499

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

What unit tests should I do, and where should I put them in?

Aside from these, I manually tested the feature and it worked. 

## Screenshots

![image](https://user-images.githubusercontent.com/20014332/146648655-eb260fb1-9381-48c1-be7f-6d0b105b4241.png)

