### PR TITLE
Add new `live.use_object_storage` config to opt-out of S3 for streaming

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -475,6 +475,9 @@ transcoding:
 live:
   enabled: false
 
+  # Publish live streams via S3 object storage
+  use_object_storage: true
+
   # Limit lives duration
   # -1 == unlimited
   max_duration: -1 # For example: '5 hours'

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -74,7 +74,7 @@ signup:
 
 live:
   enabled: true
-
+  use_object_storage: false
   allow_replay: true
 
   transcoding:

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -485,6 +485,9 @@ transcoding:
 live:
   enabled: false
 
+  # Publish live streams via object storage/S3
+  use_object_storage: false
+
   # Limit lives duration
   # -1 == unlimited
   max_duration: -1 # For example: '5 hours'

--- a/server/controllers/api/config.ts
+++ b/server/controllers/api/config.ts
@@ -243,6 +243,7 @@ function customConfig (): CustomConfig {
     },
     live: {
       enabled: CONFIG.LIVE.ENABLED,
+      useObjectStorage: CONFIG.LIVE.USE_OBJECT_STORAGE,
       allowReplay: CONFIG.LIVE.ALLOW_REPLAY,
       latencySetting: {
         enabled: CONFIG.LIVE.LATENCY_SETTING.ENABLED

--- a/server/initializers/checker-after-init.ts
+++ b/server/initializers/checker-after-init.ts
@@ -241,6 +241,11 @@ function checkSearchConfig () {
 
 function checkLiveConfig () {
   if (CONFIG.LIVE.ENABLED === true) {
+
+    if (CONFIG.LIVE.USE_OBJECT_STORAGE === true && !CONFIG.OBJECT_STORAGE.ENABLED) {
+      throw new Error('Live streaming cannot use object storage if object storage is not enabled.')
+    }
+
     if (CONFIG.LIVE.ALLOW_REPLAY === true && CONFIG.TRANSCODING.ENABLED === false) {
       throw new Error('Live allow replay cannot be enabled if transcoding is not enabled.')
     }

--- a/server/initializers/checker-after-init.ts
+++ b/server/initializers/checker-after-init.ts
@@ -242,10 +242,6 @@ function checkSearchConfig () {
 function checkLiveConfig () {
   if (CONFIG.LIVE.ENABLED === true) {
 
-    if (CONFIG.LIVE.USE_OBJECT_STORAGE === true && !CONFIG.OBJECT_STORAGE.ENABLED) {
-      throw new Error('Live streaming cannot use object storage if object storage is not enabled.')
-    }
-
     if (CONFIG.LIVE.ALLOW_REPLAY === true && CONFIG.TRANSCODING.ENABLED === false) {
       throw new Error('Live allow replay cannot be enabled if transcoding is not enabled.')
     }

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -364,6 +364,8 @@ const CONFIG = {
   LIVE: {
     get ENABLED () { return config.get<boolean>('live.enabled') },
 
+    get USE_OBJECT_STORAGE () { return config.get<boolean>('live.use_object_storage') },
+
     get MAX_DURATION () { return parseDurationToMs(config.get<string>('live.max_duration')) },
     get MAX_INSTANCE_LIVES () { return config.get<number>('live.max_instance_lives') },
     get MAX_USER_LIVES () { return config.get<number>('live.max_user_lives') },

--- a/server/lib/live/shared/muxing-session.ts
+++ b/server/lib/live/shared/muxing-session.ts
@@ -488,7 +488,7 @@ class MuxingSession extends EventEmitter {
     playlist.p2pMediaLoaderPeerVersion = P2P_MEDIA_LOADER_PEER_VERSION
     playlist.type = VideoStreamingPlaylistType.HLS
 
-    playlist.storage = CONFIG.LIVE.USE_OBJECT_STORAGE
+    playlist.storage = CONFIG.OBJECT_STORAGE.ENABLED && CONFIG.LIVE.USE_OBJECT_STORAGE
       ? VideoStorage.OBJECT_STORAGE
       : VideoStorage.FILE_SYSTEM
 
@@ -500,7 +500,7 @@ class MuxingSession extends EventEmitter {
       videoUUID: this.videoLive.Video.uuid,
       sha256Path: join(this.outDirectory, this.streamingPlaylist.segmentsSha256Filename),
       streamingPlaylist: this.streamingPlaylist,
-      sendToObjectStorage: CONFIG.LIVE.USE_OBJECT_STORAGE
+      sendToObjectStorage: CONFIG.OBJECT_STORAGE && CONFIG.LIVE.USE_OBJECT_STORAGE
     })
   }
 }

--- a/server/lib/live/shared/muxing-session.ts
+++ b/server/lib/live/shared/muxing-session.ts
@@ -488,7 +488,7 @@ class MuxingSession extends EventEmitter {
     playlist.p2pMediaLoaderPeerVersion = P2P_MEDIA_LOADER_PEER_VERSION
     playlist.type = VideoStreamingPlaylistType.HLS
 
-    playlist.storage = CONFIG.OBJECT_STORAGE.ENABLED
+    playlist.storage = CONFIG.LIVE.USE_OBJECT_STORAGE
       ? VideoStorage.OBJECT_STORAGE
       : VideoStorage.FILE_SYSTEM
 
@@ -500,7 +500,7 @@ class MuxingSession extends EventEmitter {
       videoUUID: this.videoLive.Video.uuid,
       sha256Path: join(this.outDirectory, this.streamingPlaylist.segmentsSha256Filename),
       streamingPlaylist: this.streamingPlaylist,
-      sendToObjectStorage: CONFIG.OBJECT_STORAGE.ENABLED
+      sendToObjectStorage: CONFIG.LIVE.USE_OBJECT_STORAGE
     })
   }
 }

--- a/server/tests/api/check-params/config.ts
+++ b/server/tests/api/check-params/config.ts
@@ -130,6 +130,8 @@ describe('Test config API validators', function () {
     live: {
       enabled: true,
 
+      useObjectStorage: true,
+
       allowReplay: false,
       latencySetting: {
         enabled: false

--- a/server/tests/api/server/config.ts
+++ b/server/tests/api/server/config.ts
@@ -339,6 +339,7 @@ const newCustomConfig: CustomConfig = {
   },
   live: {
     enabled: true,
+    useObjectStorage: true,
     allowReplay: true,
     latencySetting: {
       enabled: false

--- a/shared/models/server/custom-config.model.ts
+++ b/shared/models/server/custom-config.model.ts
@@ -137,6 +137,8 @@ export interface CustomConfig {
   live: {
     enabled: boolean
 
+    useObjectStorage: boolean
+
     allowReplay: boolean
 
     latencySetting: {

--- a/shared/server-commands/server/config-command.ts
+++ b/shared/server-commands/server/config-command.ts
@@ -96,16 +96,18 @@ export class ConfigCommand extends AbstractCommand {
   // ---------------------------------------------------------------------------
 
   enableLive (options: {
+    useObjectStorage?: boolean
     allowReplay?: boolean
     transcoding?: boolean
     resolutions?: 'min' | 'max' // Default max
   } = {}) {
-    const { allowReplay, transcoding, resolutions = 'max' } = options
+    const { useObjectStorage = true, allowReplay, transcoding, resolutions = 'max' } = options
 
     return this.updateExistingSubConfig({
       newConfig: {
         live: {
           enabled: true,
+          useObjectStorage,
           allowReplay: allowReplay ?? true,
           transcoding: {
             enabled: transcoding ?? true,
@@ -389,6 +391,7 @@ export class ConfigCommand extends AbstractCommand {
       },
       live: {
         enabled: true,
+        useObjectStorage: false,
         allowReplay: false,
         latencySetting: {
           enabled: false

--- a/shared/server-commands/server/config-command.ts
+++ b/shared/server-commands/server/config-command.ts
@@ -391,7 +391,7 @@ export class ConfigCommand extends AbstractCommand {
       },
       live: {
         enabled: true,
-        useObjectStorage: false,
+        useObjectStorage: true,
         allowReplay: false,
         latencySetting: {
           enabled: false


### PR DESCRIPTION
## Description

I've been trying out the S3 sync improvements from #5765 on bug #5745, but at production scale I find myself running into issues with timing and S3 sync. It works a bit better than the baseline (which did not work at all on iPhone, consistently broke down after 10-15 seconds), but I can't make it play smoothly for long periods of time as stably as I would like.

These struggles got me thinking, "why are we doing the S3 thing really?" I don't understand the reason for publishing assets to S3 and then removing them again after 30 seconds. In my naïve perspective, it seem more simple and robust to server short-lived assets like this directly from the server and not add the extra complexity that #5765 seek to address.

This PR adds a `live.use_object_storage` flag that can be set to false to disable object storage for live streams. Here you can see it in action, up and streaming directly from disk: https://pt-dev.mabl.online/w/hN6c8crzhsTciZK9yDJhvb

What do you think about this, @Chocobozzz?

## Related issues

See #5518 and #5745

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, i have only tested on a local dev server
