### PR TITLE
Add additional certbot configuration information

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -166,6 +166,9 @@ Since our nginx template supports webroot renewal, we suggest you to update the 
 ```bash
 $ # Replace authenticator = standalone by authenticator = webroot
 $ # Add webroot_path = /var/www/certbot
+$ # Add the following below webroot_path:
+$ # [[webroot_map]]
+$ # yourdomain.tld = /var/www/certbot
 $ sudo vim /etc/letsencrypt/renewal/your-domain.com.conf
 ```
 


### PR DESCRIPTION
## Description
As described [here](https://community.letsencrypt.org/t/auto-renewal-started-failing-with-error-missing-command-line-flag-or-config-entry-for-this-setting/111211/4) there must be a `[[webroot_map]]` entry for each domain in the certbot .conf file. This should be included in the documentation.

## Related issues
N/A

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
