### PR TITLE
Use displayName as label in channelFilters

### DIFF
--- a/client/src/app/+my-library/my-videos/my-videos.component.ts
+++ b/client/src/app/+my-library/my-videos/my-videos.component.ts
@@ -108,7 +108,7 @@ export class MyVideosComponent implements OnInit, DisableForReuseHook {
       const channelFilters = this.userChannels.map(c => {
         return {
           value: 'channel:' + c.name,
-          label: c.name
+          label: c.displayName
         }
       })
 


### PR DESCRIPTION
## Description

In My Library => Videos, filtering by channels is actually displaying channel's name instead of channel's displayName as label.

## Related issues

Fixes #5038

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

![image](https://user-images.githubusercontent.com/2203721/216065025-0c737ad5-a8a1-4364-ab92-7d391def8523.png)
