### PR TITLE
FIX: search on private videos

### DIFF
--- a/server/models/video/sql/video/videos-id-list-query-builder.ts
+++ b/server/models/video/sql/video/videos-id-list-query-builder.ts
@@ -323,7 +323,9 @@ export class VideosIdListQueryBuilder extends AbstractRunQuery {
   private wherePrivacyAvailable (user?: MUserAccountId) {
     if (user) {
       this.and.push(
-        `("video"."privacy" = ${VideoPrivacy.PUBLIC} OR "video"."privacy" = ${VideoPrivacy.INTERNAL})`
+        `("video"."privacy" = ${VideoPrivacy.PUBLIC} OR ` +
+        `"video"."privacy" = ${VideoPrivacy.INTERNAL} OR ` +
+        `("video"."privacy" = ${VideoPrivacy.PRIVATE} AND "account"."id" = ${user.Account.id}) )`
       )
     } else { // Or only public videos
       this.and.push(


### PR DESCRIPTION
## Description

Currently, it is not possible for an user to search on his private videos.
This fixes it (I think)

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

How to reproduce:
- Upload a private video, adding a unique tag, e.g. "foobar"
- Use the search box to find back your video, using "foobar" as search term
- See that the video is not found

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->
Tested manually

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [X] 🙋 no, because I need help <!-- Detail how we can help you -->

No clue on your test framework, tbh.

