### PR TITLE
add configs for local development

### DIFF
--- a/development.md
+++ b/development.md
@@ -1,0 +1,28 @@
+### Usage
+1. Build the image:
+	```
+	docker-compose build
+	```
+2. Start the container:
+	```
+	docker-compose --env-file ./support/docker/development/.env.local up -d
+	```
+	Or without daemon:
+	```
+	docker-compose --env-file ./support/docker/development/.env.local up
+	```
+	Wait all resources will started.
+
+3. Change root user password:
+
+   `docker-compose exec peertube npm run reset-password -- -u root`
+
+4. Remove containers:
+    ```
+    docker-compose --env-file ./support/docker/development/.env.local down
+    ```
+    Or also remove volumes:
+    
+    :warning: This step will remove all data e.g. plugins, videos, db, etc...
+    ```
+    docker-compose --env-file ./support/docker/development/.env.local down -v

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,118 @@
+version: "3.5"
+
+
+services:
+
+  s3:
+    image: minio/minio
+    ports:
+      - "9001:9001"
+    volumes:
+      - data:/data
+    env_file:
+      - ./support/docker/development/.env.local
+    environment:
+      MINIO_ROOT_USER: ${MINIO_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_PASSWORD}
+    command: server --address 0.0.0.0:9000 --console-address :9001 /data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  s3-service:
+    image: minio/mc
+    depends_on:
+      s3:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set peertube http://s3:9000 ${MINIO_USER} ${MINIO_PASSWORD};
+      /usr/bin/mc mb peertube/storage;
+      /usr/bin/mc policy set public peertube/storage;
+      "
+
+  peertube:
+    build:
+      context: .
+      dockerfile: ./support/docker/development/Dockerfile.development
+    networks:
+      default:
+        ipv4_address: 172.18.0.42
+    privileged: true
+    env_file:
+      - ./support/docker/development/.env.local
+    ports:
+     - "1935:1935" 
+     - "3000:3000"
+     - "9000:9000" 
+    volumes:
+      - ./config/default.yaml:/app/config/default.yaml
+      - ./support/docker/production/config/custom-environment-variables.yaml:/app/config/custom-environment-variables.yaml
+      - ./client/e2e:/app/client/e2e
+      - ./client/src:/app/client/src
+      - ./client/webpack:/app/client/webpack
+      - ./packages:/app/packages
+      - ./scripts:/app/scripts
+      - ./server:/app/server
+      - ./shared:/app/shared
+      - ./support:/app/support
+      - ./package.json:/app/package.json
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      s3:
+        condition: service_healthy
+    restart: "always"
+    command: >
+      /bin/sh -c "
+      sleep 5;
+      echo "${MINIO_USER}:${MINIO_PASSWORD}" > /app/s3cred;
+      chmod 600 /app/s3cred;
+      mkdir /app/storage;
+      s3fs storage /app/storage -o passwd_file=/app/s3cred,use_path_request_style,url=http://s3:9000;
+      npm run dev:client;
+      "
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+
+  postgres:
+    image: postgres:13-alpine
+    env_file:
+      - ./support/docker/development/.env.local
+    volumes:
+      - db:/var/lib/postgresql/data
+      - ./support/docker/gitpod/setup_postgres.sql:/docker-entrypoint-initdb.d/init.sql
+    restart: "always"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-U", "peertube"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:6-alpine
+    volumes:
+      - redis:/data
+    restart: "always"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+
+networks:
+  default:
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.18.0.0/16
+
+volumes:
+  data:
+  db:
+  redis:
+

--- a/support/docker/development/.env.local
+++ b/support/docker/development/.env.local
@@ -1,0 +1,18 @@
+# Minio configuration
+MINIO_USER=minio_access_key
+MINIO_PASSWORD=minio_secret_key
+# Database / Postgres service configuration
+POSTGRES_USER=peertube
+POSTGRES_PASSWORD=peertube
+# Postgres database name 
+POSTGRES_DB=peertube_dev
+PEERTUBE_DB_USERNAME=peertube
+PEERTUBE_DB_PASSWORD=peertube
+PEERTUBE_DB_SSL=false
+# Default to Postgres service name "postgres" in docker-compose.yml
+PEERTUBE_DB_HOSTNAME=postgres
+
+PEERTUBE_REDIS_HOSTNAME=redis
+PEERTUBE_REDIS_PORT=6379
+
+PEERTUBE_TRUST_PROXY=["127.0.0.1", "loopback", "172.18.0.0/16"]

--- a/support/docker/development/Dockerfile.development
+++ b/support/docker/development/Dockerfile.development
@@ -1,0 +1,22 @@
+FROM node:16-bullseye-slim
+
+# Install dependencies
+RUN apt update \
+ && apt install -y --no-install-recommends openssl ffmpeg python3 ca-certificates gnupg gosu build-essential curl git s3fs \
+ && gosu nobody true \
+ && rm /var/lib/apt/lists/* -fR
+
+# Add peertube user
+RUN groupadd -r peertube \
+    && useradd -r -g peertube -m peertube
+
+COPY --chown=peertube:peertube . /app
+WORKDIR /app
+
+USER peertube
+
+# Install manually client dependencies
+RUN yarn install --pure-lockfile
+RUN npm run build
+# Expose API and RTMP
+EXPOSE 9000 1935


### PR DESCRIPTION
## Description

This PR adds docker development.
Features:
1. Saves storage folder in minio s3 bucket.
2. Postgres, redis databases use docker volumes.
3. Attaching the Minio s3 bucket to the [PeerTube](https://github.com/Chocobozzz/PeerTube) container using s3fs.
4. Support for autoload code changes. (Tested on frontend)

P.S. Seems this changes can help to community deploy [PeerTube](https://github.com/Chocobozzz/PeerTube) on local machine with docker is very simply. If there are any changes or problems, please let me know. 
## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

