### PR TITLE
WIP: Skip over YouTube post-live manifestless mode videos during import

### DIFF
--- a/server/helpers/youtube-dl/youtube-dl-base-builder.ts
+++ b/server/helpers/youtube-dl/youtube-dl-base-builder.ts
@@ -1,0 +1,26 @@
+class YoutubeDLBaseBuilder {
+  normalizeObject (obj: any): any {
+    const newObj: any = {}
+
+    for (const key of Object.keys(obj)) {
+      // Deprecated key
+      if (key === 'resolution') continue
+
+      const value = obj[key]
+
+      if (typeof value === 'string') {
+        newObj[key] = value.normalize()
+      } else {
+        newObj[key] = value
+      }
+    }
+
+    return newObj
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+export {
+  YoutubeDLBaseBuilder
+}

--- a/server/helpers/youtube-dl/youtube-dl-cli.ts
+++ b/server/helpers/youtube-dl/youtube-dl-cli.ts
@@ -11,7 +11,32 @@ const lTags = loggerTagsFactory('youtube-dl')
 
 const youtubeDLBinaryPath = join(CONFIG.STORAGE.BIN_DIR, CONFIG.IMPORT.VIDEOS.HTTP.YOUTUBE_DL_RELEASE.NAME)
 
-export class YoutubeDLCLI {
+type YoutubeDLCLIResult = {
+  title?: string
+  description?: string
+  categories?: string[]
+  license?: string
+  language?: string
+  age_limit?: number
+  tags?: string[]
+  thumbnail?: string
+  url?: string
+  urls?: string[] | string
+  // TODO: structure for formats
+  formats?: any[]
+  // TODO: structure for thumbnails
+  thumbnails?: any[]
+  // TODO: structure for subtitles
+  subtitles?: any[]
+  upload_date?: string
+  ext: string
+  webpage_url: string
+  live_status?: string
+  ie_key?: string
+  duration?: number
+}
+
+class YoutubeDLCLI {
 
   static async safeGet () {
     if (!await pathExists(youtubeDLBinaryPath)) {
@@ -120,7 +145,7 @@ export class YoutubeDLCLI {
     format: string
     processOptions: execa.NodeOptions
     additionalYoutubeDLArgs?: string[]
-  }) {
+  }): Promise<YoutubeDLCLIResult | YoutubeDLCLIResult[]> {
     const { url, format, additionalYoutubeDLArgs = [], processOptions } = options
 
     const completeArgs = additionalYoutubeDLArgs.concat([ '--dump-json', '-f', format ])
@@ -139,7 +164,7 @@ export class YoutubeDLCLI {
     url: string
     latestVideosCount?: number
     processOptions: execa.NodeOptions
-  }): Promise<{ upload_date: string, webpage_url: string }[]> {
+  }): Promise<Partial<YoutubeDLCLIResult> | Partial<YoutubeDLCLIResult>[]> {
     const additionalYoutubeDLArgs = [ '--skip-download', '--playlist-reverse' ]
 
     if (CONFIG.IMPORT.VIDEOS.HTTP.YOUTUBE_DL_RELEASE.NAME === 'yt-dlp') {
@@ -246,4 +271,11 @@ export class YoutubeDLCLI {
 
     return args
   }
+}
+
+// ---------------------------------------------------------------------------
+
+export {
+  YoutubeDLCLIResult,
+  YoutubeDLCLI
 }

--- a/server/helpers/youtube-dl/youtube-dl-error.ts
+++ b/server/helpers/youtube-dl/youtube-dl-error.ts
@@ -1,0 +1,49 @@
+class YoutubeDLError extends Error {
+  status: YoutubeDLError.STATUS
+  url?: string
+  cause?: Error // TODO: Property to remove once ES2022 is used
+
+  constructor ({ status, url }) {
+    super(YoutubeDLError.reasonFromStatus(status, url))
+    this.status = status
+    this.url = url
+  }
+
+  static reasonFromStatus (status: YoutubeDLError.STATUS, url: string): string {
+    switch (status) {
+      case YoutubeDLError.STATUS.IS_LIVE:
+        return `Video ${url} is currently livestreaming`
+      case YoutubeDLError.STATUS.TO_BE_PUBLISHED:
+        return `Video ${url} has not been published yet`
+      case YoutubeDLError.STATUS.NOT_POST_PROCESSED:
+        return `Video ${url} is currently post processing`
+      case YoutubeDLError.STATUS.NO_FORMATS_AVAILABLE:
+        return `Video ${url} has no downloadable video formats available`
+      case YoutubeDLError.STATUS.VIDEO_AVAILABILITY_ERROR:
+        return `Video ${url} not available for import`
+    }
+  }
+
+  static fromError (err: Error, status: YoutubeDLError.STATUS, url: string) {
+    const ytDlErr = new this({ url, status })
+    ytDlErr.cause = err
+    ytDlErr.stack = err.stack // TODO: Useless once ES2022 is used
+    return ytDlErr
+  }
+}
+
+namespace YoutubeDLError {
+  export enum STATUS {
+    VIDEO_AVAILABILITY_ERROR,
+    NO_FORMATS_AVAILABLE,
+    NOT_POST_PROCESSED,
+    IS_LIVE,
+    TO_BE_PUBLISHED
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+export {
+  YoutubeDLError
+}

--- a/server/helpers/youtube-dl/youtube-dl-list-builder.ts
+++ b/server/helpers/youtube-dl/youtube-dl-list-builder.ts
@@ -1,0 +1,38 @@
+import { YoutubeDLBaseBuilder } from './youtube-dl-base-builder'
+import { YoutubeDLInfo } from './youtube-dl-info-builder'
+import { YoutubeDLCLIResult } from './youtube-dl-cli'
+
+class YoutubeDLListBuilder extends YoutubeDLBaseBuilder {
+  private readonly list: any[]
+
+  constructor (list: any[]) {
+    super()
+    this.list = [ ...list ]
+  }
+
+  getList (): Partial<YoutubeDLInfo>[] {
+    return this.buildList(this.normalizeList(this.list))
+  }
+
+  private normalizeList (entries: any[]) {
+    return entries.map((item) => {
+      return this.normalizeObject(item)
+    })
+  }
+
+  private buildList (entries: Partial<YoutubeDLCLIResult>[]): Partial<YoutubeDLInfo>[] {
+    return entries.map((item) => {
+      const info: Partial<YoutubeDLInfo> = {
+        webpageUrl: item.webpage_url
+      }
+
+      return info
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+export {
+  YoutubeDLListBuilder
+}

--- a/server/helpers/youtube-dl/youtube-dl-live-status.enum.ts
+++ b/server/helpers/youtube-dl/youtube-dl-live-status.enum.ts
@@ -1,0 +1,12 @@
+enum YoutubeDLLiveStatus {
+  LIVE = 'is_live',
+  POST_PROCESSING = 'post_live',
+  TO_BE_PUBLISHED = 'is_upcoming',
+  NOT_LIVE = 'not_live'
+}
+
+// ---------------------------------------------------------------------------
+
+export {
+  YoutubeDLLiveStatus
+}

--- a/server/helpers/youtube-dl/youtube-dl-subs.ts
+++ b/server/helpers/youtube-dl/youtube-dl-subs.ts
@@ -1,0 +1,11 @@
+type YoutubeDLSubs = {
+  language: string
+  filename: string
+  path: string
+}[]
+
+// ---------------------------------------------------------------------------
+
+export {
+  YoutubeDLSubs
+}

--- a/server/lib/video-import.ts
+++ b/server/lib/video-import.ts
@@ -33,7 +33,7 @@ import { updateVideoMiniatureFromExisting, updateVideoMiniatureFromUrl } from '.
 
 class YoutubeDlImportError extends Error {
   code: YoutubeDlImportError.CODE
-  cause?: Error // Property to remove once ES2022 is used
+  cause?: Error // TODO: Property to remove once ES2022 is used
   constructor ({ message, code }) {
     super(message)
     this.code = code
@@ -42,7 +42,7 @@ class YoutubeDlImportError extends Error {
   static fromError (err: Error, code: YoutubeDlImportError.CODE, message?: string) {
     const ytDlErr = new this({ message: message ?? err.message, code })
     ytDlErr.cause = err
-    ytDlErr.stack = err.stack // Useless once ES2022 is used
+    ytDlErr.stack = err.stack // TODO: Useless once ES2022 is used
     return ytDlErr
   }
 }


### PR DESCRIPTION
🚧👷 **Do not merge** Refactoring.

# Depends on
✔️ ~~- [yt-dlp](https://github.com/yt-dlp/yt-dlp) releasing a new version that includes fixes related to fetching `live_status`.~~

## Description

PeerTube currently syncs videos that are still being post-processed by YouTube. This results in [incomplete and cut off videos](https://github.com/yt-dlp/yt-dlp/issues/1564) (post-live manifestless mode) to be imported.

The code in this PR resolves that issue.

## Changes

- Videos in post-live manifestless mode are filtered out from `youtube-dl` playlists and direct retrieval by URL will error out.
- Seperated out the `YoutubeDLInfoBuilder` to a generic base builder and implemented a builder for `yt-dlp` playlist data.
- Added `youtube-dl` tag to various log calls to aid in debugging.
- Added `channel-sync` tag to the log calls inside the channel synchronization task.
- Implemented TypeScript types for `youtube-dl`'s JSON-LD output.
- Add type hints to functions inside YoutubeDLInfoBuilder.
- Remove redundant null check in isNSFW

## Related issues

Fixes #5331

## Has this been tested?

Unsure how we can test this reliably in a programmatic matter using unit tests, as it relies on YouTube's transcoding behavior in long livestreams.

It has however been tested in production on [pcbu.nl](https://pcbu.nl/)

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
