### PR TITLE
Hotfix/Don't send replay settings on not replayed lives

### DIFF
--- a/client/src/app/+videos/+video-edit/video-add-components/video-go-live.component.ts
+++ b/client/src/app/+videos/+video-edit/video-add-components/video-go-live.component.ts
@@ -137,9 +137,14 @@ export class VideoGoLiveComponent extends VideoSend implements OnInit, AfterView
     video.uuid = this.videoUUID
     video.shortUUID = this.videoShortUUID
 
+    const saveReplay = this.form.value.saveReplay
+    const replaySettings = saveReplay
+      ? { privacy: this.form.value.replayPrivacy }
+      : undefined
+
     const liveVideoUpdate: LiveVideoUpdate = {
-      saveReplay: this.form.value.saveReplay,
-      replaySettings: { privacy: this.form.value.replayPrivacy },
+      saveReplay,
+      replaySettings,
       latencyMode: this.form.value.latencyMode,
       permanentLive: this.form.value.permanentLive
     }

--- a/client/src/app/+videos/+video-edit/video-update.component.ts
+++ b/client/src/app/+videos/+video-edit/video-update.component.ts
@@ -127,9 +127,14 @@ export class VideoUpdateComponent extends FormReactive implements OnInit {
           switchMap(() => {
             if (!this.liveVideo) return of(undefined)
 
+            const saveReplay = !!this.form.value.saveReplay
+            const replaySettings = saveReplay
+              ? { privacy: this.form.value.replayPrivacy }
+              : undefined
+
             const liveVideoUpdate: LiveVideoUpdate = {
-              saveReplay: !!this.form.value.saveReplay,
-              replaySettings: { privacy: this.form.value.replayPrivacy },
+              saveReplay,
+              replaySettings,
               permanentLive: !!this.form.value.permanentLive,
               latencyMode: this.form.value.latencyMode
             }


### PR DESCRIPTION
## Description

Peertube client was sending replay settings even though the replay was disabled.

## Related issues

Fixes https://github.com/Chocobozzz/PeerTube/issues/5761

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
