### PR TITLE
feat(docker): make database name configurable

### DIFF
--- a/support/docker/production/.env
+++ b/support/docker/production/.env
@@ -3,6 +3,8 @@ POSTGRES_USER=<MY POSTGRES USERNAME>
 POSTGRES_PASSWORD=<MY POSTGRES PASSWORD>
 # Postgres database name "peertube"
 POSTGRES_DB=peertube
+# Database name used by PeerTube must be the same
+PEERTUBE_DB_NAME=POSTGRES_DB
 # Editable only with a suffix :
 #POSTGRES_DB=peertube_prod
 #PEERTUBE_DB_SUFFIX=_prod

--- a/support/docker/production/.env
+++ b/support/docker/production/.env
@@ -3,13 +3,12 @@ POSTGRES_USER=<MY POSTGRES USERNAME>
 POSTGRES_PASSWORD=<MY POSTGRES PASSWORD>
 # Postgres database name "peertube"
 POSTGRES_DB=peertube
-# Database name used by PeerTube must be the same
-PEERTUBE_DB_NAME=POSTGRES_DB
-# Editable only with a suffix :
-#POSTGRES_DB=peertube_prod
+# The database name used by PeerTube will be PEERTUBE_DB_NAME (only if set) *OR* 'peertube'+PEERTUBE_DB_SUFFIX
+#PEERTUBE_DB_NAME=<MY POSTGRES DB NAME>
 #PEERTUBE_DB_SUFFIX=_prod
-PEERTUBE_DB_USERNAME=<MY POSTGRES USERNAME>
-PEERTUBE_DB_PASSWORD=<MY POSTGRES PASSWORD>
+# Database username and password used by PeerTube must match Postgres', so they are copied:
+PEERTUBE_DB_USERNAME=$POSTGRES_USER
+PEERTUBE_DB_PASSWORD=$POSTGRES_PASSWORD
 PEERTUBE_DB_SSL=false
 # Default to Postgres service name "postgres" in docker-compose.yml
 PEERTUBE_DB_HOSTNAME=postgres

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -1,3 +1,8 @@
+# 
+# This file will be read by node-config
+# See https://github.com/node-config/node-config/wiki/Environment-Variables#custom-environment-variables
+# 
+
 webserver:
   hostname: "PEERTUBE_WEBSERVER_HOSTNAME"
   port:
@@ -19,7 +24,7 @@ database:
   port:
     __name: "PEERTUBE_DB_PORT"
     __format: "json"
-  dbname: "PEERTUBE_DB_NAME"
+  name: "PEERTUBE_DB_NAME"
   suffix: "PEERTUBE_DB_SUFFIX"
   username: "PEERTUBE_DB_USERNAME"
   password: "PEERTUBE_DB_PASSWORD"

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -19,6 +19,7 @@ database:
   port:
     __name: "PEERTUBE_DB_PORT"
     __format: "json"
+  dbname: "PEERTUBE_DB_NAME"
   suffix: "PEERTUBE_DB_SUFFIX"
   username: "PEERTUBE_DB_USERNAME"
   password: "PEERTUBE_DB_PASSWORD"


### PR DESCRIPTION
## Description

I found that it should be configurable via `name` from the config file here: https://github.com/Chocobozzz/PeerTube/blob/9258e9a4a37911fc64b5faada2a7e604bd1ede1f/server/initializers/database.ts#LL59C36-L59C36

## Related issues

Closes https://github.com/Chocobozzz/PeerTube/issues/5708

## Has this been tested?

I tested following the instructions from https://docs.joinpeertube.org/install/docker

Before
```
peertube-docker-peertube-1   |       "message": "database \"custom\" does not exist",
peertube-docker-peertube-1   |       "length": 93,
peertube-docker-peertube-1   |       "name": "error",
peertube-docker-peertube-1   |       "severity": "FATAL",
peertube-docker-peertube-1   |       "code": "3D000",
peertube-docker-peertube-1   |       "file": "postinit.c",
peertube-docker-peertube-1   |       "line": "875",
peertube-docker-peertube-1   |       "routine": "InitPostgres"
peertube-docker-peertube-1   |     }
peertube-docker-peertube-1   |   }
peertube-docker-peertube-1   | }
peertube-docker-peertube-1 exited with code 255
```

After the change I also added the modified `custom-environment-variables.yaml` file to this path locally `docker-volume/config/custom-environment-variables.yaml`
The error message went away.

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->
Not sure if there are tests for this?
