### PR TITLE
Support forward proxying of object storage

### DIFF
--- a/server/helpers/requests.ts
+++ b/server/helpers/requests.ts
@@ -212,6 +212,7 @@ export {
   doRequestAndSaveToFile,
   isBinaryResponse,
   downloadImage,
+  getAgent,
   findLatestRedirection,
   peertubeGot
 }

--- a/server/lib/object-storage/shared/client.ts
+++ b/server/lib/object-storage/shared/client.ts
@@ -1,21 +1,18 @@
 import { NodeHttpHandler } from "@aws-sdk/node-http-handler"
-import { HttpsProxyAgent } from 'https-proxy-agent'
-import { getProxy, isProxyEnabled } from '@server/helpers/proxy'
+import { getAgent } from '@server/helpers/requests'
 import { S3Client } from '@aws-sdk/client-s3'
 import { logger } from '@server/helpers/logger'
 import { CONFIG } from '@server/initializers/config'
 import { lTags } from './logger'
 
 function getProxyRequestHandler () {
+  const { agent } = getAgent()
+  if ( agent === null || agent === undefined ) return null
 
-  if (!isProxyEnabled()) { return new NodeHttpHandler() }
+  const httpAgent = agent.hasOwnProperty('http') ? agent.http : null
+  const httpsAgent = agent.hasOwnProperty('https') ? agent.https : null
 
-  const proxy = getProxy()
-
-  return new NodeHttpHandler({
-    httpAgent: new HttpsProxyAgent(proxy),
-    httpsAgent: new HttpsProxyAgent(proxy)
-  })
+  return new NodeHttpHandler({ httpAgent, httpsAgent })
 }
 
 let endpointParsed: URL

--- a/server/lib/object-storage/shared/client.ts
+++ b/server/lib/object-storage/shared/client.ts
@@ -7,10 +7,10 @@ import { lTags } from './logger'
 
 function getProxyRequestHandler () {
   const { agent } = getAgent()
-  if ( agent === null || agent === undefined ) return null
+  if (agent === null || agent === undefined) return null
 
-  const httpAgent = agent.hasOwnProperty('http') ? agent.http : null
-  const httpsAgent = agent.hasOwnProperty('https') ? agent.https : null
+  const httpAgent = Object.prototype.hasOwnProperty.call(agent, 'http') ? agent.http : null
+  const httpsAgent = Object.prototype.hasOwnProperty.call(agent, 'https') ? agent.https : null
 
   return new NodeHttpHandler({ httpAgent, httpsAgent })
 }

--- a/server/lib/object-storage/shared/client.ts
+++ b/server/lib/object-storage/shared/client.ts
@@ -1,4 +1,4 @@
-import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
+import { NodeHttpHandler } from "@aws-sdk/node-http-handler"
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { getProxy, isProxyEnabled } from '@server/helpers/proxy'
 import { S3Client } from '@aws-sdk/client-s3'
@@ -6,7 +6,7 @@ import { logger } from '@server/helpers/logger'
 import { CONFIG } from '@server/initializers/config'
 import { lTags } from './logger'
 
-function getProxyRequestHandler() {
+function getProxyRequestHandler () {
 
   if (!isProxyEnabled()) { return new NodeHttpHandler() }
 


### PR DESCRIPTION
## Description

Allows access to object storage via proxy when the administrator intends to use the forward proxy. 

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/4934

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

I dont know what unit tests to write for this. 
