### PR TITLE
Install plugins upon init

### DIFF
--- a/server/lib/plugins/yarn.ts
+++ b/server/lib/plugins/yarn.ts
@@ -35,11 +35,16 @@ async function rebuildNativePlugins () {
   await execYarn('install --pure-lockfile')
 }
 
+async function installNpmPlugins () {
+  await execYarn('install')
+}
+
 // ############################################################################
 
 export {
   installNpmPlugin,
   installNpmPluginFromDisk,
+  installNpmPlugins,
   rebuildNativePlugins,
   removeNpmPlugin
 }


### PR DESCRIPTION
## Description
Upon init PeerTube will check for storage/plugins/package.json, if it doesn't exist it will be created based on DB records and `yarn install` is ran.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #5595


<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [x] 🙅 no, because this PR does not update server code
