### PR TITLE
Fix missing user.Account.name on getAuthUser return type.

### DIFF
--- a/server/types/plugins/register-server-option.model.ts
+++ b/server/types/plugins/register-server-option.model.ts
@@ -106,6 +106,9 @@ export type PeerTubeHelpers = {
       email: string
       blocked: boolean
       role: UserRole
+      Account: {
+        name: string
+      }
     } | undefined>
   }
 }


### PR DESCRIPTION
## Description

I'm trying to use the new @peertube/peertype-types npm package for my peertube-plugin-livechat.
The function getAuthUser return type was missing the user.Account.name property.
This is an expected property, so that we can have the user displayName. See for example this test file:
https://github.com/Chocobozzz/PeerTube/blob/73e64592b9b949bf9b895e2fae8dafcfab0b5124/server/tests/fixtures/peertube-plugin-test-four/main.js#L101


## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
