### PR TITLE
Fix the cleanup after a failed upload

### DIFF
--- a/server/middlewares/validators/videos/videos.ts
+++ b/server/middlewares/validators/videos/videos.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import { body, header, param, query, ValidationChain } from 'express-validator'
 import { isTestInstance } from '@server/helpers/core-utils'
 import { getResumableUploadPath } from '@server/helpers/upload'
+import { uploadx } from '@server/lib/uploadx'
 import { Redis } from '@server/lib/redis'
 import { getServerActor } from '@server/models/application/application'
 import { ExpressPromiseHandler } from '@server/types/express-handler'
@@ -39,7 +40,6 @@ import {
 } from '../../../helpers/custom-validators/videos'
 import { cleanUpReqFiles } from '../../../helpers/express-utils'
 import { logger } from '../../../helpers/logger'
-import { deleteFileAndCatch } from '../../../helpers/utils'
 import { getVideoWithAttributes } from '../../../helpers/video'
 import { CONFIG } from '../../../initializers/config'
 import { CONSTRAINTS_FIELDS, OVERVIEWS } from '../../../initializers/constants'
@@ -107,7 +107,7 @@ const videosAddResumableValidator = [
     const user = res.locals.oauth.token.User
     const body: express.CustomUploadXFile<express.UploadXFileMetadata> = req.body
     const file = { ...body, duration: undefined, path: getResumableUploadPath(body.name), filename: body.metadata.filename }
-    const cleanup = () => deleteFileAndCatch(file.path)
+    const cleanup = () => uploadx.storage.delete(file).catch(err => logger.error('Cannot delete the file %s', file.name, { err }))
 
     const uploadId = req.query.upload_id
     const sessionExists = await Redis.Instance.doesUploadSessionExist(uploadId)

--- a/server/tests/api/videos/resumable-upload.ts
+++ b/server/tests/api/videos/resumable-upload.ts
@@ -93,10 +93,10 @@ describe('Test resumable upload', function () {
     expect((await stat(filePath)).size).to.equal(expectedSize)
   }
 
-  async function countResumableUploads () {
+  async function countResumableUploads (wait?: number) {
     const subPath = join('tmp', 'resumable-uploads')
     const filePath = server.servers.buildDirectory(subPath)
-
+    await new Promise(resolve => setTimeout(resolve, wait))
     const files = await readdir(filePath)
     return files.length
   }
@@ -134,7 +134,7 @@ describe('Test resumable upload', function () {
       const uploadId = await prepareUpload({ size: 8 * 1024 })
       await sendChunks({ pathUploadId: uploadId, size: 8 * 1024, expectedStatus: HttpStatusCode.UNPROCESSABLE_ENTITY_422 })
 
-      expect(await countResumableUploads()).to.equal(0)
+      expect(await countResumableUploads(2000)).to.equal(0)
     })
 
     it('Should not delete files after an unfinished upload', async function () {

--- a/server/tests/api/videos/resumable-upload.ts
+++ b/server/tests/api/videos/resumable-upload.ts
@@ -122,14 +122,20 @@ describe('Test resumable upload', function () {
 
   describe('Directory cleaning', function () {
 
-    // FIXME: https://github.com/kukhariev/node-uploadx/pull/524/files#r852989382
-    // it('Should correctly delete files after an upload', async function () {
-    //   const uploadId = await prepareUpload()
-    //   await sendChunks({ pathUploadId: uploadId })
-    //   await server.videos.endResumableUpload({ pathUploadId: uploadId })
+    it('Should correctly delete files after an upload', async function () {
+      const uploadId = await prepareUpload()
+      await sendChunks({ pathUploadId: uploadId })
+      await server.videos.endResumableUpload({ pathUploadId: uploadId })
 
-    //   expect(await countResumableUploads()).to.equal(0)
-    // })
+      expect(await countResumableUploads()).to.equal(0)
+    })
+
+    it('Should correctly delete corrupt files', async function () {
+      const uploadId = await prepareUpload({ size: 8 * 1024 })
+      await sendChunks({ pathUploadId: uploadId, size: 8 * 1024, expectedStatus: HttpStatusCode.UNPROCESSABLE_ENTITY_422 })
+
+      expect(await countResumableUploads()).to.equal(0)
+    })
 
     it('Should not delete files after an unfinished upload', async function () {
       await prepareUpload()


### PR DESCRIPTION
## Description

Along with the failed uploaded file, the metadata file will also be removed from the disk and cache.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/5812#issuecomment-1596060166

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

