### PR TITLE
Allow continusously printing logs through tail and parse-log

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,11 +7,11 @@ root = true
 end_of_line = lf
 charset = utf-8
 
-[*.yml]
+[*.{yml,html}]
 indent_style = space
 indent_size = 2
 
-[{client,server,shared}/**.{ts,json,js}]
+[{client,server,shared,scripts}/**.{ts,json,js}]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space

--- a/scripts/parse-log.ts
+++ b/scripts/parse-log.ts
@@ -1,6 +1,7 @@
 import { program } from 'commander'
 import { createReadStream, readdir } from 'fs-extra'
 import { join } from 'path'
+import { stdin } from 'process'
 import { createInterface } from 'readline'
 import { format as sqlFormat } from 'sql-formatter'
 import { inspect } from 'util'
@@ -89,7 +90,7 @@ async function run () {
 function readFile (file: string) {
   console.log('Opening %s.', file)
 
-  const stream = createReadStream(file)
+  const stream = file === '-' ? stdin : createReadStream(file)
 
   const rl = createInterface({
     input: stream
@@ -117,7 +118,7 @@ function readFile (file: string) {
       }
     })
 
-    stream.once('close', () => res())
+    stream.once('end', () => res())
   })
 }
 

--- a/support/doc/development/tests.md
+++ b/support/doc/development/tests.md
@@ -79,6 +79,19 @@ While testing, you might want to display a server's logs to understand why they 
 NODE_APP_INSTANCE=1 NODE_ENV=test npm run parse-log -- --level debug | less +GF
 ```
 
+You can also:
+ - checkout only the latest logs (PeerTube >= 5.0):
+
+```bash
+tail -n 100 test1/logs/peertube.log | npm run parse-log -- --level debug --files -
+```
+
+ - continuously print the latests logs (PeerTube >= 5.0):
+
+```bash
+tail -f test1/logs/peertube.log | npm run parse-log -- --level debug --files -
+```
+
 
 ## Client E2E tests
 


### PR DESCRIPTION
## Description

While testing APIs, one may want to only print latest logs and continuously follow them in order to ease the logs analysis.

This PR aims at allowing parse-log to read stdin so it can be piped with the output of commands like `tail` and `tail -f`.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
