### PR TITLE
p2p-media-loader: dont validate segments from http

### DIFF
--- a/client/src/assets/player/shared/p2p-media-loader/segment-validator.ts
+++ b/client/src/assets/player/shared/p2p-media-loader/segment-validator.ts
@@ -12,6 +12,8 @@ function segmentValidatorFactory (segmentsSha256Url: string, isLive: boolean) {
   const regex = /bytes=(\d+)-(\d+)/
 
   return async function segmentValidator (segment: Segment, _method: string, _peerId: string, retry = 1) {
+    if (_method === 'http') return
+
     // Wait for hash generation from the server
     if (isLive) await wait(1000)
 


### PR DESCRIPTION
## Description
Validating segments shouldn't be needed when they're fetched from http.


## Has this been tested?

- [x] 🙅 no, because this PR does not update server code
