### PR TITLE
Tests: Add response error along with unexpected status in report

### DIFF
--- a/shared/server-commands/requests/requests.ts
+++ b/shared/server-commands/requests/requests.ts
@@ -172,7 +172,6 @@ function buildRequest (req: request.Test, options: CommonRequestParams) {
   if (options.accept) req.set('Accept', options.accept)
   if (options.host) req.set('Host', options.host)
   if (options.redirects) req.redirects(options.redirects)
-  if (options.expectedStatus) req.expect(options.expectedStatus)
   if (options.xForwardedFor) req.set('X-Forwarded-For', options.xForwardedFor)
   if (options.type) req.type(options.type)
 
@@ -180,7 +179,15 @@ function buildRequest (req: request.Test, options: CommonRequestParams) {
     req.set(name, options.headers[name])
   })
 
-  return req
+  return req.expect((res) => {
+    if (options.expectedStatus && res.status !== options.expectedStatus) {
+      throw new Error(`Expected status ${options.expectedStatus}, got ${res.status}. ` +
+        `\nThe server responded this error: "${res.body?.error ?? res.text}".\n` +
+        'You may take a closer look at the logs. To see how to do so, check out this page: ' +
+        'https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/development/tests.md#debug-server-logs')
+    }
+    return res
+  })
 }
 
 function buildFields (req: request.Test, fields: { [ fieldName: string ]: any }, namespace?: string) {


### PR DESCRIPTION
## Description

Show the error message the server returned in the response when the status is not the one expected.

Note: I proposed to help the user so they can see more details in log. The last line displays a URL. I am not very sure of the relevancy, feedback welcome.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

![2022-08-11_17-29](https://user-images.githubusercontent.com/371705/184171117-e4cb2fbc-5846-4ff3-a518-5f4cf9112472.png)