### PR TITLE
Display "No subscribers" in my-library instead of "0 subscribers"

### DIFF
--- a/client/src/app/+my-library/+my-video-channels/my-video-channels.component.html
+++ b/client/src/app/+my-library/+my-video-channels/my-video-channels.component.html
@@ -31,7 +31,7 @@
         i18n class="video-channel-followers"
         [routerLink]="[ '/my-library', 'followers' ]" [queryParams]="{ search: 'channel:' + videoChannel.name }"
       >
-        {videoChannel.followersCount, plural, =1 {1 subscriber} other {{{ videoChannel.followersCount }} subscribers}}
+        {videoChannel.followersCount, plural, =0 {No subscribers} =1 {1 subscriber} other {{{ videoChannel.followersCount }} subscribers}}
       </a>
 
       <div i18n class="video-channel-videos">{videoChannel.videosCount, plural, =0 {No videos} =1 {1 video} other {{{ videoChannel.videosCount }} videos}}</div>


### PR DESCRIPTION
## Description

It displays "No subscribers" instead of "0 subscribers" in the my-library, to follow what happens with the videos count.

## Related issues

It was originally part of https://github.com/Chocobozzz/PeerTube/pull/4484, but I decided to split it into its own PR.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code


## Screenshots

![image](https://user-images.githubusercontent.com/20014332/170696415-95ca8d89-8523-4af1-84f6-375f04f0155f.png)
