### PR TITLE
add git to docker image to satisfy plugin dependencies

### DIFF
--- a/support/docker/production/Dockerfile.bullseye
+++ b/support/docker/production/Dockerfile.bullseye
@@ -2,7 +2,7 @@ FROM node:14-bullseye-slim
 
 # Install dependencies
 RUN apt update \
- && apt install -y --no-install-recommends openssl ffmpeg python3 ca-certificates gnupg gosu build-essential curl \
+ && apt install -y --no-install-recommends openssl ffmpeg python3 ca-certificates gnupg gosu build-essential curl git \
  && gosu nobody true \
  && rm /var/lib/apt/lists/* -fR
 


### PR DESCRIPTION
## Description

When installing a plugin, I noticed the following error:

~~~
live-peertube-1  | [domain:443] 2022-03-07 10:58:00.022 warn: Cannot install plugin peertube-plugin-tv-streaming. {
live-peertube-1  |   "err": {
live-peertube-1  |     "err": {
live-peertube-1  |       "stack": "Error: Command failed: yarn add peertube-plugin-tv-streaming@1.1.0\nwarning package.json: No license field\nwarning No license field\nerror Couldn't find the binary git\n\n    at ChildProcess.exithandler (child_process.js:383:12)\n    at ChildProcess.emit (events.js:400:28)\n    at ChildProcess.emit (domain.js:475:12)\n    at maybeClose (internal/child_process.js:1058:16)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5)",
live-peertube-1  |       "message": "Command failed: yarn add peertube-plugin-tv-streaming@1.1.0\nwarning package.json: No license field\nwarning No license field\nerror Couldn't find the binary git\n",
live-peertube-1  |       "killed": false,
live-peertube-1  |       "code": 1,
live-peertube-1  |       "signal": null,
live-peertube-1  |       "cmd": "yarn add peertube-plugin-tv-streaming@1.1.0"
live-peertube-1  |     },
live-peertube-1  |     "stdout": "yarn add v1.22.17\n[1/4] Resolving packages...\ninfo Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.\n",
live-peertube-1  |     "stderr": "warning package.json: No license field\nwarning No license field\nerror Couldn't find the binary git\n"
live-peertube-1  |   }
~~~

Hence, I suggest to add git to the docker image.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

