### PR TITLE
(#4959) Add 'Originally Published At' sort option in videos pages

### DIFF
--- a/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
@@ -44,6 +44,7 @@
       [searchable]="false"
     >
       <ng-option i18n value="-publishedAt">Sort by <strong>"Recently Added"</strong></ng-option>
+      <ng-option i18n value="-originallyPublishedAt">Sort by <strong>"Originally Published At"</strong></ng-option>
 
       <ng-option i18n *ngIf="isTrendingSortEnabled('most-viewed')" value="-trending">Sort by <strong>"Recent Views"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('hot')" value="-hot">Sort by <strong>"Hot"</strong></ng-option>

--- a/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
@@ -44,7 +44,7 @@
       [searchable]="false"
     >
       <ng-option i18n value="-publishedAt">Sort by <strong>"Recently Added"</strong></ng-option>
-      <ng-option i18n value="-originallyPublishedAt">Sort by <strong>"Originally Published At"</strong></ng-option>
+      <ng-option i18n value="-originallyPublishedAt">Sort by <strong>"Original Publication Date"</strong></ng-option>
 
       <ng-option i18n *ngIf="isTrendingSortEnabled('most-viewed')" value="-trending">Sort by <strong>"Recent Views"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('hot')" value="-hot">Sort by <strong>"Hot"</strong></ng-option>

--- a/client/src/app/shared/shared-video-miniature/video-filters-header.component.scss
+++ b/client/src/app/shared/shared-video-miniature/video-filters-header.component.scss
@@ -101,7 +101,7 @@
 }
 
 .sort {
-  min-width: 200px;
+  min-width: 250px;
   max-width: 300px;
   height: min-content;
 

--- a/shared/models/videos/video-sort-field.type.ts
+++ b/shared/models/videos/video-sort-field.type.ts
@@ -2,6 +2,7 @@ export type VideoSortField =
   'name' | '-name' |
   'duration' | '-duration' |
   'publishedAt' | '-publishedAt' |
+  'originallyPublishedAt' | '-originallyPublishedAt' |
   'createdAt' | '-createdAt' |
   'views' | '-views' |
   'likes' | '-likes' |


### PR DESCRIPTION
## Description
This allows the user to sort videos by the **Original publication date**, allowing them to differentiate between the date of publication on PeerTube and for example the date of publication on other platforms.
<!-- Please include a summary of the change, with motivation and context -->

## Related issues
Resolves #4959 

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code

## Screenshots
![image](https://user-images.githubusercontent.com/71319302/167626207-5c8fffcf-0080-4f05-b63c-a17af3524bf6.png)

<!-- delete if not relevant -->
