### PR TITLE
server: treat WAITING_FOR_LIVE as available

### DIFF
--- a/server/models/video/sql/video/videos-id-list-query-builder.ts
+++ b/server/models/video/sql/video/videos-id-list-query-builder.ts
@@ -315,6 +315,7 @@ export class VideosIdListQueryBuilder extends AbstractRunQuery {
   private whereStateAvailable () {
     this.and.push(
       `("video"."state" = ${VideoState.PUBLISHED} OR ` +
+      `"video"."state" = ${VideoState.WAITING_FOR_LIVE} OR ` +
       `("video"."state" = ${VideoState.TO_TRANSCODE} AND "video"."waitTranscoding" IS false))`
     )
   }

--- a/server/tests/api/live/live.ts
+++ b/server/tests/api/live/live.ts
@@ -162,12 +162,12 @@ describe('Test live', function () {
       }
     })
 
-    it('Should not have the live listed since nobody streams into', async function () {
+    it('Should have the live listed since its public', async function () {
       for (const server of servers) {
         const { total, data } = await server.videos.list()
 
-        expect(total).to.equal(0)
-        expect(data).to.have.lengthOf(0)
+        expect(total).to.equal(1)
+        expect(data).to.have.lengthOf(1)
       }
     })
 


### PR DESCRIPTION
## Description
Treat public lives as available, even if they don't have a stream since it can be a way to announce that a live is upcoming.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #5235


<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 👍 yes, I added tests to the test suite
