### PR TITLE
fix(client): hook filter:internal.player.videojs.options.result

### DIFF
--- a/client/src/assets/player/peertube-player-manager.ts
+++ b/client/src/assets/player/peertube-player-manager.ts
@@ -89,7 +89,7 @@ export class PeertubePlayerManager {
 
     const videojsOptions = await this.pluginsManager.runHook(
       'filter:internal.player.videojs.options.result',
-      videojsOptionsBuilder.getVideojsOptions(this.alreadyPlayed)
+      await videojsOptionsBuilder.getVideojsOptions(this.alreadyPlayed)
     )
 
     const self = this


### PR DESCRIPTION
## Description
PT 5 breaked the hook by providing the options as a Promise.

## Has this been tested?
- [x] 🙅 no, because this PR does not update server code
