### PR TITLE
Give the ability to define python path for youtube-dl / yt-dlp

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -446,6 +446,9 @@ import:
         # yt-dlp is also supported
         name: 'youtube-dl'
 
+        # Path to the python binary to execute for youtube-dl or yt-dlp
+        python_path: '/usr/bin/python3'
+
       # IPv6 is very strongly rate-limited on most sites supported by youtube-dl
       force_ipv4: false
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -454,6 +454,9 @@ import:
         # yt-dlp is also supported
         name: 'youtube-dl'
 
+        # Path to the python binary to execute for youtube-dl or yt-dlp
+        python_path: '/usr/bin/python3'
+
       # IPv6 is very strongly rate-limited on most sites supported by youtube-dl
       force_ipv4: false
 

--- a/server/helpers/youtube-dl/youtube-dl-cli.ts
+++ b/server/helpers/youtube-dl/youtube-dl-cli.ts
@@ -153,7 +153,8 @@ export class YoutubeDLCLI {
     completeArgs = this.wrapWithIPOptions(completeArgs)
     completeArgs = this.wrapWithFFmpegOptions(completeArgs)
 
-    const output = await execa('python', [ youtubeDLBinaryPath, ...completeArgs, url ], processOptions)
+    const { PYTHON_PATH } = CONFIG.IMPORT.VIDEOS.HTTP.YOUTUBE_DL_RELEASE
+    const output = await execa(PYTHON_PATH, [ youtubeDLBinaryPath, ...completeArgs, url ], processOptions)
 
     logger.debug('Runned youtube-dl command.', { command: output.command, ...lTags() })
 

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -333,7 +333,8 @@ const CONFIG = {
 
         YOUTUBE_DL_RELEASE: {
           get URL () { return config.get<string>('import.videos.http.youtube_dl_release.url') },
-          get NAME () { return config.get<string>('import.videos.http.youtube_dl_release.name') }
+          get NAME () { return config.get<string>('import.videos.http.youtube_dl_release.name') },
+          get PYTHON_PATH () { return config.get<string>('import.videos.http.youtube_dl_release.python_path') }
         },
 
         get FORCE_IPV4 () { return config.get<boolean>('import.videos.http.force_ipv4') }


### PR DESCRIPTION
## Description

On Debian, the `python` often points to `/usr/bin/python2`.

This PR aims at giving the ability to define the python path so the administrator can choose the path to the python with which PeerTube executes youtube-dl or yt-dlp.

## Related issues

 - https://github.com/Chocobozzz/PeerTube/issues/4682
 - https://github.com/YunoHost-Apps/peertube_ynh/issues/295

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

(*not sure whether it is relevant here as long as the tests continue passing ?*)

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help 