### PR TITLE
feat(server): add redis sentinel support

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -65,8 +65,15 @@ database:
 redis:
   hostname: 'localhost'
   port: 6379
-  auth: null
+  auth: null # Used by both standalone and sentinel
   db: 0
+  sentinel:
+    enabled: false
+    enable_tls: false
+    master_name: ''
+    sentinels:
+      - hostname: ''
+        port: 26379
 
 # SMTP server to send emails
 smtp:

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -63,8 +63,15 @@ database:
 redis:
   hostname: 'localhost'
   port: 6379
-  auth: null
+  auth: null # Used by both standalone and sentinel
   db: 0
+  sentinel:
+    enabled: false
+    enable_tls: false
+    master_name: ''
+    sentinels:
+      - hostname: ''
+        port: 26379
 
 # SMTP server to send emails
 smtp:

--- a/server/initializers/checker-before-init.ts
+++ b/server/initializers/checker-before-init.ts
@@ -84,7 +84,8 @@ function checkMissedConfig () {
   const requiredAlternatives = [
     [ // set
       [ 'redis.hostname', 'redis.port' ], // alternative
-      [ 'redis.socket' ]
+      [ 'redis.socket' ],
+      [ 'redis.sentinel.master_name', 'redis.sentinel.sentinels[0].hostname', 'redis.sentinel.sentinels[0].port' ]
     ]
   ]
   const miss: string[] = []

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -8,6 +8,7 @@ import { buildPath, root } from '../../shared/core-utils'
 import { VideoPrivacy, VideosRedundancyStrategy } from '../../shared/models'
 import { NSFWPolicyType } from '../../shared/models/videos/nsfw-policy.type'
 import { parseBytes, parseDurationToMs } from '../helpers/core-utils'
+import { SentinelAddress } from 'ioredis'
 
 // Use a variable to reload the configuration if we need
 let config: IConfig = require('config')
@@ -39,7 +40,13 @@ const CONFIG = {
     PORT: config.has('redis.port') ? config.get<number>('redis.port') : null,
     SOCKET: config.has('redis.socket') ? config.get<string>('redis.socket') : null,
     AUTH: config.has('redis.auth') ? config.get<string>('redis.auth') : null,
-    DB: config.has('redis.db') ? config.get<number>('redis.db') : null
+    DB: config.has('redis.db') ? config.get<number>('redis.db') : null,
+    SENTINEL: {
+      ENABLED: config.has('redis.sentinel.enabled') ? config.get<boolean>('redis.sentinel.enabled') : false,
+      ENABLE_TLS: config.has('redis.sentinel.enable_tls') ? config.get<boolean>('redis.sentinel.enable_tls') : false,
+      SENTINELS: config.has('redis.sentinel.sentinels') ? config.get<Partial<SentinelAddress>[]>('redis.sentinel.sentinels') : [],
+      MASTER_NAME: config.has('redis.sentinel.master_name') ? config.get<string>('redis.sentinel.master_name') : null
+    }
   },
   SMTP: {
     TRANSPORT: config.has('smtp.transport') ? config.get<string>('smtp.transport') : 'smtp',

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -8,7 +8,6 @@ import { buildPath, root } from '../../shared/core-utils'
 import { VideoPrivacy, VideosRedundancyStrategy } from '../../shared/models'
 import { NSFWPolicyType } from '../../shared/models/videos/nsfw-policy.type'
 import { parseBytes, parseDurationToMs } from '../helpers/core-utils'
-import { SentinelAddress } from 'ioredis'
 
 // Use a variable to reload the configuration if we need
 let config: IConfig = require('config')
@@ -44,7 +43,7 @@ const CONFIG = {
     SENTINEL: {
       ENABLED: config.has('redis.sentinel.enabled') ? config.get<boolean>('redis.sentinel.enabled') : false,
       ENABLE_TLS: config.has('redis.sentinel.enable_tls') ? config.get<boolean>('redis.sentinel.enable_tls') : false,
-      SENTINELS: config.has('redis.sentinel.sentinels') ? config.get<Partial<SentinelAddress>[]>('redis.sentinel.sentinels') : [],
+      SENTINELS: config.has('redis.sentinel.sentinels') ? config.get<{ hostname: string, port: number }[]>('redis.sentinel.sentinels') : [],
       MASTER_NAME: config.has('redis.sentinel.master_name') ? config.get<string>('redis.sentinel.master_name') : null
     }
   },


### PR DESCRIPTION
## Description
Adds [redis sentinel](https://redis.io/docs/management/sentinel/) support.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #5141

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?
Yes, manually. By setting up the following sentinel and connecting:

```
version: '2'

services:
  redis-sentinel:
    image: docker.io/bitnami/redis-sentinel:7.0
    environment:
      - REDIS_MASTER_HOST=127.0.0.1
    networks:
      - webproxy
    ports:
      - 26379:26379
    volumes:
      - redis-sentinel_data:/bitnami
  redis:
    image: docker.io/bitnami/redis:7.0
    environment:
      # ALLOW_EMPTY_PASSWORD is recommended only for development.
      - ALLOW_EMPTY_PASSWORD=yes
    networks:
      - webproxy
    ports:
      - 6379:6379
    volumes:
      - redis_data:/bitnami
volumes:
  redis-sentinel_data:
    driver: local
  redis_data:
    driver: local

networks:
  webproxy:
    driver: bridge
```

Not sure if it's worth to setup a test for this feature?
