### PR TITLE
Add sync logic for live stream `.m3u8` files in S3

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "jsonld": "~8.1.0",
     "lodash": "^4.17.10",
     "lru-cache": "^7.13.0",
+    "m3u8-parser": "^6.0.0",
     "magnet-uri": "^6.1.0",
     "markdown-it": "^13.0.1",
     "markdown-it-emoji": "^2.0.0",

--- a/server/lib/live/shared/muxing-session.ts
+++ b/server/lib/live/shared/muxing-session.ts
@@ -302,8 +302,8 @@ class MuxingSession extends EventEmitter {
     return Array.from(unavailableM3U8Segments)
   }
 
-  private async waitForUnavailableM3U8Segments (m3u8Path: string, m3u8SegmentPaths: string[], maxRetries = 30) {
-    const retrySleepMs = 100
+  private async waitForUnavailableM3U8Segments (m3u8Path: string, m3u8SegmentPaths: string[], maxRetries = 40) {
+    const retrySleepMs = 250
     let ackSleepMs = 0
     while (maxRetries) {
       const m3u8SegmentsUnavailable = this.getUnavailableM3U8Segments(m3u8SegmentPaths)

--- a/server/lib/live/shared/muxing-session.ts
+++ b/server/lib/live/shared/muxing-session.ts
@@ -2,6 +2,7 @@ import { mapSeries } from 'bluebird'
 import { FSWatcher, watch } from 'chokidar'
 import { FfmpegCommand } from 'fluent-ffmpeg'
 import { appendFile, ensureDir, readFile, stat } from 'fs-extra'
+import { Parser as M3u8Parser } from 'm3u8-parser'
 import PQueue from 'p-queue'
 import { basename, join } from 'path'
 import { EventEmitter } from 'stream'
@@ -80,10 +81,12 @@ class MuxingSession extends EventEmitter {
 
   private streamingPlaylist: MStreamingPlaylistVideo
   private liveSegmentShaStore: LiveSegmentShaStore
+  private liveSegmentsInStorage: string[]
 
   private tsWatcher: FSWatcher
   private masterWatcher: FSWatcher
   private m3u8Watcher: FSWatcher
+  private m3u8Parser: M3u8Parser
 
   private masterPlaylistCreated = false
   private liveReady = false
@@ -142,6 +145,7 @@ class MuxingSession extends EventEmitter {
 
     this.createLiveShaStore()
     this.createFiles()
+    this.liveSegmentsInStorage = []
 
     await this.prepareDirectories()
 
@@ -277,12 +281,66 @@ class MuxingSession extends EventEmitter {
     })
   }
 
+  private async parseM3U8Segments (srcDirectory: string, m3u8Path: string) {
+    const m3u8Data = await readFile(m3u8Path)
+    this.m3u8Parser = new M3u8Parser()
+    this.m3u8Parser.push(m3u8Data)
+    this.m3u8Parser.end()
+    const m3u8Parsed = this.m3u8Parser.manifest
+    const segmentPaths = m3u8Parsed.segments.map(segment => srcDirectory + '/' + segment.uri)
+    return segmentPaths
+  }
+
+  private getUnavailableM3U8Segments (m3u8SegmentPaths: string[]) {
+    const storedSegments = new Set(this.liveSegmentsInStorage)
+    const unavailableM3U8Segments = new Set(m3u8SegmentPaths)
+    for (const segment of m3u8SegmentPaths) {
+      if (storedSegments.has(segment)) {
+        unavailableM3U8Segments.delete(segment)
+      }
+    }
+    return Array.from(unavailableM3U8Segments)
+  }
+
+  private async waitForUnavailableM3U8Segments (m3u8Path: string, m3u8SegmentPaths: string[], maxRetries = 30) {
+    const retrySleepMs = 100
+    let ackSleepMs = 0
+    while (maxRetries) {
+      const m3u8SegmentsUnavailable = this.getUnavailableM3U8Segments(m3u8SegmentPaths)
+      logger.debug('Unavailable video segments from %s', m3u8Path, { unavailableSegments: m3u8SegmentsUnavailable })
+      const segmentCount = m3u8SegmentsUnavailable.length
+      if (segmentCount) {
+        ackSleepMs += retrySleepMs
+        maxRetries -= 1
+        if (maxRetries > 0) {
+          logger.info(
+            'Video segment(s) from %s are unavailable, wait %s ms (segments: %s, ackumulated wait: %s ms, retries left: %s)...',
+            m3u8Path, retrySleepMs, segmentCount, ackSleepMs, maxRetries
+          )
+          await new Promise(resolve => setTimeout(resolve, retrySleepMs))
+        } else {
+          logger.warn(
+            'Max retries exceeded waiting for %s video segment(s) in storage, giving up (segments: %s, wait time: %s ms, retries left: 0)',
+            m3u8Path, segmentCount, ackSleepMs, { unavailableSegments: m3u8SegmentsUnavailable }
+          )
+          break
+        }
+      } else {
+        logger.info('All %s video segments from %s available in storage (total wait: %s ms)', m3u8SegmentPaths.length, m3u8Path, ackSleepMs)
+        break
+      }
+    }
+  }
+
   private watchM3U8File () {
     this.m3u8Watcher = watch(this.outDirectory + '/*.m3u8')
 
     const sendQueues = new Map<string, PQueue>()
 
     const onChangeOrAdd = async (m3u8Path: string) => {
+      const m3u8SegmentPaths = await this.parseM3U8Segments(this.outDirectory, m3u8Path)
+      logger.debug('Parsed %s video segments from %s', m3u8SegmentPaths.length, m3u8Path, { m3u8Segments: m3u8SegmentPaths })
+
       if (this.streamingPlaylist.storage !== VideoStorage.OBJECT_STORAGE) return
 
       try {
@@ -291,7 +349,10 @@ class MuxingSession extends EventEmitter {
         }
 
         const queue = sendQueues.get(m3u8Path)
-        await queue.add(() => storeHLSFileFromPath(this.streamingPlaylist, m3u8Path))
+        await queue.add(async () => {
+          await this.waitForUnavailableM3U8Segments(m3u8Path, m3u8SegmentPaths)
+          return storeHLSFileFromPath(this.streamingPlaylist, m3u8Path)
+        })
       } catch (err) {
         logger.error('Cannot store in object storage m3u8 file %s', m3u8Path, { err, ...this.lTags() })
       }
@@ -344,6 +405,14 @@ class MuxingSession extends EventEmitter {
       if (this.streamingPlaylist.storage === VideoStorage.OBJECT_STORAGE) {
         try {
           await removeHLSFileObjectStorageByPath(this.streamingPlaylist, segmentPath)
+          if (this.liveSegmentsInStorage.includes(segmentPath)) {
+            const removedSegmentPath = this.liveSegmentsInStorage.splice(this.liveSegmentsInStorage.indexOf(segmentPath), 1)
+            logger.debug('Removed segment %s from storage', removedSegmentPath, { liveSegmentsInStorage: this.liveSegmentsInStorage })
+          } else {
+            logger.warn('Removed segment %s is missing in video segments storage', segmentPath, {
+              liveSegmentsInStorage: this.liveSegmentsInStorage
+            })
+          }
         } catch (err) {
           logger.error('Cannot remove segment %s from object storage', segmentPath, { err, ...this.lTags() })
         }
@@ -429,6 +498,8 @@ class MuxingSession extends EventEmitter {
     if (this.streamingPlaylist.storage === VideoStorage.OBJECT_STORAGE) {
       try {
         await storeHLSFileFromPath(this.streamingPlaylist, segmentPath)
+        this.liveSegmentsInStorage.push(segmentPath)
+        logger.debug('Added segment %s to storage', segmentPath, { liveSegmentsInStorage: this.liveSegmentsInStorage })
       } catch (err) {
         logger.error('Cannot store TS segment %s in object storage', segmentPath, { err, ...this.lTags() })
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,6 +1095,13 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.15.tgz#eec9f36d8eaf0948bb88c87a46784b5ee9fd0c89"
   integrity sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==
 
+"@babel/runtime@^7.12.5":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2451,6 +2458,15 @@
     bytes "^3.1.0"
     multiparty "^4.2.2"
     parse-duration "^1.0.0"
+
+"@videojs/vhs-utils@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz#665ba70d78258ba1ab977364e2fe9f4d4799c46c"
+  integrity sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    global "^4.4.0"
+    url-toolkit "^2.2.1"
 
 "@vue/compiler-core@3.2.47":
   version "3.2.47"
@@ -5269,7 +5285,7 @@ glob@^8.0.3:
     minimatch "^5.0.1"
     once "^1.3.0"
 
-global@~4.4.0:
+global@^4.4.0, global@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
@@ -6457,6 +6473,15 @@ luxon@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.2.1.tgz#14f1af209188ad61212578ea7e3d518d18cee45f"
   integrity sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==
+
+m3u8-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/m3u8-parser/-/m3u8-parser-6.0.0.tgz#e9143313b44f07bb25fdea1c8aac1098d9ada192"
+  integrity sha512-s3JfDtqhxTilZQf+P1m9dZc4ohL4O/aylP1VV6g9lhKuQNfAcVUzq7d2wgJ9nZR4ibjuXaP87QzGCV6vB0kV6g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@videojs/vhs-utils" "^3.0.5"
+    global "^4.4.0"
 
 magic-string@^0.25.7:
   version "0.25.9"
@@ -8103,7 +8128,7 @@ reflect-metadata@^0.1.12:
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
-regenerator-runtime@^0.13.3:
+regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.3:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
@@ -9406,6 +9431,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-toolkit@^2.2.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.2.5.tgz#58406b18e12c58803e14624df5e374f638b0f607"
+  integrity sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg==
 
 useragent@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Description
- Add `m3u8-parser` to project dependencies
- Keep track of all live stream video segments that are currently synced to S3 within a live _`MuxingSession`_
- Block publishing of updated `.m3u8` video metadata for up to ~~3 seconds (100 ms x 30)~~ 10 seconds (250 ms x 40), pending video segment uploads to S3 object storage

## Related issues

Resolves #5745

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, tested via [the live stream](https://pt-dev.mabl.online/w/hN6c8crzhsTciZK9yDJhvb) mentioned in the commend below
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help; ~~I don't have a real S3-enabled PeerTube server to run on at the moment~~

