### PR TITLE
Ensure peertube root directory is setup to be traversed by nginx

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -25,9 +25,9 @@ Set its password:
 $ sudo passwd peertube
 ```
 
-Ensure the directory is traversable:
+Ensure the directory is traversable by nginx:
 ```bash
-$ chmod a+rx /var/www/peertube
+$ chmod 751 /var/www/peertube
 ```
 
 **On FreeBSD**

--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -25,9 +25,9 @@ Set its password:
 $ sudo passwd peertube
 ```
 
-Ensure the directory is traversable by nginx:
+Ensure the peertube root directory is traversable by nginx:
 ```bash
-$ chmod 751 /var/www/peertube
+$ sudo chmod 751 /var/www/peertube
 ```
 
 **On FreeBSD**

--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -25,6 +25,11 @@ Set its password:
 $ sudo passwd peertube
 ```
 
+Ensure the directory is traversable:
+```bash
+$ chmod a+rx /var/www/peertube
+```
+
 **On FreeBSD**
 
 ```bash

--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -26,8 +26,9 @@ $ sudo passwd peertube
 ```
 
 Ensure the peertube root directory is traversable by nginx:
+
 ```bash
-$ sudo chmod 751 /var/www/peertube
+$ ls -ld /var/www/peertube # Should be drwxr-xr-x
 ```
 
 **On FreeBSD**


### PR DESCRIPTION
## Description

On Ubuntu 22.04, the dir `/var/www/peertube` is restricted to user peertube & group peertube. This causes issues with many of the subsequent sudo commands, and also results in white-screen on initial visit to the site due to JS files not being accessible. 

JS console output:
```
Loading module from “https://watch.thelema.social/client/en-US/runtime.a28a87033973e138.js” was blocked because of a disallowed MIME type (“text/html”).
Loading module from “https://watch.thelema.social/client/en-US/polyfills.4dee205ae13c48d1.js” was blocked because of a disallowed MIME type (“text/html”).
Loading module from “https://watch.thelema.social/client/en-US/main.559407a6b86e978c.js” was blocked because of a disallowed MIME type (“text/html”).
Loading failed for the module with source “https://watch.thelema.social/client/en-US/runtime.a28a87033973e138.js”.
Loading failed for the module with source “https://watch.thelema.social/client/en-US/polyfills.4dee205ae13c48d1.js”.
Loading failed for the module with source “https://watch.thelema.social/client/en-US/main.559407a6b86e978c.js”.
downloadable font: download failed (font-family: "Source Sans Pro" style:normal weight:200..900 stretch:100 src index:0): status=2147746065 source: https://watch.thelema.social/client/en-US/SourceSans3VF-Roman.ttf.1befb5b37992491d.woff2
```

Permissions on `/var/www/peertube` during the issue:
```bash
peertube@hostname:/var/www$ ls -la
total 16
drwxr-xr-x  4 root     root     4096 Jun  7 18:30 .
drwxr-xr-x 13 root     root     4096 Jun  7 18:29 ..
drwxr-xr-x  2 root     root     4096 Jun  7 18:29 html
drwxr-x---  7 peertube peertube 4096 Jun  7 20:02 peertube
```

This PR loosens those requirements by simply allowing all users execute perms on that directory, but maybe would be better if nginx is just added to peertube group? This is my first time installing PeertTube, so I'll defer to someone with more knowledge of this framework and implications to vet the approach here.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
