### PR TITLE
Use pvar() instead of SCSS variables

### DIFF
--- a/client/src/app/menu/notification.component.scss
+++ b/client/src/app/menu/notification.component.scss
@@ -130,7 +130,7 @@
         align-items: center;
         justify-content: center;
         font-weight: $font-semibold;
-        color: $fg-color;
+        color: pvar(--mainForegroundColor);
         padding: 7px 0;
         margin-top: auto;
         text-decoration: none;

--- a/client/src/sass/include/_mixins.scss
+++ b/client/src/sass/include/_mixins.scss
@@ -537,8 +537,8 @@
       height: 12px;
       opacity: 0;
       transform: rotate(45deg) scale(0);
-      border-right: 2px solid $bg-color;
-      border-bottom: 2px solid $bg-color;
+      border-right: 2px solid pvar(--mainBackgroundColor);
+      border-bottom: 2px solid pvar(--mainBackgroundColor);
     }
   }
 


### PR DESCRIPTION
## Description

I just updated files where I found the usage of a SCSS variable instead of the pvar() function.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
