### PR TITLE
Make the `warningTitle` param default to false on player

### DIFF
--- a/client/src/standalone/videos/shared/player-manager-options.ts
+++ b/client/src/standalone/videos/shared/player-manager-options.ts
@@ -123,7 +123,7 @@ export class PlayerManagerOptions {
       this.loop = getParamToggle(params, 'loop', false)
       this.title = getParamToggle(params, 'title', true)
       this.enableApi = getParamToggle(params, 'api', this.enableApi)
-      this.warningTitle = getParamToggle(params, 'warningTitle', true)
+      this.warningTitle = getParamToggle(params, 'warningTitle', false)
       this.peertubeLink = getParamToggle(params, 'peertubeLink', true)
       this.p2pEnabled = getParamToggle(params, 'p2p', this.isP2PEnabled(config, video))
 


### PR DESCRIPTION
## Description

See Chocobozzz/PeerTube#5572,

> Do not show the warning title by default, a client can opt in by passing `?warningTitle=true`

## Related issues

See Chocobozzz/PeerTube#5572 and Chocobozzz/PeerTube#5369

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help, I have not a working PeerTube dev environment
