### PR TITLE
Adds script to regenerate transcoding jobs.

### DIFF
--- a/scripts/regenerate-hls-transcoding-job.ts
+++ b/scripts/regenerate-hls-transcoding-job.ts
@@ -1,0 +1,64 @@
+import { registerTSPaths } from '../server/helpers/register-ts-paths'
+registerTSPaths()
+
+import { program } from 'commander'
+import { VideoModel } from '../server/models/video/video'
+import { initDatabaseModels } from '../server/initializers/database'
+import { JobQueue } from '../server/lib/job-queue'
+import { computeResolutionsToTranscode } from '@server/helpers/ffprobe-utils'
+import { VideoState, VideoTranscodingPayload } from '@shared/models'
+import { CONFIG } from '@server/initializers/config'
+import { isUUIDValid, toCompleteUUID } from '@server/helpers/custom-validators/misc'
+import { addTranscodingJob } from '@server/lib/video'
+import { map } from 'bluebird'
+
+program
+  .description('Regenerate HLS transcoding jobs')
+  .parse(process.argv)
+
+run()
+  .then(() => process.exit(0))
+  .catch(err => console.error(err))
+
+async function run () {
+  await initDatabaseModels(true)
+
+  const videos = await VideoModel.listLocal()
+
+  await map(videos, v => {
+    return createTranscodingJob(v.uuid)
+      .catch(err => console.error('Cannot create transcoding job for video %s.', v.url, err))
+  }, { concurrency: 1 })
+}
+
+async function createTranscodingJob (uuid: string) {
+  const video = await VideoModel.loadAndPopulateAccountAndServerAndTags(uuid)
+  if (!video) throw new Error('Video not found.')
+
+  const dataInput: VideoTranscodingPayload[] = []
+  const resolution = video.getMaxQualityFile().resolution
+
+  const resolutionsEnabled = computeResolutionsToTranscode(resolution, 'vod').concat([ resolution ])
+
+  for (const resolution of resolutionsEnabled) {
+    dataInput.push({
+      type: 'new-resolution-to-hls',
+      videoUUID: video.uuid,
+      resolution,
+      isPortraitMode: false,
+      copyCodecs: false,
+      isNewVideo: false,
+      isMaxQuality: false
+    })
+  }
+
+  JobQueue.Instance.init()
+
+  video.state = VideoState.TO_TRANSCODE
+  await video.save()
+
+  for (const d of dataInput) {
+    await addTranscodingJob(d, {})
+    console.log('Transcoding job for video %s created.', video.uuid)
+  }
+}


### PR DESCRIPTION
## Description

I needed to run a migration to HLS on my 3.4.1 instance.
So this code works on 3.4.1, and not on 4.0.0 (Actually, I did start dev on 4.0.0 realizing later that it didn't work :facepalm: )

It just needs minor adjustments to make it work for 4.0.0.

I create this PR more for doc than to really help the project. Sorry project, I don't have the bandwidth to do more :/
I'll just close the PR once submitted, it is more for documentation for others.

The code is just a mix of the script to regenerate thumbnails and to start a new transcoding.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/2148

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
