### PR TITLE
Update privacy-concerns.component.html

### DIFF
--- a/client/src/app/+videos/+video-watch/shared/information/privacy-concerns.component.html
+++ b/client/src/app/+videos/+video-watch/shared/information/privacy-concerns.component.html
@@ -1,7 +1,7 @@
 <div class="privacy-concerns" *ngIf="display">
   <div class="privacy-concerns-text">
     <span class="me-2">
-      <strong i18n>Friendly Reminder: </strong>
+      <strong i18n>Friendly Reminder:</strong>&#32;
       <ng-container i18n>
         the sharing system used for this video implies that some technical information about your system (such as a public IP address) can be sent to other peers.
       </ng-container>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
I found a small flaw in the HTML. When translated, the white space after "Friendly Reminder:" is cut off, so the following text starts directly after the "Reminder:" without space, which looks ugly (see e.g. in the German translation). Solution is to move the white space outside the translated phrase (using html entity 32 for space).

HTML rendering in English - with white space:
`<strong _ngcontent-qih-c176="">Friendly Reminder: </strong> the sharing system used for ...`

HTML rendering e.g. in German - without white space:
`<strong _ngcontent-upc-c176="">Freundliche Erinnerung:</strong>Das Sharing-System für ...`

See also the screenshots below.

## Related issues
No.
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

English with space:
![english](https://user-images.githubusercontent.com/36190088/198076763-4970b60d-a486-432f-a6ac-62f1345158b5.png)

German without space (looks ugly):
![german](https://user-images.githubusercontent.com/36190088/198076770-c5806075-8ec1-4155-b6b4-46f2bc981f17.png)
