### PR TITLE
Fix #5744: Missing plugins-global.css + missing async

### DIFF
--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { readFile, pathExists } from 'fs-extra'
+import { pathExists, readFile } from 'fs-extra'
 import { join } from 'path'
 import validator from 'validator'
 import { isTestOrDevInstance } from '@server/helpers/core-utils'
@@ -412,13 +412,16 @@ class ClientHtml {
       logger.info('Plugin Global CSS file is not available (generation may still be in progress), ignoring it.')
       return htmlStringPage
     }
-    let globalCSSContent
+
+    let globalCSSContent: Buffer
+
     try {
       globalCSSContent = await readFile(PLUGIN_GLOBAL_CSS_PATH)
     } catch (err) {
       logger.error('Error retrieving the Plugin Global CSS file, ignoring it.', { err })
       return htmlStringPage
     }
+
     if (globalCSSContent.byteLength === 0) return htmlStringPage
 
     const fileHash = sha256(globalCSSContent)

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { readFile } from 'fs-extra'
+import { readFile, pathExists } from 'fs-extra'
 import { join } from 'path'
 import validator from 'validator'
 import { isTestOrDevInstance } from '@server/helpers/core-utils'
@@ -408,11 +408,15 @@ class ClientHtml {
   }
 
   private static async addAsyncPluginCSS (htmlStringPage: string) {
+    if (!pathExists(PLUGIN_GLOBAL_CSS_PATH)) {
+      logger.info('Plugin Global CSS file is not available (generation may still be in progress), ignoring it.')
+      return htmlStringPage
+    }
     let globalCSSContent
     try {
       globalCSSContent = await readFile(PLUGIN_GLOBAL_CSS_PATH)
     } catch (err) {
-      logger.error('Global CSS file is not available (generation may still be in progress), ignoring it.', { err })
+      logger.error('Error retrieving the Plugin Global CSS file, ignoring it.', { err })
       return htmlStringPage
     }
     if (globalCSSContent.byteLength === 0) return htmlStringPage

--- a/server/lib/client-html.ts
+++ b/server/lib/client-html.ts
@@ -408,7 +408,13 @@ class ClientHtml {
   }
 
   private static async addAsyncPluginCSS (htmlStringPage: string) {
-    const globalCSSContent = await readFile(PLUGIN_GLOBAL_CSS_PATH)
+    let globalCSSContent
+    try {
+      globalCSSContent = await readFile(PLUGIN_GLOBAL_CSS_PATH)
+    } catch (err) {
+      logger.error('Global CSS file is not available (generation may still be in progress), ignoring it.', { err })
+      return htmlStringPage
+    }
     if (globalCSSContent.byteLength === 0) return htmlStringPage
 
     const fileHash = sha256(globalCSSContent)

--- a/server/lib/plugins/plugin-manager.ts
+++ b/server/lib/plugins/plugin-manager.ts
@@ -540,7 +540,7 @@ export class PluginManager implements ServerHook {
 
   // ###################### CSS ######################
 
-  private resetCSSGlobalFile () {
+  private async resetCSSGlobalFile () {
     return outputFile(PLUGIN_GLOBAL_CSS_PATH, '')
   }
 

--- a/server/lib/plugins/plugin-manager.ts
+++ b/server/lib/plugins/plugin-manager.ts
@@ -540,7 +540,7 @@ export class PluginManager implements ServerHook {
 
   // ###################### CSS ######################
 
-  private async resetCSSGlobalFile () {
+  private resetCSSGlobalFile () {
     return outputFile(PLUGIN_GLOBAL_CSS_PATH, '')
   }
 


### PR DESCRIPTION
## Description
On startup, people trying to display the Peertube index page could face an error, because of a missing plugins-global.css file.
There was also a missing `async` attribute on a related function.

## Related issues

See https://github.com/Chocobozzz/PeerTube/issues/5744

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

I tested it by building Peertube, and running it again.
