### PR TITLE
Fix media player error handling

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -328,6 +328,10 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
     this.notifier.error(errorMessage)
   }
 
+  private handleVideojsError (err: any) {
+    this.player.addClass('vjs-error-display-enabled')
+  }
+
   private async onVideoFetched (options: {
     video: VideoDetails
     videoCaptions: VideoCaption[]
@@ -401,6 +405,10 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
     this.zone.runOutsideAngular(async () => {
       this.player = await PeertubePlayerManager.initialize(playerMode, playerOptions, player => this.player = player)
+
+      this.player.on('error', () => {
+        this.zone.run(() => this.handleVideojsError(this.player.error()))
+      })
 
       this.player.on('customError', ({ err }: { err: any }) => {
         this.zone.run(() => this.handleGlobalError(err))

--- a/client/src/app/+videos/+video-watch/video-watch.component.ts
+++ b/client/src/app/+videos/+video-watch/video-watch.component.ts
@@ -83,7 +83,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
 
   private hotkeys: Hotkey[] = []
 
-  private anonymousOrLoggedUser: User
+  private loggedInOrAnonymousUser: User
 
   private videojsDecodeErrors = 0
 
@@ -249,7 +249,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       this.userService.getAnonymousOrLoggedUser()
     ]).subscribe({
       next: ([ video, captionsResult, loggedInOrAnonymousUser ]) => {
-        this.anonymousOrLoggedUser = loggedInOrAnonymousUser
+        this.loggedInOrAnonymousUser = loggedInOrAnonymousUser
 
         const urlOptions = {
           ...this.buildUrlOptions(),
@@ -357,7 +357,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
         this.buildPlayer({
           ...this.buildUrlOptions(),
           startTime: this.player.currentTime() + 2
-        }, this.anonymousOrLoggedUser)
+        }, this.loggedInOrAnonymousUser)
 
         break
       default:
@@ -390,7 +390,7 @@ export class VideoWatchComponent implements OnInit, OnDestroy {
       if (res === false) return this.location.back()
     }
 
-    this.buildPlayer(urlOptions, this.anonymousOrLoggedUser)
+    this.buildPlayer(urlOptions, this.loggedInOrAnonymousUser)
       .catch(err => console.error('Cannot build the player', err))
 
     this.setOpenGraphTags()

--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -167,16 +167,24 @@ export class PeertubePlayerManager {
       videojs(options.common.playerElement, videojsOptions, function (this: videojs.Player) {
         const player = this
 
+        const hasFallback = options.webtorrent.videoFiles.length > 0
         let alreadyFallback = false
 
-        player.tech(true).one('error', () => {
+        const handleFallback = () => {
           if (!alreadyFallback) self.maybeFallbackToWebTorrent(mode, player, options)
           alreadyFallback = true
+        }
+
+        player.tech(true).one('error', () => {
+          if (hasFallback) {
+            handleFallback()
+          }
         })
 
         player.one('error', () => {
-          if (!alreadyFallback) self.maybeFallbackToWebTorrent(mode, player, options)
-          alreadyFallback = true
+          if (hasFallback) {
+            handleFallback()
+          }
         })
 
         player.one('play', () => {


### PR DESCRIPTION
## Description
* Don't try to fallback to webtorrent when webtorrent is missing.
* Display a notification for the user when decoding issues appear.
* Try to fast forward to get rid of the decoding issue.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #4748

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code