### PR TITLE
Non latin keyboard layout support player shortcut

### DIFF
--- a/client/src/assets/player/shared/hotkeys/peertube-hotkeys-plugin.ts
+++ b/client/src/assets/player/shared/hotkeys/peertube-hotkeys-plugin.ts
@@ -79,7 +79,7 @@ class PeerTubeHotkeysPlugin extends Plugin {
       // Fullscreen
       {
         // f key or Ctrl + Enter
-        accept: e => this.isNaked(e, 'F') || (!e.altKey && e.ctrlKey && e.key === 'Enter'),
+        accept: e => this.isNaked(e, 'f') || (!e.altKey && e.ctrlKey && e.key === 'Enter'),
         cb: e => {
           e.preventDefault()
 
@@ -90,7 +90,7 @@ class PeerTubeHotkeysPlugin extends Plugin {
 
       // Mute
       {
-        accept: e => this.isNaked(e, 'M'),
+        accept: e => this.isNaked(e, 'm'),
         cb: e => {
           e.preventDefault()
 
@@ -218,6 +218,8 @@ class PeerTubeHotkeysPlugin extends Plugin {
   }
 
   private isNaked (event: KeyboardEvent, key: string) {
+    if (key.length === 1) key = key.toUpperCase()
+
     return (!event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && this.getLatinKey(event.key, event.code) === key)
   }
 

--- a/client/src/assets/player/shared/hotkeys/peertube-hotkeys-plugin.ts
+++ b/client/src/assets/player/shared/hotkeys/peertube-hotkeys-plugin.ts
@@ -79,7 +79,7 @@ class PeerTubeHotkeysPlugin extends Plugin {
       // Fullscreen
       {
         // f key or Ctrl + Enter
-        accept: e => this.isNaked(e, 'f') || (!e.altKey && e.ctrlKey && e.key === 'Enter'),
+        accept: e => this.isNaked(e, 'F') || (!e.altKey && e.ctrlKey && e.key === 'Enter'),
         cb: e => {
           e.preventDefault()
 
@@ -90,7 +90,7 @@ class PeerTubeHotkeysPlugin extends Plugin {
 
       // Mute
       {
-        accept: e => this.isNaked(e, 'm'),
+        accept: e => this.isNaked(e, 'M'),
         cb: e => {
           e.preventDefault()
 
@@ -218,11 +218,34 @@ class PeerTubeHotkeysPlugin extends Plugin {
   }
 
   private isNaked (event: KeyboardEvent, key: string) {
-    return (!event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && event.key === key)
+    return (!event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && this.getLatinKey(event.key, event.code) === key)
   }
 
   private isNakedOrShift (event: KeyboardEvent, key: string) {
     return (!event.ctrlKey && !event.altKey && !event.metaKey && event.key === key)
+  }
+
+  // Thanks Maciej Krawczyk
+  // https://stackoverflow.com/questions/70211837/keyboard-shortcuts-commands-on-non-latin-alphabet-keyboards-javascript?rq=1
+  private getLatinKey (key: string, code: string) {
+    if (key.length !== 1) {
+      return key
+    }
+
+    const capitalHetaCode = 880
+    const isNonLatin = key.charCodeAt(0) >= capitalHetaCode
+
+    if (isNonLatin) {
+      if (code.indexOf('Key') === 0 && code.length === 4) { // i.e. 'KeyW'
+        return code.charAt(3)
+      }
+
+      if (code.indexOf('Digit') === 0 && code.length === 6) { // i.e. 'Digit7'
+        return code.charAt(5)
+      }
+    }
+
+    return key.toUpperCase()
   }
 }
 


### PR DESCRIPTION
## Description

Add player hotkey support for non-Latin keyboard layouts

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/5682

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
