### PR TITLE
Implement 5036: more readable diff on configuration file when upgrading.

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -78,7 +78,8 @@ ln -s "$PEERTUBE_PATH/versions/peertube-${VERSION}" $PEERTUBE_PATH/peertube-late
 cp $PEERTUBE_PATH/peertube-latest/config/default.yaml $PEERTUBE_PATH/config/default.yaml
 
 echo "Differences in configuration files..."
-diff -u $PEERTUBE_PATH/config/production.yaml "$PEERTUBE_PATH/versions/peertube-${VERSION}/config/production.yaml.example"
+cd $PEERTUBE_PATH/versions
+diff -u "$(ls --sort=t | head -2 | tail -1)/config/production.yaml.example" "$(ls --sort=t | head -1)/config/production.yaml.example"
 
 echo ""
 echo "==========================================="

--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -339,6 +339,15 @@ $ cd /var/www/peertube && \
     sudo -u peertube ln -s versions/peertube-${VERSION} ./peertube-latest
 ```
 
+### Configuration
+
+You can check for configuration changes, and report them in your `config/production.yaml` file:
+
+```bash
+$ cd /var/www/peertube/versions
+$ diff -u "$(ls --sort=t | head -2 | tail -1)/config/production.yaml.example" "$(ls --sort=t | head -1)/config/production.yaml.example"
+```
+
 ### nginx
 
 Check changes in nginx configuration:


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

More readable diff on configuration file when upgrading.
When we use the upgrade.sh script, the script does a diff between the current production.yaml file and the production.yaml.example file. This diff is difficult to read, because there are many customizations in the production.yaml file.

This PR replaces the diff in upgrade.sh by the same kind of diff mentioned in the documentation for nginx and systemd: a diff between production.yaml.example in the 2 last available versions.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

https://github.com/Chocobozzz/PeerTube/issues/5036

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
