### PR TITLE
document parallel depedency for tests and how to install it

### DIFF
--- a/support/doc/development/tests.md
+++ b/support/doc/development/tests.md
@@ -33,8 +33,14 @@ $ sudo docker run -p 10389:10389 chocobozzz/docker-test-openldap
 
 Ensure you also have these commands:
 
-```
+```bash
 $ exiftool --help
+$ parallel --help
+```
+
+Otherwise, install the packages. On Debian-based systems (like Debian, Ubuntu or Mint):
+```bash
+$ sudo apt-get install parallel libimage-exiftool-perl
 ```
 
 ### Test


### PR DESCRIPTION
## Description

Nowhere the contributor is told to install parallel. This fixes that.

Also explain how to install parallel and exiftool on debian-based systems.

## Related issues

N/A

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->