### PR TITLE
Fix plugin settings manager definition

### DIFF
--- a/client/src/types/register-client-option.model.ts
+++ b/client/src/types/register-client-option.model.ts
@@ -4,7 +4,7 @@ import {
   RegisterClientRouteOptions,
   RegisterClientSettingsScriptOptions,
   RegisterClientVideoFieldOptions,
-  ServerConfig
+  ServerConfig, SettingEntries
 } from '@shared/models'
 
 export type RegisterClientOptions = {
@@ -30,7 +30,7 @@ export type RegisterClientHelpers = {
 
   getAuthHeader: () => { 'Authorization': string } | undefined
 
-  getSettings: () => Promise<{ [ name: string ]: string }>
+  getSettings: () => Promise<SettingEntries>
 
   getServerConfig: () => Promise<ServerConfig>
 

--- a/server/lib/plugins/register-helpers.ts
+++ b/server/lib/plugins/register-helpers.ts
@@ -17,6 +17,7 @@ import {
   RegisterServerHookOptions,
   RegisterServerSettingOptions,
   serverHookObject,
+  SettingsChangeCallback,
   VideoPlaylistPrivacy,
   VideoPrivacy
 } from '@shared/models'
@@ -46,7 +47,7 @@ export class RegisterHelpers {
   private idAndPassAuths: RegisterServerAuthPassOptions[] = []
   private externalAuths: RegisterServerAuthExternalOptions[] = []
 
-  private readonly onSettingsChangeCallbacks: ((settings: any) => Promise<any>)[] = []
+  private readonly onSettingsChangeCallbacks: SettingsChangeCallback[] = []
 
   private readonly router: express.Router
   private readonly videoConstantManagerFactory: VideoConstantManagerFactory
@@ -256,7 +257,7 @@ export class RegisterHelpers {
 
       setSetting: (name: string, value: string) => PluginModel.setSetting(this.plugin.name, this.plugin.type, name, value),
 
-      onSettingsChange: (cb: (settings: any) => Promise<any>) => this.onSettingsChangeCallbacks.push(cb)
+      onSettingsChange: (cb: SettingsChangeCallback) => this.onSettingsChangeCallbacks.push(cb)
     }
   }
 

--- a/server/models/server/plugin.ts
+++ b/server/models/server/plugin.ts
@@ -2,7 +2,7 @@ import { FindAndCountOptions, json, QueryTypes } from 'sequelize'
 import { AllowNull, Column, CreatedAt, DataType, DefaultScope, Is, Model, Table, UpdatedAt } from 'sequelize-typescript'
 import { MPlugin, MPluginFormattable } from '@server/types/models'
 import { AttributesOnly } from '@shared/typescript-utils'
-import { PeerTubePlugin, PluginType, RegisterServerSettingOptions } from '../../../shared/models'
+import { PeerTubePlugin, PluginType, RegisterServerSettingOptions, SettingEntries, SettingValue } from '../../../shared/models'
 import {
   isPluginDescriptionValid,
   isPluginHomepage,
@@ -148,7 +148,7 @@ export class PluginModel extends Model<Partial<AttributesOnly<PluginModel>>> {
 
     return PluginModel.findOne(query)
       .then(p => {
-        const result: { [settingName: string ]: string | boolean } = {}
+        const result: SettingEntries = {}
 
         for (const name of settingNames) {
           if (!p || !p.settings || p.settings[name] === undefined) {
@@ -166,7 +166,7 @@ export class PluginModel extends Model<Partial<AttributesOnly<PluginModel>>> {
       })
   }
 
-  static setSetting (pluginName: string, pluginType: PluginType, settingName: string, settingValue: string) {
+  static setSetting (pluginName: string, pluginType: PluginType, settingName: string, settingValue: SettingValue) {
     const query = {
       where: {
         name: pluginName,
@@ -273,7 +273,7 @@ export class PluginModel extends Model<Partial<AttributesOnly<PluginModel>>> {
   }
 
   getPublicSettings (registeredSettings: RegisterServerSettingOptions[]) {
-    const result: { [ name: string ]: string } = {}
+    const result: SettingEntries = {}
     const settings = this.settings || {}
 
     for (const r of registeredSettings) {

--- a/shared/models/plugins/server/managers/plugin-settings-manager.model.ts
+++ b/shared/models/plugins/server/managers/plugin-settings-manager.model.ts
@@ -1,9 +1,17 @@
+export type SettingValue = string | boolean
+
+export interface SettingEntries {
+  [settingName: string]: SettingValue
+}
+
+export type SettingsChangeCallback = (settings: SettingEntries) => Promise<any>
+
 export interface PluginSettingsManager {
-  getSetting: (name: string) => Promise<string | boolean>
+  getSetting: (name: string) => Promise<SettingValue>
 
-  getSettings: (names: string[]) => Promise<{ [settingName: string]: string | boolean }>
+  getSettings: (names: string[]) => Promise<SettingEntries>
 
-  setSetting: (name: string, value: string) => Promise<any>
+  setSetting: (name: string, value: SettingValue) => Promise<any>
 
-  onSettingsChange: (cb: (names: string[]) => Promise<any>) => void
+  onSettingsChange: (cb: SettingsChangeCallback) => void
 }

--- a/shared/models/plugins/server/settings/public-server.setting.ts
+++ b/shared/models/plugins/server/settings/public-server.setting.ts
@@ -1,3 +1,5 @@
+import { SettingEntries } from '../managers/plugin-settings-manager.model'
+
 export interface PublicServerSetting {
-  publicSettings: { [ name: string ]: string }
+  publicSettings: SettingEntries
 }


### PR DESCRIPTION
## Description

This mainly fix the `onSettingsChange` argument typing.
I'm not 100% sure the setting `value` can be a boolean though.
But this is how it was typed before so I just made it consistent.