### PR TITLE
Fix HLS transcoding upon WebTorrent transcoding

### DIFF
--- a/scripts/create-transcoding-job.ts
+++ b/scripts/create-transcoding-job.ts
@@ -1,6 +1,5 @@
 import { program } from 'commander'
 import { isUUIDValid, toCompleteUUID } from '@server/helpers/custom-validators/misc'
-import { computeLowerResolutionsToTranscode } from '@server/helpers/ffprobe-utils'
 import { CONFIG } from '@server/initializers/config'
 import { addTranscodingJob } from '@server/lib/video'
 import { VideoState, VideoTranscodingPayload } from '@shared/models'
@@ -51,26 +50,22 @@ async function run () {
 
   // Generate HLS files
   if (options.generateHls || CONFIG.TRANSCODING.WEBTORRENT.ENABLED === false) {
-    const resolutionsEnabled = options.resolution
-      ? [ parseInt(options.resolution) ]
-      : computeLowerResolutionsToTranscode(maxResolution, 'vod').concat([ maxResolution ])
+    const resolution = parseInt(options.resolution) || maxResolution
 
-    for (const resolution of resolutionsEnabled) {
-      dataInput.push({
-        type: 'new-resolution-to-hls',
-        videoUUID: video.uuid,
-        resolution,
+    dataInput.push({
+      type: 'new-resolution-to-hls',
+      videoUUID: video.uuid,
+      resolution,
 
-        // FIXME: check the file has audio and is not in portrait mode
-        isPortraitMode: false,
-        hasAudio: true,
+      // FIXME: check the file has audio and is not in portrait mode
+      isPortraitMode: false,
+      hasAudio: true,
 
-        copyCodecs: false,
-        isNewVideo: false,
-        isMaxQuality: maxResolution === resolution,
-        autoDeleteWebTorrentIfNeeded: false
-      })
-    }
+      copyCodecs: false,
+      isNewVideo: false,
+      isMaxQuality: resolution === maxResolution,
+      autoDeleteWebTorrentIfNeeded: false
+    })
   } else {
     if (options.resolution !== undefined) {
       dataInput.push({

--- a/server/controllers/api/videos/transcoding.ts
+++ b/server/controllers/api/videos/transcoding.ts
@@ -25,7 +25,7 @@ export {
 
 async function createTranscoding (req: express.Request, res: express.Response) {
   const video = res.locals.videoAll
-  logger.info('Creating %s transcoding job for %s.', req.body.type, video.url, lTags())
+  logger.info('Creating %s transcoding job for %s.', req.body.transcodingType, video.url, lTags())
 
   const body: VideoTranscodingCreate = req.body
 

--- a/server/lib/job-queue/handlers/video-transcoding.ts
+++ b/server/lib/job-queue/handlers/video-transcoding.ts
@@ -219,7 +219,10 @@ async function onNewWebTorrentFileResolution (
   user: MUserId,
   payload: NewResolutionTranscodingPayload | MergeAudioTranscodingPayload
 ) {
-  await createHlsJobIfEnabled(user, { hasAudio: true, copyCodecs: true, isMaxQuality: false, ...payload })
+  if (payload.isNewVideo) {
+    await createHlsJobIfEnabled(user, { hasAudio: true, copyCodecs: true, isMaxQuality: false, ...payload })
+  }
+
   await VideoJobInfoModel.decrease(video.uuid, 'pendingTranscode')
 
   await retryTransactionWrapper(moveToNextState, video, payload.isNewVideo)

--- a/server/tests/cli/create-transcoding-job.ts
+++ b/server/tests/cli/create-transcoding-job.ts
@@ -213,19 +213,17 @@ function runTests (objectStorage: boolean) {
     this.timeout(120000)
 
     await servers[0].config.enableTranscoding()
-    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[4]}`)
+    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[4]} --generate-hls`)
 
     await waitJobs(servers)
 
     for (const server of servers) {
       const videoDetails = await server.videos.get({ id: videosUUID[4] })
 
-      expect(videoDetails.files).to.have.lengthOf(5)
       expect(videoDetails.streamingPlaylists).to.have.lengthOf(1)
       expect(videoDetails.streamingPlaylists[0].files).to.have.lengthOf(5)
 
       if (objectStorage) {
-        await checkFilesInObjectStorage(videoDetails.files, 'webtorrent')
         await checkFilesInObjectStorage(videoDetails.streamingPlaylists[0].files, 'playlist')
       }
     }


### PR DESCRIPTION
## Description
Previously the web torrent transcoding was the on initializing HLS transcoding. This PR will separate the logic and make the HLS transcoding independent of the WebTorrent transcoding.

## Related issues
closes #4749 

## Has this been tested?
- [x] 👍 yes, I added tests to the test suite