### PR TITLE
Use correct URI for schema.org in `@context`

### DIFF
--- a/server/lib/activitypub/context.ts
+++ b/server/lib/activitypub/context.ts
@@ -179,7 +179,7 @@ function buildContext (contextValue?: ContextValue) {
 
     {
       pt: 'https://joinpeertube.org/ns#',
-      sc: 'http://schema.org#',
+      sc: 'http://schema.org/',
 
       ...contextValue
     }


### PR DESCRIPTION
## Description

schema.org should resolve properly, but it currently does not, due to the usage of a hash instead of a slash

## Related issues

Fix #5019

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help

i do not know enough about how peertube processes JSON(LD) in order to know for sure that this will not cause any other issues. if peertube uses plain json, then it should be fine. if peertube uses json-ld, then some additional compatibility code might be necessary.