### PR TITLE
Hotfix/reinject video file token in fragments

### DIFF
--- a/server/controllers/object-storage-proxy.ts
+++ b/server/controllers/object-storage-proxy.ts
@@ -77,7 +77,7 @@ async function proxifyHLS (req: express.Request, res: express.Response) {
     setS3Headers(res, s3Response)
 
     const streamReplacer = filename.endsWith('.m3u8') && doReinjectVideoFileToken(req)
-      ? new StreamReplacer(line => injectQueryToPlaylistUrls(line, buildReinjectVideoFileTokenQuery(req)))
+      ? new StreamReplacer(line => injectQueryToPlaylistUrls(line, buildReinjectVideoFileTokenQuery(req, filename.endsWith('master.m3u8'))))
       : new PassThrough()
 
     return pipeline(

--- a/server/controllers/shared/m3u8-playlist.ts
+++ b/server/controllers/shared/m3u8-playlist.ts
@@ -4,8 +4,12 @@ function doReinjectVideoFileToken (req: express.Request) {
   return req.query.videoFileToken && req.query.reinjectVideoFileToken
 }
 
-function buildReinjectVideoFileTokenQuery (req: express.Request) {
-  return 'videoFileToken=' + req.query.videoFileToken
+function buildReinjectVideoFileTokenQuery (req: express.Request, isMaster: boolean) {
+  const query = 'videoFileToken=' + req.query.videoFileToken
+  if (isMaster) {
+    return query + '&reinjectVideoFileToken=true'
+  }
+  return query
 }
 
 export {

--- a/server/controllers/static.ts
+++ b/server/controllers/static.ts
@@ -90,6 +90,7 @@ export {
 
 async function servePrivateM3U8 (req: express.Request, res: express.Response) {
   const path = join(DIRECTORIES.HLS_STREAMING_PLAYLIST.PRIVATE, req.params.videoUUID, req.params.playlistName + '.m3u8')
+  const filename = req.params.playlistName + '.m3u8'
 
   let playlistContent: string
 
@@ -108,7 +109,7 @@ async function servePrivateM3U8 (req: express.Request, res: express.Response) {
 
   // Inject token in playlist so players that cannot alter the HTTP request can still watch the video
   const transformedContent = doReinjectVideoFileToken(req)
-    ? injectQueryToPlaylistUrls(playlistContent, buildReinjectVideoFileTokenQuery(req))
+    ? injectQueryToPlaylistUrls(playlistContent, buildReinjectVideoFileTokenQuery(req, filename.endsWith('master.m3u8')))
     : playlistContent
 
   return res.set('content-type', 'application/vnd.apple.mpegurl').send(transformedContent).end()

--- a/server/tests/api/videos/video-static-file-privacy.ts
+++ b/server/tests/api/videos/video-static-file-privacy.ts
@@ -256,10 +256,9 @@ describe('Test video static file privacy', function () {
       const videoFileToken = await server.videoToken.getVideoFileToken({ videoId: uuid })
       await waitJobs([ server ])
 
-      const video = await server.videos.getWithToken({ id: uuid })
-      const hls = video.streamingPlaylists[0]
-
       {
+        const video = await server.videos.getWithToken({ id: uuid })
+        const hls = video.streamingPlaylists[0]
         const query = { videoFileToken }
         const { text } = await makeRawRequest({ url: hls.playlistUrl, query, expectedStatus: HttpStatusCode.OK_200 })
 

--- a/server/tests/shared/streaming-playlists.ts
+++ b/server/tests/shared/streaming-playlists.ts
@@ -214,7 +214,7 @@ async function checkVideoFileTokenReinjection (options: {
       ? i
       : `-${resolution}`
 
-    expect(text).to.contain(`${suffix}.m3u8?videoFileToken=${videoFileToken}`)
+    expect(text).to.contain(`${suffix}.m3u8?videoFileToken=${videoFileToken}&reinjectVideoFileToken=true`)
   }
 
   const resolutionPlaylists = extractResolutionPlaylistUrls(hls.playlistUrl, text)
@@ -228,6 +228,7 @@ async function checkVideoFileTokenReinjection (options: {
       : '.mp4'
 
     expect(text).to.contain(`${extension}?videoFileToken=${videoFileToken}`)
+    expect(text).not.to.contain(`reinjectVideoFileToken=true`)
   }
 }
 


### PR DESCRIPTION
## Description
Re-inject video file token in fragments from master

## Related issues

Fixes https://github.com/Chocobozzz/PeerTube/issues/5617

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
