### PR TITLE
Fix password for root in dev mode

### DIFF
--- a/server/initializers/installer.ts
+++ b/server/initializers/installer.ts
@@ -10,6 +10,7 @@ import { applicationExist, clientsExist, usersExist } from './checker-after-init
 import { CONFIG } from './config'
 import { FILES_CACHE, HLS_STREAMING_PLAYLIST_DIRECTORY, LAST_MIGRATION_VERSION, RESUMABLE_UPLOAD_DIRECTORY } from './constants'
 import { sequelizeTypescript } from './database'
+import { isTestOrDevInstance } from '@server/helpers/core-utils'
 
 async function installApplication () {
   try {
@@ -135,8 +136,8 @@ async function createOAuthAdminIfNotExist () {
   let validatePassword = true
   let password = ''
 
-  // Do not generate a random password for tests
-  if (process.env.NODE_ENV === 'test') {
+  // Do not generate a random password for test and dev environments
+  if (isTestOrDevInstance()) {
     password = 'test'
 
     if (process.env.NODE_APP_INSTANCE) {


### PR DESCRIPTION
## Description
Password should remain "test" in dev mode for root.
Fix regression of 9452d4fd33 which introduces NODE_ENV=dev

Steps to reproduce:
```bash
sudo -u postgres dropdb peertube_dev
sudo -u postgres createdb -O peertube peertube_dev
sudo -u postgres psql -c "CREATE EXTENSION unaccent;" peertube_dev
sudo -u postgres psql -c "CREATE EXTENSION pg_trgm;" peertube_dev
```

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
