### PR TITLE
fixes video not played from defined parameters in embed service 

### DIFF
--- a/server/controllers/services.ts
+++ b/server/controllers/services.ts
@@ -4,6 +4,7 @@ import { asyncMiddleware, oembedValidator } from '../middlewares'
 import { accountNameWithHostGetValidator } from '../middlewares/validators'
 import { MChannelSummary } from '@server/types/models'
 import { escapeHTML } from '@shared/core-utils/renderer'
+import { logger } from '@server/helpers/logger'
 
 const servicesRouter = express.Router()
 
@@ -48,10 +49,13 @@ function generatePlaylistOEmbed (req: express.Request, res: express.Response) {
 function generateVideoOEmbed (req: express.Request, res: express.Response) {
   const video = res.locals.videoAll
 
+  const regex = /\?[^?]*$/
+  const params = regex.test(req.query.url) ? req.query.url.match(regex) : ''
+
   const json = buildOEmbed({
     channel: video.VideoChannel,
     title: video.name,
-    embedPath: video.getEmbedStaticPath(),
+    embedPath: video.getEmbedStaticPath() + params,
     previewPath: video.getPreviewStaticPath(),
     previewSize: PREVIEWS_SIZE,
     req

--- a/server/tests/api/server/services.ts
+++ b/server/tests/api/server/services.ts
@@ -13,6 +13,21 @@ describe('Test services', function () {
   let playlistDisplayName: string
   let video: Video
 
+  const urlSuffixes = [
+    {
+      input: '',
+      output: ''
+    },
+    {
+      input: '?param=1',
+      output: ''
+    },
+    {
+      input: '?muted=1&warningTitle=0&toto=1',
+      output: '?muted=1&warningTitle=0'
+    }
+  ]
+
   before(async function () {
     this.timeout(30000)
 
@@ -52,14 +67,15 @@ describe('Test services', function () {
 
   it('Should have a valid oEmbed video response', async function () {
     for (const basePath of [ '/videos/watch/', '/w/' ]) {
-      for (const suffix of [ '', '?param=1' ]) {
-        const oembedUrl = server.url + basePath + video.uuid + suffix
+      for (const suffix of urlSuffixes) {
+        const oembedUrl = server.url + basePath + video.uuid + suffix.input
 
         const res = await server.services.getOEmbed({ oembedUrl })
         const expectedHtml = '<iframe width="560" height="315" sandbox="allow-same-origin allow-scripts allow-popups" ' +
-          `title="${video.name}" src="http://localhost:${server.port}/videos/embed/${video.uuid}" ` +
+          `title="${video.name}" src="http://${server.host}/videos/embed/${video.uuid}${suffix.output}" ` +
           'frameborder="0" allowfullscreen></iframe>'
-        const expectedThumbnailUrl = 'http://localhost:' + server.port + video.previewPath
+
+        const expectedThumbnailUrl = 'http://' + server.host + video.previewPath
 
         expect(res.body.html).to.equal(expectedHtml)
         expect(res.body.title).to.equal(video.name)
@@ -75,12 +91,12 @@ describe('Test services', function () {
 
   it('Should have a valid playlist oEmbed response', async function () {
     for (const basePath of [ '/videos/watch/playlist/', '/w/p/' ]) {
-      for (const suffix of [ '', '?param=1' ]) {
-        const oembedUrl = server.url + basePath + playlistUUID + suffix
+      for (const suffix of urlSuffixes) {
+        const oembedUrl = server.url + basePath + playlistUUID + suffix.input
 
         const res = await server.services.getOEmbed({ oembedUrl })
         const expectedHtml = '<iframe width="560" height="315" sandbox="allow-same-origin allow-scripts allow-popups" ' +
-          `title="${playlistDisplayName}" src="http://localhost:${server.port}/video-playlists/embed/${playlistUUID}" ` +
+          `title="${playlistDisplayName}" src="http://${server.host}/video-playlists/embed/${playlistUUID}${suffix.output}" ` +
           'frameborder="0" allowfullscreen></iframe>'
 
         expect(res.body.html).to.equal(expectedHtml)
@@ -97,14 +113,14 @@ describe('Test services', function () {
 
   it('Should have a valid oEmbed response with small max height query', async function () {
     for (const basePath of [ '/videos/watch/', '/w/' ]) {
-      const oembedUrl = 'http://localhost:' + server.port + basePath + video.uuid
+      const oembedUrl = 'http://' + server.host + basePath + video.uuid
       const format = 'json'
       const maxHeight = 50
       const maxWidth = 50
 
       const res = await server.services.getOEmbed({ oembedUrl, format, maxHeight, maxWidth })
       const expectedHtml = '<iframe width="50" height="50" sandbox="allow-same-origin allow-scripts allow-popups" ' +
-        `title="${video.name}" src="http://localhost:${server.port}/videos/embed/${video.uuid}" ` +
+        `title="${video.name}" src="http://${server.host}/videos/embed/${video.uuid}" ` +
         'frameborder="0" allowfullscreen></iframe>'
 
       expect(res.body.html).to.equal(expectedHtml)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Since the oembed service of peertube ignores the parameters passed in the URL, here with the changes the parameters are added to the oembed URL by extracting the query parameters.



## Related issues

This fixes issue [#4974](https://github.com/Chocobozzz/PeerTube/issues/4974)

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots
![image](https://user-images.githubusercontent.com/26194365/172312466-f86e9b15-286c-4c39-a173-64326c69f061.png)
![image](https://user-images.githubusercontent.com/26194365/172312879-a3535b99-e898-43bf-86f3-41f6abc12931.png)
<!-- delete if not relevant -->
