### PR TITLE
Fix broken links in contributing guideline

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,7 +126,7 @@ You can get a complete PeerTube development setup with Gitpod, a free one-click 
 
 ### Server side
 
-You can find a documentation of the server code/architecture [here](https://docs.joinpeertube.org/#/contribute-architecture?id=server-code).
+You can find a documentation of the server code/architecture [here](https://docs.joinpeertube.org/contribute-architecture?id=server-code).
 
 To develop on the server-side:
 
@@ -141,7 +141,7 @@ restart.
 ### Client side
 
 You can find a documentation of the client code/architecture
-[here](https://docs.joinpeertube.org/#/contribute-architecture?id=client-code).
+[here](https://docs.joinpeertube.org/contribute-architecture?id=client-code).
 
 
 To develop on the client side:
@@ -220,4 +220,4 @@ To test emails with PeerTube:
 
 ## Plugins & Themes
 
-See the dedicated documentation: https://docs.joinpeertube.org/#/contribute-plugins
+See the dedicated documentation: https://docs.joinpeertube.org/contribute-plugins


### PR DESCRIPTION
## Description

This PR removes redundant `#/` in some links after the root URI in the contributing guideline, fixing broken links.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
See links to client-side architecture and server-side architecture on https://github.com/Chocobozzz/PeerTube/blob/3726c3725506d0f8a26ded34f42d7bcfb5d0e639/.github/CONTRIBUTING.md

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->