### PR TITLE
Added filter to sort videos by name (alphabetical order)

### DIFF
--- a/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
@@ -46,6 +46,7 @@
       <ng-option i18n value="-publishedAt">Sort by <strong>"Recently Added"</strong></ng-option>
       <ng-option i18n value="-originallyPublishedAt">Sort by <strong>"Original Publication Date"</strong></ng-option>
 
+      <ng-option i18n value="name">Sort by <strong>"Name"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('most-viewed')" value="-trending">Sort by <strong>"Recent Views"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('hot')" value="-hot">Sort by <strong>"Hot"</strong></ng-option>
       <ng-option i18n *ngIf="isTrendingSortEnabled('most-liked')" value="-likes">Sort by <strong>"Likes"</strong></ng-option>


### PR DESCRIPTION
## Description

As requested in #5134, I have added an option in the "sort" menu in order to use the already-existing "name" filter.

## Related issues
Implements https://github.com/Chocobozzz/PeerTube/issues/5134

## Has this been tested?

- [x] 🙅 no, because this PR does not update server code

## Screenshots

![image](https://user-images.githubusercontent.com/20014332/195590957-fabbe403-83a2-4b1d-8eeb-1068943d682b.png)

(you can see it's sorting alphabetically, instead of any other sorts that would put the SkylandStyle video first (date, view count, etc.))