### PR TITLE
Added "total views" in the my channels list

### DIFF
--- a/client/src/app/+my-library/+my-video-channels/my-video-channels.component.html
+++ b/client/src/app/+my-library/+my-video-channels/my-video-channels.component.html
@@ -36,6 +36,8 @@
 
       <div i18n class="video-channel-videos">{videoChannel.videosCount, plural, =0 {No videos} =1 {1 video} other {{{ videoChannel.videosCount }} videos}}</div>
 
+      <div i18n class="video-channel-views">{videoChannel.totalViews, plural, =0 {No views} =1 {1 view} other {{{ videoChannel.totalViews }} views}}</div>
+
       <div class="video-channel-buttons">
         <my-edit-button label [routerLink]="[ '/manage/update', videoChannel.nameWithHost ]"></my-edit-button>
         <my-delete-button label (click)="deleteVideoChannel(videoChannel)"></my-delete-button>

--- a/client/src/app/shared/shared-main/video-channel/video-channel.model.ts
+++ b/client/src/app/shared/shared-main/video-channel/video-channel.model.ts
@@ -27,6 +27,7 @@ export class VideoChannel extends Actor implements ServerVideoChannel {
   videosCount?: number
 
   viewsPerDay?: ViewsPerDate[]
+  totalViews?: number
 
   static GET_ACTOR_AVATAR_URL (actor: { avatars: { width: number, url?: string, path: string }[] }, size: number) {
     return Actor.GET_ACTOR_AVATAR_URL(actor, size)
@@ -72,6 +73,10 @@ export class VideoChannel extends Actor implements ServerVideoChannel {
 
     if (hash.viewsPerDay) {
       this.viewsPerDay = hash.viewsPerDay.map(v => ({ ...v, date: new Date(v.date) }))
+    }
+
+    if (hash.totalViews) {
+      this.totalViews = hash.totalViews
     }
 
     if (hash.ownerAccount) {

--- a/server/models/video/video-channel.ts
+++ b/server/models/video/video-channel.ts
@@ -311,6 +311,17 @@ export type SummaryOptions = {
               ')'
             ),
             'viewsPerDay'
+          ],
+          [
+            literal(
+              '(' +
+              'SELECT COALESCE(SUM("video".views), 0) AS totalViews ' +
+              'FROM "video" ' +
+              'WHERE "video"."channelId" = "VideoChannelModel"."id" ' +
+              'GROUP BY "video"."channelId" ' +
+              ')'
+            ),
+            'totalViews'
           ]
         ]
       }
@@ -766,6 +777,8 @@ ON              "Account->Actor"."serverId" = "Account->Actor->Server"."id"`
         })
     }
 
+    const totalViews = this.get('totalViews') as number
+
     const actor = this.Actor.toFormattedJSON()
     const videoChannel = {
       id: this.id,
@@ -779,6 +792,7 @@ ON              "Account->Actor"."serverId" = "Account->Actor->Server"."id"`
 
       videosCount,
       viewsPerDay,
+      totalViews,
 
       avatars: actor.avatars,
 

--- a/server/tests/api/videos/video-channels.ts
+++ b/server/tests/api/videos/video-channels.ts
@@ -478,6 +478,34 @@ describe('Test video channels', function () {
     }
   })
 
+  it('Should report correct total views count', async function() {
+    this.timeout(10000)
+
+    // check if there's the property
+    {
+      const { data } = await servers[0].channels.listByAccount({ accountName, withStats: true })
+
+      for (const channel of data) {
+        expect(channel).to.haveOwnProperty('totalViews')
+        expect(channel.totalViews).to.be.an('number')
+      }
+    }
+
+    // Check if the totalViews count can be updated
+    {
+      // video has been posted on channel servers[0].store.videoChannel.id since last update
+      await servers[0].views.simulateView({ id: videoUUID, xForwardedFor: '0.0.0.1,127.0.0.1' })
+      await servers[0].views.simulateView({ id: videoUUID, xForwardedFor: '0.0.0.2,127.0.0.1' })
+
+      // Wait the repeatable job
+      await wait(8000)
+
+      const { data } = await servers[0].channels.listByAccount({ accountName, withStats: true })
+      const channelWithView = data.find(channel => channel.id === servers[0].store.channel.id)
+      expect(channelWithView.totalViews).to.equal(2)
+    }
+  })
+
   it('Should report correct videos count', async function () {
     const { data } = await servers[0].channels.listByAccount({ accountName, withStats: true })
 

--- a/shared/models/videos/channel/video-channel.model.ts
+++ b/shared/models/videos/channel/video-channel.model.ts
@@ -18,6 +18,7 @@ export interface VideoChannel extends Actor {
 
   videosCount?: number
   viewsPerDay?: ViewsPerDate[] // chronologically ordered
+  totalViews?: number
 
   banners: ActorImage[]
 


### PR DESCRIPTION
## Description

I added a "total views" counter for each channel in the "my-channels" list.

As requested in #4484, I added a test :wink: 

## Related issues

Implements https://github.com/Chocobozzz/PeerTube/issues/4331, completes #4484.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
