### PR TITLE
Feature/filter already watched videos

### DIFF
--- a/client/src/app/+videos/+video-watch/shared/recommendations/recent-videos-recommendation.service.ts
+++ b/client/src/app/+videos/+video-watch/shared/recommendations/recent-videos-recommendation.service.ts
@@ -63,6 +63,9 @@ export class RecentVideosRecommendationService implements RecommendationService 
               searchTarget: 'local',
               nsfw: user.nsfwPolicy
                 ? this.videos.nsfwPolicyToParam(user.nsfwPolicy)
+                : undefined,
+              excludeAlreadyWatched: user.id
+                ? true
                 : undefined
             })
           }

--- a/client/src/app/shared/shared-search/advanced-search.model.ts
+++ b/client/src/app/shared/shared-search/advanced-search.model.ts
@@ -40,6 +40,8 @@ export class AdvancedSearch {
   searchTarget: SearchTargetType
   resultType: AdvancedSearchResultType
 
+  excludeAlreadyWatched?: boolean
+
   constructor (options?: {
     startDate?: string
     endDate?: string
@@ -62,6 +64,8 @@ export class AdvancedSearch {
     sort?: string
     searchTarget?: SearchTargetType
     resultType?: AdvancedSearchResultType
+
+    excludeAlreadyWatched?: boolean
   }) {
     if (!options) return
 
@@ -86,6 +90,8 @@ export class AdvancedSearch {
     this.searchTarget = options.searchTarget || undefined
 
     this.resultType = options.resultType || undefined
+
+    this.excludeAlreadyWatched = options.excludeAlreadyWatched || undefined
 
     if (!this.resultType && this.hasVideoFilter()) {
       this.resultType = 'videos'
@@ -138,7 +144,8 @@ export class AdvancedSearch {
       host: this.host,
       sort: this.sort,
       searchTarget: this.searchTarget,
-      resultType: this.resultType
+      resultType: this.resultType,
+      excludeAlreadyWatched: this.excludeAlreadyWatched
     }
   }
 
@@ -162,7 +169,8 @@ export class AdvancedSearch {
       host: this.host,
       isLive,
       sort: this.sort,
-      searchTarget: this.searchTarget
+      searchTarget: this.searchTarget,
+      excludeAlreadyWatched: this.excludeAlreadyWatched
     }
   }
 

--- a/server/helpers/query.ts
+++ b/server/helpers/query.ts
@@ -24,7 +24,8 @@ function pickCommonVideoQuery (query: VideosCommonQueryAfterSanitize) {
     'skipCount',
     'hasHLSFiles',
     'hasWebtorrentFiles',
-    'search'
+    'search',
+    'excludeAlreadyWatched'
   ])
 }
 
@@ -41,7 +42,8 @@ function pickSearchVideoQuery (query: VideosSearchQueryAfterSanitize) {
       'originallyPublishedEndDate',
       'durationMin',
       'durationMax',
-      'uuids'
+      'uuids',
+      'excludeAlreadyWatched'
     ])
   }
 }

--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -489,6 +489,9 @@ const commonVideosFiltersValidator = [
   query('search')
     .optional()
     .custom(exists),
+  query('excludeAlreadyWatched')
+    .optional()
+    .isBoolean(),
 
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (areValidationErrors(req, res)) return
@@ -520,6 +523,15 @@ const commonVideosFiltersValidator = [
       }
     }
 
+    logger.error(!user)
+    logger.error(req.query.excludeAlreadyWatched)
+    if (!user && exists(req.query.excludeAlreadyWatched)) {
+      res.fail({
+        status: HttpStatusCode.BAD_REQUEST_400,
+        message: 'Cannot use excludeAlreadyWatched parameter for unlogged users'
+      })
+      return false
+    }
     return next()
   }
 ]

--- a/server/models/video/sql/video/videos-id-list-query-builder.ts
+++ b/server/models/video/sql/video/videos-id-list-query-builder.ts
@@ -78,6 +78,8 @@ export type BuildVideosListQueryOptions = {
 
   transaction?: Transaction
   logging?: boolean
+
+  excludeAlreadyWatched?: boolean
 }
 
 export class VideosIdListQueryBuilder extends AbstractRunQuery {
@@ -258,6 +260,10 @@ export class VideosIdListQueryBuilder extends AbstractRunQuery {
 
     if (options.durationMax) {
       this.whereDurationMax(options.durationMax)
+    }
+
+    if (options.excludeAlreadyWatched) {
+      this.whereExcludeAlreadyWatched(options.user.id)
     }
 
     this.whereSearch(options.search)
@@ -596,6 +602,18 @@ export class VideosIdListQueryBuilder extends AbstractRunQuery {
   private whereDurationMax (durationMax: number) {
     this.and.push('"video"."duration" <= :durationMax')
     this.replacements.durationMax = durationMax
+  }
+
+  private whereExcludeAlreadyWatched (userId: number) {
+    this.and.push(
+      'NOT EXISTS (' +
+      '  SELECT *' +
+      '  FROM "userVideoHistory"' +
+      '  WHERE "video"."id" = "userVideoHistory"."videoId"' +
+      '  AND "userVideoHistory"."userId" = :excludeAlreadyWatched' +
+      ')'
+    )
+    this.replacements.excludeAlreadyWatched = userId
   }
 
   private groupForTrending (trendingDays: number) {

--- a/server/models/video/video.ts
+++ b/server/models/video/video.ts
@@ -1086,6 +1086,8 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
     countVideos?: boolean
 
     search?: string
+
+    excludeAlreadyWatched?: boolean
   }) {
     VideoModel.throwIfPrivateIncludeWithoutUser(options.include, options.user)
     VideoModel.throwIfPrivacyOneOfWithoutUser(options.privacyOneOf, options.user)
@@ -1124,7 +1126,8 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
         'historyOfUser',
         'hasHLSFiles',
         'hasWebtorrentFiles',
-        'search'
+        'search',
+        'excludeAlreadyWatched'
       ]),
 
       serverAccountIdForBlock: serverActor.Account.id,
@@ -1170,6 +1173,8 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
     durationMin?: number // seconds
     durationMax?: number // seconds
     uuids?: string[]
+
+    excludeAlreadyWatched?: boolean
   }) {
     VideoModel.throwIfPrivateIncludeWithoutUser(options.include, options.user)
     VideoModel.throwIfPrivacyOneOfWithoutUser(options.privacyOneOf, options.user)
@@ -1203,7 +1208,8 @@ export class VideoModel extends Model<Partial<AttributesOnly<VideoModel>>> {
         'hasWebtorrentFiles',
         'uuids',
         'search',
-        'displayOnlyForFollower'
+        'displayOnlyForFollower',
+        'excludeAlreadyWatched'
       ]),
       serverAccountIdForBlock: serverActor.Account.id
     }

--- a/server/tests/api/check-params/videos-common-filters.ts
+++ b/server/tests/api/check-params/videos-common-filters.ts
@@ -122,6 +122,8 @@ describe('Test video filters validators', function () {
       include?: VideoInclude
       privacyOneOf?: VideoPrivacy[]
       expectedStatus: HttpStatusCode
+      excludeAlreadyWatched?: boolean
+      unauthenticatedUser?: boolean
     }) {
       const paths = [
         '/api/v1/video-channels/root_channel/videos',
@@ -131,14 +133,19 @@ describe('Test video filters validators', function () {
       ]
 
       for (const path of paths) {
+        const token = options.unauthenticatedUser
+          ? undefined
+          : options.token || server.accessToken
+
         await makeGetRequest({
           url: server.url,
           path,
-          token: options.token || server.accessToken,
+          token,
           query: {
             isLocal: options.isLocal,
             privacyOneOf: options.privacyOneOf,
-            include: options.include
+            include: options.include,
+            excludeAlreadyWatched: options.excludeAlreadyWatched
           },
           expectedStatus: options.expectedStatus
         })
@@ -212,6 +219,14 @@ describe('Test video filters validators', function () {
           isLocal: true
         }
       })
+    })
+
+    it('Should fail when trying to exclude already watched videos for an unlogged user', async function () {
+      await testEndpoints({ excludeAlreadyWatched: true, unauthenticatedUser: true, expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
+    })
+
+    it('Should succeed when trying to exclude already watched videos for a logged user', async function () {
+      await testEndpoints({ token: userAccessToken, excludeAlreadyWatched: true, expectedStatus: HttpStatusCode.OK_200 })
     })
   })
 

--- a/shared/models/search/videos-common-query.model.ts
+++ b/shared/models/search/videos-common-query.model.ts
@@ -35,6 +35,8 @@ export interface VideosCommonQuery {
   skipCount?: boolean
 
   search?: string
+
+  excludeAlreadyWatched?: boolean
 }
 
 export interface VideosCommonQueryAfterSanitize extends VideosCommonQuery {

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -717,6 +717,7 @@ paths:
         - $ref: '#/components/parameters/start'
         - $ref: '#/components/parameters/count'
         - $ref: '#/components/parameters/videosSort'
+        - $ref: '#/components/parameters/excludeAlreadyWatched'
       responses:
         '200':
           description: successful operation
@@ -1835,6 +1836,7 @@ paths:
         - $ref: '#/components/parameters/start'
         - $ref: '#/components/parameters/count'
         - $ref: '#/components/parameters/videosSort'
+        - $ref: '#/components/parameters/excludeAlreadyWatched'
       responses:
         '200':
           description: successful operation
@@ -2378,6 +2380,7 @@ paths:
         - $ref: '#/components/parameters/start'
         - $ref: '#/components/parameters/count'
         - $ref: '#/components/parameters/videosSort'
+        - $ref: '#/components/parameters/excludeAlreadyWatched'
       responses:
         '200':
           description: successful operation
@@ -3799,6 +3802,7 @@ paths:
         - $ref: '#/components/parameters/start'
         - $ref: '#/components/parameters/count'
         - $ref: '#/components/parameters/videosSort'
+        - $ref: '#/components/parameters/excludeAlreadyWatched'
       responses:
         '200':
           description: successful operation
@@ -4742,6 +4746,7 @@ paths:
         - $ref: '#/components/parameters/count'
         - $ref: '#/components/parameters/searchTarget'
         - $ref: '#/components/parameters/videosSearchSort'
+        - $ref: '#/components/parameters/excludeAlreadyWatched'
         - name: startDate
           in: query
           description: Get videos that are published after this date
@@ -5872,6 +5877,12 @@ components:
       schema:
         $ref: '#/components/schemas/VideoPrivacySet'
       description: '**PeerTube >= 4.0** Display only videos in this specific privacy/privacies'
+    excludeAlreadyWatched:
+      name: excludeAlreadyWatched
+      in: query
+      description: Whether or not to exclude videos that are in the user's video history
+      schema:
+        type: boolean
     uuids:
       name: uuids
       in: query


### PR DESCRIPTION
## Description

Add a filter to not list already watched videos for a user.

## Related issues

Fixes https://github.com/Chocobozzz/PeerTube/issues/1985 for logged users

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

