### PR TITLE
Move zxx to its own group in select-languages component

### DIFF
--- a/client/src/app/shared/shared-forms/select/select-languages.component.ts
+++ b/client/src/app/shared/shared-forms/select/select-languages.component.ts
@@ -39,12 +39,12 @@ export class SelectLanguagesComponent implements ControlValueAccessor, OnInit {
     this.server.getVideoLanguages()
       .subscribe(
         languages => {
-          this.availableLanguages = [{
+          this.availableLanguages = [ {
             label: $localize`Unknown language`,
             id: '_unknown',
             group: this.allLanguagesGroup,
             groupOrder: this.allLanguagesGroupOrder
-          }]
+          } ]
 
           this.availableLanguages = this.availableLanguages
             .concat(languages.map(l => {

--- a/client/src/app/shared/shared-forms/select/select-languages.component.ts
+++ b/client/src/app/shared/shared-forms/select/select-languages.component.ts
@@ -23,6 +23,7 @@ export class SelectLanguagesComponent implements ControlValueAccessor, OnInit {
   availableLanguages: SelectOptionsItem[] = []
 
   allLanguagesGroup = $localize`All languages`
+  allLanguagesGroupOrder = 1
 
   // Fix a bug on ng-select when we update items after we selected items
   private toWrite: any
@@ -38,10 +39,16 @@ export class SelectLanguagesComponent implements ControlValueAccessor, OnInit {
     this.server.getVideoLanguages()
       .subscribe(
         languages => {
-          this.availableLanguages = [ { label: $localize`Unknown language`, id: '_unknown', group: this.allLanguagesGroup } ]
+          this.availableLanguages = [ { label: $localize`Unknown language`, id: '_unknown', group: this.allLanguagesGroup,
+                                        groupOrder: this.allLanguagesGroupOrder } ]
 
           this.availableLanguages = this.availableLanguages
-            .concat(languages.map(l => ({ label: l.label, id: l.id, group: this.allLanguagesGroup })))
+            .concat(languages.map(l => {
+              if (l.id === 'zxx') return { label: l.label, id: l.id, group: $localize`Other`, groupOrder: 0 }
+              return { label: l.label, id: l.id, group: this.allLanguagesGroup, groupOrder: this.allLanguagesGroupOrder }
+            }))
+
+          this.availableLanguages.sort((a, b) => a.groupOrder - b.groupOrder)
 
           this.loaded = true
           this.writeValue(this.toWrite)

--- a/client/src/app/shared/shared-forms/select/select-languages.component.ts
+++ b/client/src/app/shared/shared-forms/select/select-languages.component.ts
@@ -20,10 +20,9 @@ export class SelectLanguagesComponent implements ControlValueAccessor, OnInit {
   @Input() maxLanguages: number
 
   selectedLanguages: ItemSelectCheckboxValue[]
-  availableLanguages: SelectOptionsItem[] = []
+  availableLanguages: (SelectOptionsItem & { groupOrder: number })[] = []
 
   allLanguagesGroup = $localize`All languages`
-  allLanguagesGroupOrder = 1
 
   // Fix a bug on ng-select when we update items after we selected items
   private toWrite: any
@@ -43,13 +42,13 @@ export class SelectLanguagesComponent implements ControlValueAccessor, OnInit {
             label: $localize`Unknown language`,
             id: '_unknown',
             group: this.allLanguagesGroup,
-            groupOrder: this.allLanguagesGroupOrder
+            groupOrder: 1
           } ]
 
           this.availableLanguages = this.availableLanguages
             .concat(languages.map(l => {
               if (l.id === 'zxx') return { label: l.label, id: l.id, group: $localize`Other`, groupOrder: 0 }
-              return { label: l.label, id: l.id, group: this.allLanguagesGroup, groupOrder: this.allLanguagesGroupOrder }
+              return { label: l.label, id: l.id, group: this.allLanguagesGroup, groupOrder: 1 }
             }))
 
           this.availableLanguages.sort((a, b) => a.groupOrder - b.groupOrder)

--- a/client/src/app/shared/shared-forms/select/select-languages.component.ts
+++ b/client/src/app/shared/shared-forms/select/select-languages.component.ts
@@ -39,8 +39,12 @@ export class SelectLanguagesComponent implements ControlValueAccessor, OnInit {
     this.server.getVideoLanguages()
       .subscribe(
         languages => {
-          this.availableLanguages = [ { label: $localize`Unknown language`, id: '_unknown', group: this.allLanguagesGroup,
-                                        groupOrder: this.allLanguagesGroupOrder } ]
+          this.availableLanguages = [{
+            label: $localize`Unknown language`,
+            id: '_unknown',
+            group: this.allLanguagesGroup,
+            groupOrder: this.allLanguagesGroupOrder
+          }]
 
           this.availableLanguages = this.availableLanguages
             .concat(languages.map(l => {

--- a/client/src/types/select-options-item.model.ts
+++ b/client/src/types/select-options-item.model.ts
@@ -4,6 +4,7 @@ export interface SelectOptionsItem {
   description?: string
   group?: string
   groupLabel?: string
+  groupOrder?: number
 }
 
 export interface SelectChannelItem extends SelectOptionsItem {

--- a/client/src/types/select-options-item.model.ts
+++ b/client/src/types/select-options-item.model.ts
@@ -4,7 +4,6 @@ export interface SelectOptionsItem {
   description?: string
   group?: string
   groupLabel?: string
-  groupOrder?: number
 }
 
 export interface SelectChannelItem extends SelectOptionsItem {


### PR DESCRIPTION
## Description

#4631 introduced the `zxx` language code and put it in a "Other" group in the language selector of the video-edit page. However, `zxx` was not in a dedicated group in the more widely-used `my-select-languages` component.

This PR adds a `groupOrder` attribute to `SelectOptionsItem` and puts `zxx` in group "Other" (order 0), and all languages remain in the "All languages" group (order 1).

## Related issues

None.

## Has this been tested?

- [x] 🙅 no, because this PR does not update server code

## Screenshots

![image](https://user-images.githubusercontent.com/20014332/147073065-16037197-e6cd-457f-9637-9111441aeb21.png)

