### PR TITLE
additional trackers for webtorrent applicable from config

### DIFF
--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -293,6 +293,30 @@ tracker:
   private: true
   # Reject peers that do a lot of announces (could improve privacy of TCP/UDP peers)
   reject_too_many_announces: false
+  
+customize_torrents:
+  # If additional trackers is more than 0, 
+  # then as many as additional trackers entries from the trakcers list will be 
+  # added to the torrent file
+  # entries are randomly chosen if number is less than whole list otherwise all
+  # 0 , empty or absense of this property means disabled   
+  # additional_trackers: 6
+  # trackers_list:
+  #   - 'udp://tracker.leechers-paradise.org:6969'
+  #   - 'udp://www.torrent.eu.org:451/announce'
+  #   - 'udp://tracker.opentrackr.org:1337'
+  #   - 'udp://tracker.moeking.me:6969/announce'
+  #   - 'udp://explodie.org:6969'
+  #   - 'wss://tracker.btorrent.xyz'
+  #   - 'wss://tracker.openwebtorrent.com'
+  #   - 'udp://open.stealth.si:80/announce'
+  #   - 'udp://tracker.coppersurfer.tk:6969'
+  #   - 'udp://exodus.desync.com:6969/announce'
+  #   - 'udp://retracker.lanta-net.ru:2710/announce'
+  #   - 'http://open.acgnxtracker.com:80/announce'
+  #   - 'udp://tracker.torrent.eu.org:451/announce'
+  #   - 'udp://tracker.empire-js.us:1337'
+  #   - 'udp://open.stealth.si:80/announce'
 
 history:
   videos:

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -243,6 +243,12 @@ const CONFIG = {
     PRIVATE: config.get<boolean>('tracker.private'),
     REJECT_TOO_MANY_ANNOUNCES: config.get<boolean>('tracker.reject_too_many_announces')
   },
+  CUSTOMIZE_TORRENTS: {
+    ADDITIONAL_TRACKERS: config.has('customize_torrents.additional_trackers')
+      ? config.get<number>('customize_torrents.additional_trackers')
+      : 0,
+    TRACKERS_LIST: config.has('customize_torrents.trackers_list') ? config.get<string[]>('customize_torrents.trackers_list') : []
+  },
   HISTORY: {
     VIDEOS: {
       MAX_AGE: parseDurationToMs(config.get('history.videos.max_age'))


### PR DESCRIPTION
## Description
Currently the only tracker used in creation of webtorrents is the server itself.
there are additional public tracker that you can use as a fail safe tracker to make presence and accessability of your torrents more robust and redundant. this PR is to fix this issue

## Related issues
- power of global public trackers could not be leveraged
- The only tracker was server itself, so if  servers tracker was down or filtered, the video could not be tracked

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->


- [X] 🙋 yes, torrent being created as per existing tests, also tested on local and it contains additional trackers


