### PR TITLE
Fix lint on server/lib/hls.ts

### DIFF
--- a/server/lib/hls.ts
+++ b/server/lib/hls.ts
@@ -100,7 +100,7 @@ function updateMasterHLSPlaylist (video: MVideo, playlistArg: MStreamingPlaylist
 
 // ---------------------------------------------------------------------------
 
-async function updateSha256VODSegments (video: MVideo, playlistArg: MStreamingPlaylist): Promise<MStreamingPlaylistFilesVideo> {
+function updateSha256VODSegments (video: MVideo, playlistArg: MStreamingPlaylist): Promise<MStreamingPlaylistFilesVideo> {
   return playlistFilesQueue.add(async () => {
     const json: { [filename: string]: { [range: string]: string } } = {}
 


### PR DESCRIPTION
npm run lint report an error on server/lib/hls.ts

And indeed, the `async` is useless in this function as we just need to return the result of `playlistFilesQueue.add` which is a Promise.