### PR TITLE
Fix #5614: do not log bearerToken.

### DIFF
--- a/server/lib/auth/oauth-model.ts
+++ b/server/lib/auth/oauth-model.ts
@@ -34,7 +34,7 @@ export type BypassLogin = {
 }
 
 async function getAccessToken (bearerToken: string) {
-  logger.debug('Getting access token (bearerToken: ' + bearerToken + ').')
+  logger.debug('Getting access token.')
 
   if (!bearerToken) return undefined
 


### PR DESCRIPTION
## Description

A secret bearerToken was written in debug logs.

## Related issues
https://github.com/Chocobozzz/PeerTube/issues/5614

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute-getting-started?id=unit-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
