### PR TITLE
Fix: missing peertube version in documentation

### DIFF
--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -320,6 +320,8 @@ The `ping` route can be accessed using:
 
 #### Add custom WebSocket handlers
 
+**PeerTube >= 5.0**
+
 You can create custom WebSocket servers (like [ws](https://github.com/websockets/ws) for example) using `registerWebSocketRoute`:
 
 ```js


### PR DESCRIPTION
## Description

Websocket handlers for plugins is a new feature, coming with Peertube 5.0.0 (unreleased yet).
This information is missing in the documentation.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
