### PR TITLE
open privacy info in user settings dialogue in new window

### DIFF
--- a/client/src/app/shared/shared-user-settings/user-video-settings.component.html
+++ b/client/src/app/shared/shared-user-settings/user-video-settings.component.html
@@ -42,7 +42,7 @@
       i18n-labelText labelText="Help share videos being played"
     >
       <ng-container ngProjectAs="description">
-        <span i18n>The <a routerLink="/about/peertube" fragment="privacy">sharing system</a> implies that some technical information about your system (such as a public IP address) can be sent to other peers, but greatly helps to reduce server load.</span>
+        <span i18n>The <a routerLink="/about/peertube" fragment="privacy" target="_blank">sharing system</a> implies that some technical information about your system (such as a public IP address) can be sent to other peers, but greatly helps to reduce server load.</span>
       </ng-container>
     </my-peertube-checkbox>
   </div>


### PR DESCRIPTION
## Description

When a user clicks on *sharing system* in the user settings, then the privacy notice is opened, but still covered by the settings. Closing the settings is confusing. Hence, we open a new window with the privacy notice.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help (I don't have a working dev environment here)
