### PR TITLE
Fix broken links in contributing guideline

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,7 +126,7 @@ You can get a complete PeerTube development setup with Gitpod, a free one-click 
 
 ### Server side
 
-You can find a documentation of the server code/architecture [here](https://docs.joinpeertube.org/#/contribute-architecture?id=server-code).
+You can find a documentation of the server code/architecture [here](https://docs.joinpeertube.org/contribute-architecture?id=server-code).
 
 To develop on the server-side:
 
@@ -141,7 +141,7 @@ restart.
 ### Client side
 
 You can find a documentation of the client code/architecture
-[here](https://docs.joinpeertube.org/#/contribute-architecture?id=client-code).
+[here](https://docs.joinpeertube.org/contribute-architecture?id=client-code).
 
 
 To develop on the client side:
@@ -220,4 +220,4 @@ To test emails with PeerTube:
 
 ## Plugins & Themes
 
-See the dedicated documentation: https://docs.joinpeertube.org/#/contribute-plugins
+See the dedicated documentation: https://docs.joinpeertube.org/contribute-plugins


### PR DESCRIPTION
## Description

This commit fixes the following:
- The links on lines 129 and 144 would redirect incorrectly.
- The link on line 223 had a redundant `#/` after the base URI. It does not seem to do anything, as far as I tested.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Visit said links on lines 129 and 144 of the contributing guideline.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->