### PR TITLE
I18n missing parameter

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-instance-information.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-instance-information.component.html
@@ -77,7 +77,7 @@
     <div class="row mt-4"> <!-- moderation & nsfw grid -->
       <div class="col-12 col-lg-4 col-xl-3">
         <div i18n class="inner-form-title">MODERATION & NSFW</div>
-        <div i18row="inner-form-description">
+        <div i18n class="inner-form-description">
           Manage <a class="link-orange" routerLink="/admin/users">users</a> to build a moderation team.
         </div>
       </div>

--- a/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
+++ b/client/src/app/+my-account/my-account-notifications/my-account-notifications.component.html
@@ -8,7 +8,7 @@
 
   <div class="peertube-select-container peertube-select-button ms-2 me-2">
     <select [(ngModel)]="notificationSortType" (ngModelChange)="onChangeSortColumn()" class="form-control">
-      <option value="undefined" disabled>Sort by</option>
+      <option value="undefined" disabled i18n>Sort by</option>
       <option value="createdAt" i18n>Newest first</option>
       <option value="read" [disabled]="!hasUnreadNotifications()" i18n>Unread first</option>
     </select>


### PR DESCRIPTION
## Description

There was a typo in the code that prevented a sentence from being translated and a missing `i18n` parameter. 

## Related issues

Fixes https://github.com/Chocobozzz/PeerTube/issues/5771
Fixes https://github.com/Chocobozzz/PeerTube/issues/5758

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
