### PR TITLE
menu: hide undefined icons

### DIFF
--- a/client/src/app/menu/menu.component.html
+++ b/client/src/app/menu/menu.component.html
@@ -110,7 +110,7 @@
           <div i18n class="block-title">{{ menuSection.title }}</div>
 
           <a class="menu-link" *ngFor="let link of menuSection.links" [routerLink]="link.path" routerLinkActive="active">
-            <my-global-icon [iconName]="link.icon" aria-hidden="true"></my-global-icon>
+            <my-global-icon *ngIf="link.icon" [iconName]="link.icon" aria-hidden="true"></my-global-icon>
             <ng-container>{{ link.shortLabel }}</ng-container>
           </a>
         </div>


### PR DESCRIPTION
## Description
Hide my-global-icon when custom menu items are added without icon property.

## Has this been tested?

- [x] 🙅 no, because this PR does not update server code