### PR TITLE
Make the update script fully FreeBSD compatible

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -79,7 +79,7 @@ cp $PEERTUBE_PATH/peertube-latest/config/default.yaml $PEERTUBE_PATH/config/defa
 
 echo "Differences in configuration files..."
 cd $PEERTUBE_PATH/versions
-diff -u "$(ls --sort=t | head -2 | tail -1)/config/production.yaml.example" "$(ls --sort=t | head -1)/config/production.yaml.example"
+diff -u "$(ls -t | head -2 | tail -1)/config/production.yaml.example" "$(ls -t | head -1)/config/production.yaml.example"
 
 echo ""
 echo "==========================================="


### PR DESCRIPTION
The `ls` CLI command of FreebSD does not understand the `--search=time` parameter. "ls -t" is eequivalent and behaves the same on Linux as it does on FreeBSD.

## Description

The script scripts/update.sh contains code for updating the peertube server. It works fine, but the last command, which shows differences to the former config file, does not work on FreeBSD: the FreeBSD `ls` CLI command does not support `--search=time` parameter.

This change changes the parameter to `-t`, which is supported on Linux and FreeBSD and behaves the same on Linux as it does on FreeBSD. As a result, this notation trades some readability for better compatibility.


## Related issues

none

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

