### PR TITLE
Update third party link to docs in noscript version of page

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -50,7 +50,7 @@
 
       <ul>
         <li>Allow JavaScript in your browser</li>
-        <li>Use one of the <a class="link-orange" href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/use-third-party-application.md" target="_blank">third-party applications</a> to browse this instance</li>
+        <li>Use one of the <a class="link-orange" href="https://framagit.org/framasoft/peertube/documentation/-/raw/master/docs/use/third-party-application.md" target="_blank">third-party applications</a> to browse this instance</li>
         <li>Review the source code on <a class="link-orange" href="https://github.com/Chocobozzz/PeerTube" target="_blank">GitHub</a> or <a class="link-orange" href="https://framagit.org/framasoft/peertube/PeerTube" target="_blank">Framasoft's GitLab</a>, and ask for modifications from the instance owner.
       </ul>
     </noscript>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
The noscript version (https://github.com/Chocobozzz/PeerTube/pull/2896) of PeerTube pages links to a dead link. This PR updates it.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
To see the links:
1. Disable JavaScript
2. Go onto the PeerTube instance on any page

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

~~Help needed with~~:
- Setting up development version of PeerTube (may not be required for such a simple change unless tests depends on it)