### PR TITLE
Sync channel: move the list imports button #5337

### DIFF
--- a/client/src/app/+my-library/my-video-channel-syncs/my-video-channel-syncs.component.html
+++ b/client/src/app/+my-library/my-video-channel-syncs/my-video-channel-syncs.component.html
@@ -36,7 +36,6 @@
       <th style="width: 10%" i18n pSortableColumn="state">State <p-sortIcon field="state"></p-sortIcon></th>
       <th style="width: 10%" i18n pSortableColumn="createdAt">Created <p-sortIcon field="createdAt"></p-sortIcon></th>
       <th style="width: 10%" i18n pSortableColumn="lastSyncAt">Last synchronization at <p-sortIcon field="lastSyncAt"></p-sortIcon></th>
-      <th></th>
     </tr>
   </ng-template>
 
@@ -79,12 +78,6 @@
 
       <td>{{ videoChannelSync.createdAt | date: 'short' }}</td>
       <td>{{ videoChannelSync.lastSyncAt | date: 'short' }}</td>
-
-      <td>
-        <a i18n routerLink="/my-library/video-imports" [queryParams]="{ search: 'videoChannelSyncId:' + videoChannelSync.id }" class="peertube-button-link grey-button">
-          List imports
-        </a>
-      </td>
     </tr>
   </ng-template>
 </p-table>

--- a/client/src/app/+my-library/my-video-channel-syncs/my-video-channel-syncs.component.ts
+++ b/client/src/app/+my-library/my-video-channel-syncs/my-video-channel-syncs.component.ts
@@ -46,6 +46,13 @@ export class MyVideoChannelSyncsComponent extends RestTable implements OnInit {
     this.videoChannelSyncActions = [
       [
         {
+          label: $localize`List imports`,
+          linkBuilder: (videoChannelSync) => [ `/my-library/video-imports?search=videoChannelSyncId:${videoChannelSync.id}` ],
+          iconName: 'cloud-download'
+        }
+      ],
+      [
+        {
           label: $localize`Delete`,
           iconName: 'delete',
           handler: videoChannelSync => this.deleteSync(videoChannelSync)


### PR DESCRIPTION
## Description

On channel sync screen, move the list imports button form the left of the table into the action buttons list.

## Related issues

Fixes #5337

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

Previously:

![list imports cut button](https://user-images.githubusercontent.com/371705/194825681-56c8f654-136e-45db-a824-230f8ab01c88.png)

With the patch:

![list imports in actions list](https://user-images.githubusercontent.com/371705/194825701-aa81c53b-f599-4b21-b8b9-8cd67e0790c2.png)

