### PR TITLE
Disallow sending analytics data to Angular team

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -330,5 +330,8 @@
     "@schematics/angular:directive": {
       "prefix": "my"
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }


### PR DESCRIPTION
## Description

Each time we run `npm run build`, a prompt asks us whether we want to send analytics data to angular.

I think we should disallow that by default.