### PR TITLE
Updated notification types in openapi reference

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: PeerTube
-  version: 3.3.0
+  version: 4.0.0
   contact:
     name: PeerTube Community
     url: https://joinpeertube.org
@@ -7228,6 +7228,14 @@ components:
             - `13` NEW_INSTANCE_FOLLOWER
 
             - `14` AUTO_INSTANCE_FOLLOWING
+            
+            - `15` ABUSE_STATE_CHANGE
+            
+            - `16` ABUSE_NEW_MESSAGE
+            
+            - `17` NEW_PLUGIN_VERSION
+            
+            - `18` NEW_PEERTUBE_VERSION
         read:
           type: boolean
         video:


### PR DESCRIPTION
## Description

The API reference was falling behind: I added all the new types in the openapi reference.

## Related issues

Relates to https://github.com/Chocobozzz/PeerTube/issues/1565

## Has this been tested?

- [x] 🙅 no, because this PR does not update server code

## Screenshots

![image](https://user-images.githubusercontent.com/20014332/147074742-8dd6d50a-0884-4676-b3a4-8e074c61aa5b.png)

