### PR TITLE
Use largest avatar in RSS feeds, unique guid for liveItems

### DIFF
--- a/server/controllers/feeds/shared/common-feed-utils.ts
+++ b/server/controllers/feeds/shared/common-feed-utils.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { maxBy } from "lodash"
+import { maxBy } from 'lodash'
 import { Feed } from '@peertube/feed'
 import { CustomTag, CustomXMLNS, Person } from '@peertube/feed/lib/typings'
 import { mdToOneLinePlainText } from '@server/helpers/markdown'

--- a/server/controllers/feeds/shared/common-feed-utils.ts
+++ b/server/controllers/feeds/shared/common-feed-utils.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import { maxBy } from "lodash"
 import { Feed } from '@peertube/feed'
 import { CustomTag, CustomXMLNS, Person } from '@peertube/feed/lib/typings'
 import { mdToOneLinePlainText } from '@server/helpers/markdown'
@@ -104,11 +105,13 @@ export async function buildFeedMetadata (options: {
     accountLink = videoChannel.Account.getClientUrl()
 
     if (videoChannel.Actor.hasImage(ActorImageType.AVATAR)) {
-      imageUrl = WEBSERVER.URL + videoChannel.Actor.Avatars[0].getStaticPath()
+      const videoChannelAvatar = maxBy(videoChannel.Actor.Avatars, 'width')
+      imageUrl = WEBSERVER.URL + videoChannelAvatar.getStaticPath()
     }
 
     if (videoChannel.Account.Actor.hasImage(ActorImageType.AVATAR)) {
-      accountImageUrl = WEBSERVER.URL + videoChannel.Account.Actor.Avatars[0].getStaticPath()
+      const accountAvatar = maxBy(videoChannel.Account.Actor.Avatars, 'width')
+      accountImageUrl = WEBSERVER.URL + accountAvatar.getStaticPath()
     }
 
     user = await UserModel.loadById(videoChannel.Account.userId)
@@ -120,7 +123,8 @@ export async function buildFeedMetadata (options: {
     accountLink = link
 
     if (account.Actor.hasImage(ActorImageType.AVATAR)) {
-      imageUrl = WEBSERVER.URL + account.Actor.Avatars[0].getStaticPath()
+      const accountAvatar = maxBy(account.Actor.Avatars, 'width')
+      imageUrl = WEBSERVER.URL + accountAvatar?.getStaticPath()
       accountImageUrl = imageUrl
     }
 

--- a/server/controllers/feeds/video-podcast-feeds.ts
+++ b/server/controllers/feeds/video-podcast-feeds.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import { maxBy } from 'lodash'
 import { extname } from 'path'
 import { Feed } from '@peertube/feed'
 import { CustomTag, CustomXMLNS, LiveItemStatus } from '@peertube/feed/lib/typings'
@@ -7,7 +8,7 @@ import { Hooks } from '@server/lib/plugins/hooks'
 import { buildPodcastGroupsCache, cacheRouteFactory, videoFeedsPodcastSetCacheKey } from '@server/middlewares'
 import { MVideo, MVideoCaptionVideo, MVideoFullLight } from '@server/types/models'
 import { sortObjectComparator } from '@shared/core-utils'
-import { ActorImageType, VideoFile, VideoInclude, VideoResolution, VideoState } from '@shared/models'
+import { VideoFile, VideoInclude, VideoResolution, VideoState } from '@shared/models'
 import { buildNSFWFilter } from '../../helpers/express-utils'
 import { MIMETYPES, ROUTE_CACHE_LIFETIME, WEBSERVER } from '../../initializers/constants'
 import { asyncMiddleware, setFeedPodcastContentType, videoFeedsPodcastValidator } from '../../middlewares'
@@ -141,6 +142,9 @@ async function generatePodcastItem (options: {
     href: account.getClientUrl()
   }
 
+  const avatar = maxBy(account.Actor.Avatars, 'width')
+  const img = avatar?.getStaticPath()
+
   return {
     ...getCommonVideoFeedAttributes(video),
 
@@ -151,9 +155,7 @@ async function generatePodcastItem (options: {
       {
         ...author,
 
-        img: account.Actor.hasImage(ActorImageType.AVATAR)
-          ? WEBSERVER.URL + account.Actor.Avatars[0].getStaticPath()
-          : undefined
+        img
       }
     ],
 

--- a/server/controllers/feeds/video-podcast-feeds.ts
+++ b/server/controllers/feeds/video-podcast-feeds.ts
@@ -144,11 +144,11 @@ async function generatePodcastItem (options: {
 
   const attributes = getCommonVideoFeedAttributes(video)
   const guid = liveItem ? `${video.uuid}_${video.publishedAt.toISOString()}` : attributes.link
-  let img
+  let personImage
 
   if (account.Actor.hasImage(ActorImageType.AVATAR)) {
     const avatar = maxBy(account.Actor.Avatars, 'width')
-    img = WEBSERVER.URL + avatar.getStaticPath()
+    personImage = WEBSERVER.URL + avatar.getStaticPath()
   }
 
   return {
@@ -162,7 +162,7 @@ async function generatePodcastItem (options: {
       {
         ...author,
 
-        img
+        img: personImage
       }
     ],
 

--- a/server/controllers/feeds/video-podcast-feeds.ts
+++ b/server/controllers/feeds/video-podcast-feeds.ts
@@ -142,9 +142,12 @@ async function generatePodcastItem (options: {
     href: account.getClientUrl()
   }
 
-  const attributes = getCommonVideoFeedAttributes(video)
-  const guid = liveItem ? `${video.uuid}_${video.publishedAt.toISOString()}` : attributes.link
-  let personImage
+  const commonAttributes = getCommonVideoFeedAttributes(video)
+  const guid = liveItem
+    ? `${video.uuid}_${video.publishedAt.toISOString()}`
+    : commonAttributes.link
+
+  let personImage: string
 
   if (account.Actor.hasImage(ActorImageType.AVATAR)) {
     const avatar = maxBy(account.Actor.Avatars, 'width')
@@ -153,7 +156,7 @@ async function generatePodcastItem (options: {
 
   return {
     guid,
-    ...attributes,
+    ...commonAttributes,
 
     trackers: video.getTrackerUrls(),
 

--- a/server/middlewares/validators/feeds.ts
+++ b/server/middlewares/validators/feeds.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { param, query } from 'express-validator'
-import { HttpStatusCode } from '../../../shared/models/http/http-error-codes'
+import { HttpStatusCode } from '@shared/models'
 import { isValidRSSFeed } from '../../helpers/custom-validators/feeds'
 import { exists, isIdOrUUIDValid, isIdValid, toCompleteUUID } from '../../helpers/custom-validators/misc'
 import { buildPodcastGroupsCache } from '../cache'

--- a/server/tests/feeds/feeds.ts
+++ b/server/tests/feeds/feeds.ts
@@ -177,6 +177,9 @@ describe('Test syndication feeds', () => {
         const parser = new XMLParser({ parseAttributeValue: true, ignoreAttributes: false })
         const xmlDoc = parser.parse(rss)
 
+        const itemGuid = xmlDoc.rss.channel.item.guid
+        expect(itemGuid).to.exist
+        expect(itemGuid['@_isPermaLink']).to.equal(true)
         const enclosure = xmlDoc.rss.channel.item.enclosure
         expect(enclosure).to.exist
         const alternateEnclosure = xmlDoc.rss.channel.item['podcast:alternateEnclosure']
@@ -286,6 +289,8 @@ describe('Test syndication feeds', () => {
         const xmlDoc = parser.parse(rss)
         const liveItem = xmlDoc.rss.channel['podcast:liveItem']
         expect(liveItem.title).to.equal('live-0')
+        expect(liveItem.guid['@_isPermaLink']).to.equal(false)
+        expect(liveItem.guid['#text']).to.contain(`${uuid}_`)
         expect(liveItem['@_status']).to.equal('live')
 
         const enclosure = liveItem.enclosure

--- a/server/tests/feeds/feeds.ts
+++ b/server/tests/feeds/feeds.ts
@@ -180,6 +180,7 @@ describe('Test syndication feeds', () => {
         const itemGuid = xmlDoc.rss.channel.item.guid
         expect(itemGuid).to.exist
         expect(itemGuid['@_isPermaLink']).to.equal(true)
+
         const enclosure = xmlDoc.rss.channel.item.enclosure
         expect(enclosure).to.exist
         const alternateEnclosure = xmlDoc.rss.channel.item['podcast:alternateEnclosure']
@@ -204,6 +205,10 @@ describe('Test syndication feeds', () => {
 
         const parser = new XMLParser({ parseAttributeValue: true, ignoreAttributes: false })
         const xmlDoc = parser.parse(rss)
+
+        const itemGuid = xmlDoc.rss.channel.item.guid
+        expect(itemGuid).to.exist
+        expect(itemGuid['@_isPermaLink']).to.equal(true)
 
         const enclosure = xmlDoc.rss.channel.item.enclosure
         const alternateEnclosure = xmlDoc.rss.channel.item['podcast:alternateEnclosure']


### PR DESCRIPTION
## Description

This pull request adjusts the following:

1. In Podcast RSS feeds, it uses the largest available actor avatar instead of the first available.  Greatly improves user experience in applications.
2. Sets a unique `<guid>` element in `<podcast:liveItem>` to make it easier for applications to uniquely identify different times the same permanent live stream goes live.

## Has this been tested?

Updated tests for `<guid>`.  Avatar checks will need more work to pull in avatars during testing, but they have been checked manually.

Testing in production on 5.2.0-rc.1

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

