### PR TITLE
feat(about): render images in markdown

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-instance-information.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-instance-information.component.html
@@ -126,6 +126,7 @@
 
           <my-markdown-textarea
             name="instanceTerms" formControlName="terms"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.terms']"
           ></my-markdown-textarea>
         </div>
@@ -135,6 +136,7 @@
 
           <my-markdown-textarea
             name="instanceCodeOfConduct" formControlName="codeOfConduct"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.codeOfConduct']"
           ></my-markdown-textarea>
         </div>
@@ -145,6 +147,7 @@
 
           <my-markdown-textarea
             name="instanceModerationInformation" formControlName="moderationInformation"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.moderationInformation']"
           ></my-markdown-textarea>
         </div>
@@ -165,6 +168,7 @@
 
           <my-markdown-textarea
             name="instanceAdministrator" formControlName="administrator"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.administrator']"
           ></my-markdown-textarea>
         </div>
@@ -175,6 +179,7 @@
 
           <my-markdown-textarea
             name="instanceCreationReason" formControlName="creationReason"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.creationReason']"
           ></my-markdown-textarea>
         </div>
@@ -185,6 +190,7 @@
 
           <my-markdown-textarea
             name="instanceMaintenanceLifetime" formControlName="maintenanceLifetime"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.maintenanceLifetime']"
           ></my-markdown-textarea>
         </div>
@@ -195,6 +201,7 @@
 
           <my-markdown-textarea
             name="instanceBusinessModel" formControlName="businessModel"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.businessModel']"
           ></my-markdown-textarea>
         </div>
@@ -215,6 +222,7 @@
 
           <my-markdown-textarea
             name="instanceHardwareInformation" formControlName="hardwareInformation"
+            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
             [formError]="formErrors['instance.hardwareInformation']"
           ></my-markdown-textarea>
         </div>

--- a/client/src/app/+admin/config/edit-custom-config/edit-instance-information.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-instance-information.component.html
@@ -125,8 +125,7 @@
           <label i18n for="instanceTerms">Terms</label><my-help helpType="markdownText"></my-help>
 
           <my-markdown-textarea
-            name="instanceTerms" formControlName="terms"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceTerms" formControlName="terms" markdownType="enhanced"
             [formError]="formErrors['instance.terms']"
           ></my-markdown-textarea>
         </div>
@@ -135,8 +134,7 @@
           <label i18n for="instanceCodeOfConduct">Code of conduct</label><my-help helpType="markdownText"></my-help>
 
           <my-markdown-textarea
-            name="instanceCodeOfConduct" formControlName="codeOfConduct"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceCodeOfConduct" formControlName="codeOfConduct" markdownType="enhanced"
             [formError]="formErrors['instance.codeOfConduct']"
           ></my-markdown-textarea>
         </div>
@@ -146,8 +144,7 @@
           <div i18n class="label-small-info">Who moderates the instance? What is the policy regarding NSFW videos? Political videos? etc</div>
 
           <my-markdown-textarea
-            name="instanceModerationInformation" formControlName="moderationInformation"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceModerationInformation" formControlName="moderationInformation" markdownType="enhanced"
             [formError]="formErrors['instance.moderationInformation']"
           ></my-markdown-textarea>
         </div>
@@ -167,8 +164,7 @@
           <div i18n class="label-small-info">A single person? A non-profit? A company?</div>
 
           <my-markdown-textarea
-            name="instanceAdministrator" formControlName="administrator"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceAdministrator" formControlName="administrator" markdownType="enhanced"
             [formError]="formErrors['instance.administrator']"
           ></my-markdown-textarea>
         </div>
@@ -178,8 +174,7 @@
           <div i18n class="label-small-info">To share your personal videos? To open registrations and allow people to upload what they want?</div>
 
           <my-markdown-textarea
-            name="instanceCreationReason" formControlName="creationReason"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceCreationReason" formControlName="creationReason" markdownType="enhanced"
             [formError]="formErrors['instance.creationReason']"
           ></my-markdown-textarea>
         </div>
@@ -189,8 +184,7 @@
           <div i18n class="label-small-info">It's important to know for users who want to register on your instance</div>
 
           <my-markdown-textarea
-            name="instanceMaintenanceLifetime" formControlName="maintenanceLifetime"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceMaintenanceLifetime" formControlName="maintenanceLifetime" markdownType="enhanced"
             [formError]="formErrors['instance.maintenanceLifetime']"
           ></my-markdown-textarea>
         </div>
@@ -200,8 +194,7 @@
           <div i18n class="label-small-info">With your own funds? With user donations? Advertising?</div>
 
           <my-markdown-textarea
-            name="instanceBusinessModel" formControlName="businessModel"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceBusinessModel" formControlName="businessModel" markdownType="enhanced"
             [formError]="formErrors['instance.businessModel']"
           ></my-markdown-textarea>
         </div>
@@ -221,8 +214,7 @@
           <div i18n class="label-small-info">i.e. 2vCore 2GB RAM, a direct the link to the server you rent, etc.</div>
 
           <my-markdown-textarea
-            name="instanceHardwareInformation" formControlName="hardwareInformation"
-            [customMarkdownRenderer]="getCustomMarkdownRenderer()" [debounceTime]="500"
+            name="instanceHardwareInformation" formControlName="hardwareInformation" markdownType="enhanced"
             [formError]="formErrors['instance.hardwareInformation']"
           ></my-markdown-textarea>
         </div>

--- a/client/src/app/shared/shared-instance/instance.service.ts
+++ b/client/src/app/shared/shared-instance/instance.service.ts
@@ -56,7 +56,7 @@ export class InstanceService {
     }
 
     for (const key of Object.keys(html)) {
-      html[key] = await this.markdownService.textMarkdownToHTML({ markdown: about.instance[key] })
+      html[key] = await this.markdownService.enhancedMarkdownToHTML({ markdown: about.instance[key] })
     }
 
     return html


### PR DESCRIPTION
Closes https://github.com/Chocobozzz/PeerTube/issues/5710

## Description

It looks to me that why it works in the "Support" section is because it's using `this.markdownService.enhancedMarkdownToHTML()` 
https://github.com/Chocobozzz/PeerTube/blob/00ee545c2444c35ed0d37df9f91984246aa36124/client/src/app/shared/shared-support-modal/support-modal.component.ts

which has different rules set in https://github.com/Chocobozzz/PeerTube/blob/00ee545c2444c35ed0d37df9f91984246aa36124/shared/core-utils/renderer/markdown.ts#L17 which allows `image`

So I changed the relevant line for the "About" page fields and now it works 🎊 

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/5710

## Has this been tested?
<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->
Do we need to run or have a test for this?

## Screenshots

Before
<img width="480" alt="Screenshot 2023-04-04 at 15 39 15" src="https://user-images.githubusercontent.com/1328733/229812070-339be358-582b-4690-a8bc-686d2570e8dc.png">

After
<img width="330" alt="Screenshot 2023-04-04 at 15 40 08" src="https://user-images.githubusercontent.com/1328733/229812038-e39c027a-fb20-4321-a62d-a9de0e673055.png">
