### PR TITLE
Install python3 instead of global python in docker image

### DIFF
--- a/support/docker/production/Dockerfile.bullseye
+++ b/support/docker/production/Dockerfile.bullseye
@@ -2,7 +2,7 @@ FROM node:14-bullseye-slim
 
 # Install dependencies
 RUN apt update \
- && apt install -y --no-install-recommends openssl ffmpeg python ca-certificates gnupg gosu build-essential curl \
+ && apt install -y --no-install-recommends openssl ffmpeg python3 ca-certificates gnupg gosu build-essential curl \
  && gosu nobody true \
  && rm /var/lib/apt/lists/* -fR
 


### PR DESCRIPTION
Hello !

Regarding issue #4812, python virtual package uses python-is-python2 and so install python2 instead of python3
But we need to explicitly use python3 for PeerTube tools (especially ytp-dl)

May need an hotfix to propagate changes as currently import is probably broken for everyone using the official docker image :-/

## Related issues

Issue #4812 

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

However, I test installing python3 inside the official docker image and it solves the problem with ytp-dl