### PR TITLE
Fix retranscoding HLS with object storage enabled

### DIFF
--- a/client/src/app/+admin/overview/videos/video-list.component.html
+++ b/client/src/app/+admin/overview/videos/video-list.component.html
@@ -81,8 +81,8 @@
       </td>
 
       <td>
-        <span *ngIf="isHLS(video)" class="badge badge-blue">HLS</span>
-        <span *ngIf="isWebTorrent(video)" class="badge badge-blue">WebTorrent</span>
+        <span *ngIf="isHLS(video)" class="badge badge-blue">HLS ({{ video.streamingPlaylists.length }})</span>
+        <span *ngIf="isWebTorrent(video)" class="badge badge-blue">WebTorrent ({{ video.files.length }})</span>
         <span *ngIf="video.isLive" class="badge badge-blue">Live</span>
 
         <span *ngIf="!isImport(video) && !video.isLive && video.isLocal">{{ getFilesSize(video) | bytes: 1 }}</span>
@@ -112,11 +112,16 @@
           <div *ngIf="isHLS(video)">
             HLS:
 
-            <ul>
-              <li *ngFor="let file of video.streamingPlaylists[0].files">
-                {{ file.resolution.label }}: {{ file.size | bytes: 1 }}
-              </li>
-            </ul>
+            <div *ngFor="let playlist of video.streamingPlaylists; let i = index;" class="hls-playlist-list">
+              <strong>Playlist {{ playlist.id }}</strong>
+              <span *ngIf="i === video.streamingPlaylists.length - 1" class="badge badge-yellow">Active</span>
+
+              <ul>
+                <li *ngFor="let file of playlist.files">
+                  {{ file.resolution.label }}: {{ file.size | bytes: 1 }}
+                </li>
+              </ul>
+              </div>
           </div>
 
           <my-embed class="ml-auto" [video]="video"></my-embed>

--- a/client/src/app/+admin/overview/videos/video-list.component.scss
+++ b/client/src/app/+admin/overview/videos/video-list.component.scss
@@ -14,8 +14,17 @@ my-embed {
 
 .video-info > div {
   display: flex;
+
+  > div {
+    width: 25%;
+  }
 }
 
 .loading {
   opacity: 0.5;
 }
+
+.hls-playlist-list {
+  padding-left: 15px;
+}
+

--- a/client/src/app/+admin/overview/videos/video-list.component.ts
+++ b/client/src/app/+admin/overview/videos/video-list.component.ts
@@ -167,7 +167,7 @@ export class VideoListComponent extends RestTable implements OnInit {
     let files = video.files
 
     if (this.isHLS(video)) {
-      files = files.concat(video.streamingPlaylists[0].files)
+      files = files.concat(...video.streamingPlaylists.map(p => p.files))
     }
 
     return files.reduce((p, f) => p += f.size, 0)

--- a/scripts/create-transcoding-job.ts
+++ b/scripts/create-transcoding-job.ts
@@ -9,7 +9,6 @@ import { VideoModel } from '../server/models/video/video'
 
 program
   .option('-v, --video [videoUUID]', 'Video UUID')
-  .option('-r, --resolution [resolution]', 'Video resolution (integer)')
   .option('--generate-hls', 'Generate HLS playlist')
   .parse(process.argv)
 
@@ -52,11 +51,9 @@ async function run () {
 
   // Generate HLS files
   if (options.generateHls || CONFIG.TRANSCODING.WEBTORRENT.ENABLED === false) {
-    const resolution = parseInt(options.resolution) || maxResolution
-
     await addHlsJob({
       video,
-      resolution,
+      resolution: maxResolution,
 
       // FIXME: check the file has audio and is not in portrait mode
       isPortraitMode: false,
@@ -64,7 +61,7 @@ async function run () {
 
       copyCodecs: false,
       isNewVideo: false,
-      isMaxQuality: resolution === maxResolution,
+      isMaxQuality: true,
       autoDeleteWebTorrentIfNeeded: false
     })
 

--- a/scripts/create-transcoding-job.ts
+++ b/scripts/create-transcoding-job.ts
@@ -1,6 +1,5 @@
 import { program } from 'commander'
 import { isUUIDValid, toCompleteUUID } from '@server/helpers/custom-validators/misc'
-import { computeLowerResolutionsToTranscode } from '@server/helpers/ffprobe-utils'
 import { CONFIG } from '@server/initializers/config'
 import { addTranscodingJob } from '@server/lib/video'
 import { VideoState, VideoTranscodingPayload } from '@shared/models'
@@ -51,26 +50,22 @@ async function run () {
 
   // Generate HLS files
   if (options.generateHls || CONFIG.TRANSCODING.WEBTORRENT.ENABLED === false) {
-    const resolutionsEnabled = options.resolution
-      ? [ parseInt(options.resolution) ]
-      : computeLowerResolutionsToTranscode(maxResolution, 'vod').concat([ maxResolution ])
+    const resolution = parseInt(options.resolution) || maxResolution
 
-    for (const resolution of resolutionsEnabled) {
-      dataInput.push({
-        type: 'new-resolution-to-hls',
-        videoUUID: video.uuid,
-        resolution,
+    dataInput.push({
+      type: 'new-resolution-to-hls',
+      videoUUID: video.uuid,
+      resolution,
 
-        // FIXME: check the file has audio and is not in portrait mode
-        isPortraitMode: false,
-        hasAudio: true,
+      // FIXME: check the file has audio and is not in portrait mode
+      isPortraitMode: false,
+      hasAudio: true,
 
-        copyCodecs: false,
-        isNewVideo: false,
-        isMaxQuality: maxResolution === resolution,
-        autoDeleteWebTorrentIfNeeded: false
-      })
-    }
+      copyCodecs: false,
+      isNewVideo: false,
+      isMaxQuality: resolution === maxResolution,
+      autoDeleteWebTorrentIfNeeded: false
+    })
   } else {
     if (options.resolution !== undefined) {
       dataInput.push({

--- a/server/controllers/api/videos/transcoding.ts
+++ b/server/controllers/api/videos/transcoding.ts
@@ -36,7 +36,7 @@ async function createTranscoding (req: express.Request, res: express.Response) {
   await video.save()
 
   if (body.transcodingType === 'hls') {
-    await addHlsJob(res.locals.oauth.token.user, {
+    await addHlsJob({
       video,
       resolution: maxResolution,
       isPortraitMode,
@@ -45,7 +45,7 @@ async function createTranscoding (req: express.Request, res: express.Response) {
       isNewVideo: false,
       autoDeleteWebTorrentIfNeeded: false,
       isMaxQuality: true
-    })
+    }, res.locals.oauth.token.user)
   } else if (body.transcodingType === 'webtorrent') {
     for (const resolution of resolutions) {
       await addTranscodingJob({

--- a/server/controllers/api/videos/transcoding.ts
+++ b/server/controllers/api/videos/transcoding.ts
@@ -25,7 +25,7 @@ export {
 
 async function createTranscoding (req: express.Request, res: express.Response) {
   const video = res.locals.videoAll
-  logger.info('Creating %s transcoding job for %s.', req.body.type, video.url, lTags())
+  logger.info('Creating %s transcoding job for %s.', req.body.transcodingType, video.url, lTags())
 
   const body: VideoTranscodingCreate = req.body
 

--- a/server/helpers/custom-validators/videos.ts
+++ b/server/helpers/custom-validators/videos.ts
@@ -112,7 +112,7 @@ function isVideoOriginallyPublishedAtValid (value: string | null) {
 }
 
 function isVideoFileInfoHashValid (value: string | null | undefined) {
-  return exists(value) && validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH)
+  return value === undefined || validator.isLength(value, VIDEOS_CONSTRAINTS_FIELDS.INFO_HASH)
 }
 
 function isVideoFileResolutionValid (value: string) {
@@ -131,7 +131,7 @@ function isVideoMagnetUriValid (value: string) {
   if (!exists(value)) return false
 
   const parsed = magnetUtil.decode(value)
-  return parsed && isVideoFileInfoHashValid(parsed.infoHash)
+  return parsed && exists(parsed.infoHash) && isVideoFileInfoHashValid(parsed.infoHash)
 }
 
 // ---------------------------------------------------------------------------

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -24,7 +24,7 @@ import { CONFIG, registerConfigChangedHandler } from './config'
 
 // ---------------------------------------------------------------------------
 
-const LAST_MIGRATION_VERSION = 675
+const LAST_MIGRATION_VERSION = 680
 
 // ---------------------------------------------------------------------------
 

--- a/server/initializers/migrations/0680-video-streaming-playlist-multiple-empty.ts
+++ b/server/initializers/migrations/0680-video-streaming-playlist-multiple-empty.ts
@@ -1,0 +1,54 @@
+import * as Sequelize from 'sequelize'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction
+  queryInterface: Sequelize.QueryInterface
+  sequelize: Sequelize.Sequelize
+  db: any
+}): Promise<void> {
+  {
+    {
+      await utils.queryInterface.removeIndex('videoStreamingPlaylist', 'video_streaming_playlist_video_id_type')
+    }
+
+    {
+      await utils.queryInterface.addIndex('videoStreamingPlaylist', {
+        unique: true,
+        fields: [ 'videoId', 'playlistFilename', 'type' ]
+      })
+    }
+
+    {
+      const data = {
+        type: Sequelize.STRING,
+        allowNull: true
+      }
+      await utils.queryInterface.changeColumn('videoStreamingPlaylist', 'playlistFilename', data)
+    }
+
+    {
+      const data = {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      }
+      await utils.queryInterface.changeColumn('videoStreamingPlaylist', 'p2pMediaLoaderPeerVersion', data)
+    }
+
+    {
+      const data = {
+        type: Sequelize.STRING,
+        allowNull: true
+      }
+      await utils.queryInterface.changeColumn('videoStreamingPlaylist', 'segmentsSha256Filename', data)
+    }
+  }
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export {
+  up,
+  down
+}

--- a/server/lib/job-queue/handlers/move-to-object-storage.ts
+++ b/server/lib/job-queue/handlers/move-to-object-storage.ts
@@ -26,10 +26,12 @@ export async function processMoveToObjectStorage (job: Job) {
 
   try {
     if (video.VideoFiles) {
+      logger.debug(`Moving ${video.VideoFiles.length} web torrent files.`)
       await moveWebTorrentFiles(video)
     }
 
     if (video.VideoStreamingPlaylists) {
+      logger.debug(`Moving ${video.VideoStreamingPlaylists.length} HLS files.`)
       await moveHLSFiles(video)
     }
 
@@ -91,7 +93,10 @@ async function doAfterLastJob (video: MVideoWithAllFiles, isNewVideo: boolean) {
     // Master playlist
     playlist.playlistUrl = await storeHLSFile(playlistWithVideo, playlist.playlistFilename)
     // Sha256 segments file
-    playlist.segmentsSha256Url = await storeHLSFile(playlistWithVideo, playlist.segmentsSha256Filename)
+    playlist.segmentsSha256Url = await storeHLSFile(
+      playlistWithVideo,
+      playlist.segmentsSha256Filename
+    )
 
     playlist.storage = VideoStorage.OBJECT_STORAGE
 

--- a/server/lib/job-queue/handlers/video-live-ending.ts
+++ b/server/lib/job-queue/handlers/video-live-ending.ts
@@ -103,7 +103,8 @@ async function saveLive (video: MVideo, live: MVideoLive, streamingPlaylist: MSt
       concatenatedTsFilePath,
       resolution,
       isPortraitMode,
-      isAAC: audioStream?.codec_name === 'aac'
+      isAAC: audioStream?.codec_name === 'aac',
+      videoPlaylistId: hlsPlaylist.id
     })
 
     if (!durationDone) {

--- a/server/lib/job-queue/handlers/video-transcoding.ts
+++ b/server/lib/job-queue/handlers/video-transcoding.ts
@@ -219,7 +219,10 @@ async function onNewWebTorrentFileResolution (
   user: MUserId,
   payload: NewResolutionTranscodingPayload | MergeAudioTranscodingPayload
 ) {
-  await createHlsJobIfEnabled(user, { hasAudio: true, copyCodecs: true, isMaxQuality: false, ...payload })
+  if (payload.isNewVideo) {
+    await createHlsJobIfEnabled(user, { hasAudio: true, copyCodecs: true, isMaxQuality: false, ...payload })
+  }
+
   await VideoJobInfoModel.decrease(video.uuid, 'pendingTranscode')
 
   await retryTransactionWrapper(moveToNextState, video, payload.isNewVideo)

--- a/server/lib/job-queue/handlers/video-transcoding.ts
+++ b/server/lib/job-queue/handlers/video-transcoding.ts
@@ -241,7 +241,7 @@ async function createHlsJobIfEnabled (user: MUserId, payload: {
 }) {
   if (!payload || CONFIG.TRANSCODING.ENABLED !== true || CONFIG.TRANSCODING.HLS.ENABLED !== true) return false
 
-  await addHlsJob(user, payload)
+  await addHlsJob(payload, user)
 
   return true
 }

--- a/server/lib/transcoding/video-transcoding.ts
+++ b/server/lib/transcoding/video-transcoding.ts
@@ -189,6 +189,7 @@ async function generateHlsPlaylistResolutionFromTS (options: {
   resolution: VideoResolution
   isPortraitMode: boolean
   isAAC: boolean
+  videoPlaylistId: number
 }) {
   return generateHlsPlaylistCommon({
     video: options.video,
@@ -196,7 +197,8 @@ async function generateHlsPlaylistResolutionFromTS (options: {
     isPortraitMode: options.isPortraitMode,
     inputPath: options.concatenatedTsFilePath,
     type: 'hls-from-ts' as 'hls-from-ts',
-    isAAC: options.isAAC
+    isAAC: options.isAAC,
+    videoPlaylistId: options.videoPlaylistId
   })
 }
 
@@ -208,6 +210,7 @@ function generateHlsPlaylistResolution (options: {
   copyCodecs: boolean
   isPortraitMode: boolean
   job?: Job
+  videoPlaylistId: number
 }) {
   return generateHlsPlaylistCommon({
     video: options.video,
@@ -216,7 +219,8 @@ function generateHlsPlaylistResolution (options: {
     isPortraitMode: options.isPortraitMode,
     inputPath: options.videoInputPath,
     type: 'hls' as 'hls',
-    job: options.job
+    job: options.job,
+    videoPlaylistId: options.videoPlaylistId
   })
 }
 
@@ -264,6 +268,7 @@ async function generateHlsPlaylistCommon (options: {
   copyCodecs?: boolean
   isAAC?: boolean
   isPortraitMode: boolean
+  videoPlaylistId: number
 
   job?: Job
 }) {
@@ -302,7 +307,7 @@ async function generateHlsPlaylistCommon (options: {
   await transcode(transcodeOptions)
 
   // Create or update the playlist
-  const playlist = await VideoStreamingPlaylistModel.loadOrGenerate(video)
+  const playlist = await VideoStreamingPlaylistModel.loadWithVideo(options.videoPlaylistId)
 
   if (!playlist.playlistFilename) {
     playlist.playlistFilename = generateHLSMasterPlaylistFilename(video.isLive)

--- a/server/lib/video.ts
+++ b/server/lib/video.ts
@@ -131,7 +131,7 @@ async function addTranscodingJob (payload: VideoTranscodingPayload, options: Cre
   return JobQueue.Instance.createJobWithPromise({ type: 'video-transcoding', payload: payload }, options)
 }
 
-async function addHlsJob (user: MUserId, payload: {
+async function addHlsJob (payload: {
   video: MVideo
   resolution: number
   hasAudio: boolean
@@ -140,7 +140,7 @@ async function addHlsJob (user: MUserId, payload: {
   isMaxQuality: boolean
   isNewVideo?: boolean
   autoDeleteWebTorrentIfNeeded?: boolean
-}) {
+}, user?: MUserId) {
   const playlist = new VideoStreamingPlaylistModel() as MStreamingPlaylistFilesVideo
   playlist.Video = payload.video
   playlist.videoId = payload.video.id
@@ -156,7 +156,7 @@ async function addHlsJob (user: MUserId, payload: {
   }
 
   const jobOptions = {
-    priority: await getTranscodingJobPriority(user)
+    priority: user ? await getTranscodingJobPriority(user) : 1
   }
 
   const hlsTranscodingPayload: HLSTranscodingPayload = {

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -253,7 +253,8 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
 
   hasSameUniqueKeysThan (other: MStreamingPlaylist) {
     return this.type === other.type &&
-      this.videoId === other.videoId
+      this.videoId === other.videoId &&
+      this.playlistFilename === other.playlistFilename
   }
 
   withVideo (video: MVideo) {

--- a/server/models/video/video-streaming-playlist.ts
+++ b/server/models/video/video-streaming-playlist.ts
@@ -45,7 +45,7 @@ import { VideoModel } from './video'
       fields: [ 'videoId' ]
     },
     {
-      fields: [ 'videoId', 'type' ],
+      fields: [ 'videoId', 'type', 'playlistFilename' ],
       unique: true
     },
     {
@@ -65,7 +65,7 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   @Column
   type: VideoStreamingPlaylistType
 
-  @AllowNull(false)
+  @AllowNull(true)
   @Column
   playlistFilename: string
 
@@ -74,16 +74,16 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   @Column(DataType.STRING(CONSTRAINTS_FIELDS.VIDEOS.URL.max))
   playlistUrl: string
 
-  @AllowNull(false)
+  @AllowNull(true)
   @Is('VideoStreamingPlaylistInfoHashes', value => throwIfNotValid(value, v => isArrayOf(v, isVideoFileInfoHashValid), 'info hashes'))
   @Column(DataType.ARRAY(DataType.STRING))
   p2pMediaLoaderInfohashes: string[]
 
-  @AllowNull(false)
+  @AllowNull(true)
   @Column
   p2pMediaLoaderPeerVersion: number
 
-  @AllowNull(false)
+  @AllowNull(true)
   @Column
   segmentsSha256Filename: string
 
@@ -214,6 +214,10 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   }
 
   getMasterPlaylistUrl (video: MVideo) {
+    if (!this.playlistFilename) {
+      return null
+    }
+
     if (this.storage === VideoStorage.OBJECT_STORAGE) {
       return getHLSPublicFileUrl(this.playlistUrl)
     }
@@ -224,6 +228,10 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
   }
 
   getSha256SegmentsUrl (video: MVideo) {
+    if (!this.segmentsSha256Filename) {
+      return null
+    }
+
     if (this.storage === VideoStorage.OBJECT_STORAGE) {
       return getHLSPublicFileUrl(this.segmentsSha256Url)
     }

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1351,6 +1351,11 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
     const queryBuilder = new VideoModelGetQueryBuilder(VideoModel.sequelize)
 
     return queryBuilder.queryVideo({ id, transaction, type: 'api', userId })
+      .then(video => {
+        video?.VideoStreamingPlaylists?.sort((c, p) => p.id - c.id)
+
+        return video
+      })
   }
 
   static async getStats () {

--- a/server/tests/cli/create-transcoding-job.ts
+++ b/server/tests/cli/create-transcoding-job.ts
@@ -52,7 +52,7 @@ function runTests (objectStorage: boolean) {
 
     if (objectStorage) await ObjectStorageCommand.prepareDefaultBuckets()
 
-    for (let i = 1; i <= 5; i++) {
+    for (let i = 1; i <= 4; i++) {
       const { uuid, shortUUID } = await servers[0].videos.upload({ attributes: { name: 'video' + i } })
 
       await waitJobs(servers)
@@ -125,79 +125,15 @@ function runTests (objectStorage: boolean) {
     }
   })
 
-  it('Should run a transcoding job on video 1 with resolution', async function () {
-    this.timeout(60000)
-
-    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[0]} -r 480`)
-
-    await waitJobs(servers)
-
-    for (const server of servers) {
-      const { data } = await server.videos.list()
-      expect(data).to.have.lengthOf(videosUUID.length)
-
-      const videoDetails = await server.videos.get({ id: videosUUID[0] })
-
-      expect(videoDetails.files).to.have.lengthOf(2)
-      expect(videoDetails.files[0].resolution.id).to.equal(720)
-      expect(videoDetails.files[1].resolution.id).to.equal(480)
-
-      expect(videoDetails.streamingPlaylists).to.have.lengthOf(0)
-
-      if (objectStorage) await checkFilesInObjectStorage(videoDetails.files, 'webtorrent')
-    }
-  })
-
-  it('Should generate an HLS resolution', async function () {
-    this.timeout(120000)
-
-    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[2]} --generate-hls -r 480`)
-
-    await waitJobs(servers)
-
-    for (const server of servers) {
-      const videoDetails = await server.videos.get({ id: videosUUID[2] })
-
-      expect(videoDetails.files).to.have.lengthOf(1)
-      if (objectStorage) await checkFilesInObjectStorage(videoDetails.files, 'webtorrent')
-
-      expect(videoDetails.streamingPlaylists).to.have.lengthOf(1)
-
-      const files = videoDetails.streamingPlaylists[0].files
-      expect(files).to.have.lengthOf(1)
-      expect(files[0].resolution.id).to.equal(480)
-
-      if (objectStorage) await checkFilesInObjectStorage(files, 'playlist')
-    }
-  })
-
-  it('Should not duplicate an HLS resolution', async function () {
-    this.timeout(120000)
-
-    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[2]} --generate-hls -r 480`)
-
-    await waitJobs(servers)
-
-    for (const server of servers) {
-      const videoDetails = await server.videos.get({ id: videosUUID[2] })
-
-      const files = videoDetails.streamingPlaylists[0].files
-      expect(files).to.have.lengthOf(1)
-      expect(files[0].resolution.id).to.equal(480)
-
-      if (objectStorage) await checkFilesInObjectStorage(files, 'playlist')
-    }
-  })
-
   it('Should generate all HLS resolutions', async function () {
     this.timeout(120000)
 
-    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[3]} --generate-hls`)
+    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[2]} --generate-hls`)
 
     await waitJobs(servers)
 
     for (const server of servers) {
-      const videoDetails = await server.videos.get({ id: videosUUID[3] })
+      const videoDetails = await server.videos.get({ id: videosUUID[2] })
 
       expect(videoDetails.files).to.have.lengthOf(1)
       expect(videoDetails.streamingPlaylists).to.have.lengthOf(1)
@@ -213,12 +149,12 @@ function runTests (objectStorage: boolean) {
     this.timeout(120000)
 
     await servers[0].config.enableTranscoding()
-    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[4]} --generate-hls`)
+    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[3]} --generate-hls`)
 
     await waitJobs(servers)
 
     for (const server of servers) {
-      const videoDetails = await server.videos.get({ id: videosUUID[4] })
+      const videoDetails = await server.videos.get({ id: videosUUID[3] })
 
       expect(videoDetails.streamingPlaylists).to.have.lengthOf(1)
       expect(videoDetails.streamingPlaylists[0].files).to.have.lengthOf(5)

--- a/server/tests/cli/create-transcoding-job.ts
+++ b/server/tests/cli/create-transcoding-job.ts
@@ -213,19 +213,17 @@ function runTests (objectStorage: boolean) {
     this.timeout(120000)
 
     await servers[0].config.enableTranscoding()
-    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[4]}`)
+    await servers[0].cli.execWithEnv(`npm run create-transcoding-job -- -v ${videosUUID[4]} --generate-hls`)
 
     await waitJobs(servers)
 
     for (const server of servers) {
       const videoDetails = await server.videos.get({ id: videosUUID[4] })
 
-      expect(videoDetails.files).to.have.lengthOf(5)
       expect(videoDetails.streamingPlaylists).to.have.lengthOf(1)
       expect(videoDetails.streamingPlaylists[0].files).to.have.lengthOf(5)
 
       if (objectStorage) {
-        await checkFilesInObjectStorage(videoDetails.files, 'webtorrent')
         await checkFilesInObjectStorage(videoDetails.streamingPlaylists[0].files, 'playlist')
       }
     }

--- a/shared/models/server/job.model.ts
+++ b/shared/models/server/job.model.ts
@@ -99,6 +99,7 @@ export type VideoRedundancyPayload = {
 interface BaseTranscodingPayload {
   videoUUID: string
   isNewVideo?: boolean
+  videoPlaylistId?: number
 }
 
 export interface HLSTranscodingPayload extends BaseTranscodingPayload {
@@ -111,6 +112,8 @@ export interface HLSTranscodingPayload extends BaseTranscodingPayload {
 
   autoDeleteWebTorrentIfNeeded: boolean
   isMaxQuality: boolean
+
+  videoPlaylistId?: number
 }
 
 export interface NewResolutionTranscodingPayload extends BaseTranscodingPayload {


### PR DESCRIPTION
## Description
Upon trying to solve #4746 I found the solution became too complex in handling different cases. So instead I did some refactor that in broad terms means that when doing retranscoding a new HLS playlist is created, instead of updating the existing. Possible benefits (each would need some additional code):

* Avoid disruption or downtime during transcoding
* Rollback a broken retranscoding/video file import
* Preview a new video file import before publishing

What has changed:
* Video streaming playlists unique index has changed from video, type > video, type, playlistFilename
* playlistFilename, p2pMediaLoaderPeerVersion and segmentsSha256Filename can now be null (during transcoding)
* WebTorrent and HLS transcoding jobs less coupled
* Removed support to transcode a particular resolution just to be consistent (with the new way of doing it this would have been creating a new playlist with only one resolution)

This PR is based on #4750.

## Related issues
closes #4746 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite
