### PR TITLE
Add an option to sign federated fetches for mastodon compatibility

### DIFF
--- a/client/src/assets/player/shared/bezels/bezels-plugin.ts
+++ b/client/src/assets/player/shared/bezels/bezels-plugin.ts
@@ -12,7 +12,10 @@ class BezelsPlugin extends Plugin {
       player.addClass('vjs-bezels')
     })
 
-    player.addChild(new PauseBezel(player, options))
+    const component = new PauseBezel(player, options)
+    player.addChild(component)
+
+    this.on('dispose', () => player.removeChild(component))
   }
 }
 

--- a/client/src/assets/player/shared/peertube/peertube-plugin.ts
+++ b/client/src/assets/player/shared/peertube/peertube-plugin.ts
@@ -36,6 +36,8 @@ class PeerTubePlugin extends Plugin {
   private mouseInControlBar = false
   private mouseInSettings = false
 
+  private errorModal: videojs.ModalDialog
+
   private videoViewOnPlayHandler: (...args: any[]) => void
   private videoViewOnSeekedHandler: (...args: any[]) => void
   private videoViewOnEndedHandler: (...args: any[]) => void
@@ -109,6 +111,8 @@ class PeerTubePlugin extends Plugin {
 
       this.player.on('video-change', () => {
         this.initOnVideoChange()
+
+        this.hideFatalError()
       })
     })
   }
@@ -130,6 +134,11 @@ class PeerTubePlugin extends Plugin {
   }
 
   displayFatalError () {
+    // Already displayed an error
+    if (this.errorModal) return
+
+    debugLogger('Display fatal error')
+
     this.player.loadingSpinner.hide()
 
     const buildModal = (error: MediaError) => {
@@ -150,17 +159,24 @@ class PeerTubePlugin extends Plugin {
       return wrapper
     }
 
-    const modal = this.player.createModal(buildModal(this.player.error()), {
-      temporary: false,
+    this.errorModal = this.player.createModal(buildModal(this.player.error()), {
+      temporary: true,
       uncloseable: true
     })
-    modal.addClass('vjs-custom-error-display')
+    this.errorModal.addClass('vjs-custom-error-display')
 
     this.player.addClass('vjs-error-display-enabled')
   }
 
   hideFatalError () {
+    if (!this.errorModal) return
+
+    debugLogger('Hiding fatal error')
+
     this.player.removeClass('vjs-error-display-enabled')
+    this.player.removeChild(this.errorModal)
+    this.errorModal.close()
+    this.errorModal = undefined
   }
 
   private initializePlayer () {

--- a/client/src/assets/player/shared/upnext/end-card.ts
+++ b/client/src/assets/player/shared/upnext/end-card.ts
@@ -31,7 +31,7 @@ export interface EndCardOptions extends videojs.ComponentOptions, UpNextPluginOp
 }
 
 const Component = videojs.getComponent('Component')
-class EndCard extends Component {
+export class EndCard extends Component {
   options_: EndCardOptions
 
   dashOffsetTotal = 586

--- a/client/src/assets/player/shared/upnext/upnext-plugin.ts
+++ b/client/src/assets/player/shared/upnext/upnext-plugin.ts
@@ -1,6 +1,6 @@
 import videojs from 'video.js'
 import { UpNextPluginOptions } from '../../types'
-import { EndCardOptions } from './end-card'
+import { EndCard, EndCardOptions } from './end-card'
 
 const Plugin = videojs.getPlugin('plugin')
 
@@ -24,7 +24,10 @@ class UpNextPlugin extends Plugin {
       player.addClass('vjs-upnext')
     })
 
-    player.addChild('EndCard', settings)
+    const component = new EndCard(player, settings)
+
+    player.addChild(component)
+    this.on('dispose', () => player.removeChild(component))
   }
 }
 

--- a/client/src/assets/player/shared/web-video/web-video-plugin.ts
+++ b/client/src/assets/player/shared/web-video/web-video-plugin.ts
@@ -65,9 +65,10 @@ class WebVideoPlugin extends Plugin {
     const playbackRate = this.player.playbackRate()
     const currentTime = this.player.currentTime()
 
-    // Enable error display now this is our last fallback
-    this.onErrorHandler = () => this.player.peertube().displayFatalError()
-    this.player.one('error', this.onErrorHandler)
+    if (!this.onErrorHandler) {
+      this.onErrorHandler = () => this.player.peertube().displayFatalError()
+      this.player.one('error', this.onErrorHandler)
+    }
 
     let httpUrl = this.currentVideoFile.fileUrl
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -374,7 +374,9 @@ plugins:
     url: 'https://packages.joinpeertube.org'
 
 federation:
-  sign_federated_fetches: false
+  # Some federated software such as Mastodon may require an HTTP signature to access content
+  sign_federated_fetches: true
+
   videos:
     federate_unlisted: false
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -374,6 +374,7 @@ plugins:
     url: 'https://packages.joinpeertube.org'
 
 federation:
+  sign_federated_fetches: false
   videos:
     federate_unlisted: false
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -372,7 +372,9 @@ plugins:
     url: 'https://packages.joinpeertube.org'
 
 federation:
-  sign_federated_fetches: false
+  # Some federated software such as Mastodon may require an HTTP signature to access content
+  sign_federated_fetches: true
+
   videos:
     federate_unlisted: false
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -372,6 +372,7 @@ plugins:
     url: 'https://packages.joinpeertube.org'
 
 federation:
+  sign_federated_fetches: false
   videos:
     federate_unlisted: false
 

--- a/server/controllers/api/search/search-video-channels.ts
+++ b/server/controllers/api/search/search-video-channels.ts
@@ -1,9 +1,10 @@
 import express from 'express'
 import { sanitizeUrl } from '@server/helpers/core-utils'
 import { pickSearchChannelQuery } from '@server/helpers/query'
-import { doJSONRequest, findLatestRedirection } from '@server/helpers/requests'
+import { doJSONRequest } from '@server/helpers/requests'
 import { CONFIG } from '@server/initializers/config'
 import { WEBSERVER } from '@server/initializers/constants'
+import { findLatestAPRedirection } from '@server/lib/activitypub/activity'
 import { Hooks } from '@server/lib/plugins/hooks'
 import { buildMutedForSearchIndex, isSearchIndexSearch, isURISearch } from '@server/lib/search'
 import { getServerActor } from '@server/models/application/application'
@@ -126,7 +127,7 @@ async function searchVideoChannelURI (search: string, res: express.Response) {
 
   if (isUserAbleToSearchRemoteURI(res)) {
     try {
-      const latestUri = await findLatestRedirection(uri, { activityPub: true })
+      const latestUri = await findLatestAPRedirection(uri)
 
       const actor = await getOrCreateAPActor(latestUri, 'all', true, true)
       videoChannel = actor.VideoChannel

--- a/server/controllers/api/search/search-video-playlists.ts
+++ b/server/controllers/api/search/search-video-playlists.ts
@@ -3,10 +3,11 @@ import { sanitizeUrl } from '@server/helpers/core-utils'
 import { isUserAbleToSearchRemoteURI } from '@server/helpers/express-utils'
 import { logger } from '@server/helpers/logger'
 import { pickSearchPlaylistQuery } from '@server/helpers/query'
-import { doJSONRequest, findLatestRedirection } from '@server/helpers/requests'
+import { doJSONRequest } from '@server/helpers/requests'
 import { getFormattedObjects } from '@server/helpers/utils'
 import { CONFIG } from '@server/initializers/config'
 import { WEBSERVER } from '@server/initializers/constants'
+import { findLatestAPRedirection } from '@server/lib/activitypub/activity'
 import { getOrCreateAPVideoPlaylist } from '@server/lib/activitypub/playlists/get'
 import { Hooks } from '@server/lib/plugins/hooks'
 import { buildMutedForSearchIndex, isSearchIndexSearch, isURISearch } from '@server/lib/search'
@@ -105,7 +106,7 @@ async function searchVideoPlaylistsURI (search: string, res: express.Response) {
 
   if (isUserAbleToSearchRemoteURI(res)) {
     try {
-      const url = await findLatestRedirection(search, { activityPub: true })
+      const url = await findLatestAPRedirection(search)
 
       videoPlaylist = await getOrCreateAPVideoPlaylist(url)
     } catch (err) {

--- a/server/controllers/api/search/search-videos.ts
+++ b/server/controllers/api/search/search-videos.ts
@@ -1,9 +1,10 @@
 import express from 'express'
 import { sanitizeUrl } from '@server/helpers/core-utils'
 import { pickSearchVideoQuery } from '@server/helpers/query'
-import { doJSONRequest, findLatestRedirection } from '@server/helpers/requests'
+import { doJSONRequest } from '@server/helpers/requests'
 import { CONFIG } from '@server/initializers/config'
 import { WEBSERVER } from '@server/initializers/constants'
+import { findLatestAPRedirection } from '@server/lib/activitypub/activity'
 import { getOrCreateAPVideo } from '@server/lib/activitypub/videos'
 import { Hooks } from '@server/lib/plugins/hooks'
 import { buildMutedForSearchIndex, isSearchIndexSearch, isURISearch } from '@server/lib/search'
@@ -141,7 +142,7 @@ async function searchVideoURI (url: string, res: express.Response) {
       }
 
       const result = await getOrCreateAPVideo({
-        videoObject: await findLatestRedirection(url, { activityPub: true }),
+        videoObject: await findLatestAPRedirection(url),
         syncParam
       })
       video = result ? result.video : undefined

--- a/server/initializers/config.ts
+++ b/server/initializers/config.ts
@@ -309,7 +309,8 @@ const CONFIG = {
     VIDEOS: {
       FEDERATE_UNLISTED: config.get<boolean>('federation.videos.federate_unlisted'),
       CLEANUP_REMOTE_INTERACTIONS: config.get<boolean>('federation.videos.cleanup_remote_interactions')
-    }
+    },
+    SIGN_FEDERATED_FETCHES: config.get<boolean>('federation.sign_federated_fetches')
   },
   PEERTUBE: {
     CHECK_LATEST_VERSION: {

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -712,8 +712,8 @@ const ACTIVITY_PUB_ACTOR_TYPES: { [ id: string ]: ActivityPubActorType } = {
 const HTTP_SIGNATURE = {
   HEADER_NAME: 'signature',
   ALGORITHM: 'rsa-sha256',
-  HEADERS_TO_SIGN: [ '(request-target)', 'host', 'date', 'digest' ],
-  HEADERS_TO_SIGN_FETCH: [ '(request-target)', 'host', 'date' ],
+  HEADERS_TO_SIGN_WITH_PAYLOAD: [ '(request-target)', 'host', 'date', 'digest' ],
+  HEADERS_TO_SIGN_WITHOUT_PAYLOAD: [ '(request-target)', 'host', 'date' ],
   CLOCK_SKEW_SECONDS: 1800
 }
 

--- a/server/initializers/constants.ts
+++ b/server/initializers/constants.ts
@@ -713,6 +713,7 @@ const HTTP_SIGNATURE = {
   HEADER_NAME: 'signature',
   ALGORITHM: 'rsa-sha256',
   HEADERS_TO_SIGN: [ '(request-target)', 'host', 'date', 'digest' ],
+  HEADERS_TO_SIGN_FETCH: [ '(request-target)', 'host', 'date' ],
   CLOCK_SKEW_SECONDS: 1800
 }
 

--- a/server/lib/activitypub/actors/get.ts
+++ b/server/lib/activitypub/actors/get.ts
@@ -5,7 +5,7 @@ import { ActorLoadByUrlType, loadActorByUrl } from '@server/lib/model-loaders'
 import { MActor, MActorAccountChannelId, MActorAccountChannelIdActor, MActorAccountId, MActorFullActor } from '@server/types/models'
 import { arrayify } from '@shared/core-utils'
 import { ActivityPubActor, APObjectId } from '@shared/models'
-import { fetchAPObject, getAPId } from '../activity'
+import { fetchAPObjectIfNeeded, getAPId } from '../activity'
 import { checkUrlsSameHost } from '../url'
 import { refreshActorIfNeeded } from './refresh'
 import { APActorCreator, fetchRemoteActor } from './shared'
@@ -87,7 +87,7 @@ async function getOrCreateAPOwner (actorObject: ActivityPubActor, actorUrl: stri
 
 async function findOwner (rootUrl: string, attributedTo: APObjectId[] | APObjectId, type: 'Person' | 'Group') {
   for (const actorToCheck of arrayify(attributedTo)) {
-    const actorObject = await fetchAPObject<ActivityPubActor>(getAPId(actorToCheck))
+    const actorObject = await fetchAPObjectIfNeeded<ActivityPubActor>(getAPId(actorToCheck))
 
     if (!actorObject) {
       logger.warn('Unknown attributed to actor %s for owner %s', actorToCheck, rootUrl)

--- a/server/lib/activitypub/crawl.ts
+++ b/server/lib/activitypub/crawl.ts
@@ -3,8 +3,8 @@ import { URL } from 'url'
 import { retryTransactionWrapper } from '@server/helpers/database-utils'
 import { ActivityPubOrderedCollection } from '../../../shared/models/activitypub'
 import { logger } from '../../helpers/logger'
-import { doJSONRequest } from '../../helpers/requests'
 import { ACTIVITY_PUB, WEBSERVER } from '../../initializers/constants'
+import { fetchAP } from './activity'
 
 type HandlerFunction<T> = (items: T[]) => (Promise<any> | Bluebird<any>)
 type CleanerFunction = (startedDate: Date) => Promise<any>
@@ -14,11 +14,9 @@ async function crawlCollectionPage <T> (argUrl: string, handler: HandlerFunction
 
   logger.info('Crawling ActivityPub data on %s.', url)
 
-  const options = { activityPub: true }
-
   const startDate = new Date()
 
-  const response = await doJSONRequest<ActivityPubOrderedCollection<T>>(url, options)
+  const response = await fetchAP<ActivityPubOrderedCollection<T>>(url)
   const firstBody = response.body
 
   const limit = ACTIVITY_PUB.FETCH_PAGE_LIMIT
@@ -34,7 +32,7 @@ async function crawlCollectionPage <T> (argUrl: string, handler: HandlerFunction
 
       url = nextLink
 
-      const res = await doJSONRequest<ActivityPubOrderedCollection<T>>(url, options)
+      const res = await fetchAP<ActivityPubOrderedCollection<T>>(url)
       body = res.body
     } else {
       // nextLink is already the object we want

--- a/server/lib/activitypub/playlists/shared/url-to-object.ts
+++ b/server/lib/activitypub/playlists/shared/url-to-object.ts
@@ -1,8 +1,8 @@
 import { isPlaylistElementObjectValid, isPlaylistObjectValid } from '@server/helpers/custom-validators/activitypub/playlist'
 import { isArray } from '@server/helpers/custom-validators/misc'
 import { logger, loggerTagsFactory } from '@server/helpers/logger'
-import { doJSONRequest } from '@server/helpers/requests'
 import { PlaylistElementObject, PlaylistObject } from '@shared/models'
+import { fetchAP } from '../../activity'
 import { checkUrlsSameHost } from '../../url'
 
 async function fetchRemoteVideoPlaylist (playlistUrl: string): Promise<{ statusCode: number, playlistObject: PlaylistObject }> {
@@ -10,7 +10,7 @@ async function fetchRemoteVideoPlaylist (playlistUrl: string): Promise<{ statusC
 
   logger.info('Fetching remote playlist %s.', playlistUrl, lTags())
 
-  const { body, statusCode } = await doJSONRequest<any>(playlistUrl, { activityPub: true })
+  const { body, statusCode } = await fetchAP<any>(playlistUrl)
 
   if (isPlaylistObjectValid(body) === false || checkUrlsSameHost(body.id, playlistUrl) !== true) {
     logger.debug('Remote video playlist JSON is not valid.', { body, ...lTags() })
@@ -30,7 +30,7 @@ async function fetchRemotePlaylistElement (elementUrl: string): Promise<{ status
 
   logger.debug('Fetching remote playlist element %s.', elementUrl, lTags())
 
-  const { body, statusCode } = await doJSONRequest<PlaylistElementObject>(elementUrl, { activityPub: true })
+  const { body, statusCode } = await fetchAP<PlaylistElementObject>(elementUrl)
 
   if (!isPlaylistElementObjectValid(body)) throw new Error(`Invalid body in fetch playlist element ${elementUrl}`)
 

--- a/server/lib/activitypub/process/process-create.ts
+++ b/server/lib/activitypub/process/process-create.ts
@@ -18,7 +18,7 @@ import { sequelizeTypescript } from '../../../initializers/database'
 import { APProcessorOptions } from '../../../types/activitypub-processor.model'
 import { MActorSignature, MCommentOwnerVideo, MVideoAccountLightBlacklistAllFiles } from '../../../types/models'
 import { Notifier } from '../../notifier'
-import { fetchAPObject } from '../activity'
+import { fetchAPObjectIfNeeded } from '../activity'
 import { createOrUpdateCacheFile } from '../cache-file'
 import { createOrUpdateLocalVideoViewer } from '../local-video-viewer'
 import { createOrUpdateVideoPlaylist } from '../playlists'
@@ -31,7 +31,7 @@ async function processCreateActivity (options: APProcessorOptions<ActivityCreate
 
   // Only notify if it is not from a fetcher job
   const notify = options.fromFetch !== true
-  const activityObject = await fetchAPObject<Exclude<ActivityObject, AbuseObject>>(activity.object)
+  const activityObject = await fetchAPObjectIfNeeded<Exclude<ActivityObject, AbuseObject>>(activity.object)
   const activityType = activityObject.type
 
   if (activityType === 'Video') {

--- a/server/lib/activitypub/process/process-undo.ts
+++ b/server/lib/activitypub/process/process-undo.ts
@@ -19,7 +19,7 @@ import { VideoRedundancyModel } from '../../../models/redundancy/video-redundanc
 import { VideoShareModel } from '../../../models/video/video-share'
 import { APProcessorOptions } from '../../../types/activitypub-processor.model'
 import { MActorSignature } from '../../../types/models'
-import { fetchAPObject } from '../activity'
+import { fetchAPObjectIfNeeded } from '../activity'
 import { forwardVideoRelatedActivity } from '../send/shared/send-utils'
 import { federateVideoIfNeeded, getOrCreateAPVideo } from '../videos'
 
@@ -32,7 +32,7 @@ async function processUndoActivity (options: APProcessorOptions<ActivityUndo<Act
   }
 
   if (activityToUndo.type === 'Create') {
-    const objectToUndo = await fetchAPObject<CacheFileObject>(activityToUndo.object)
+    const objectToUndo = await fetchAPObjectIfNeeded<CacheFileObject>(activityToUndo.object)
 
     if (objectToUndo.type === 'CacheFile') {
       return retryTransactionWrapper(processUndoCacheFile, byActor, activity, objectToUndo)

--- a/server/lib/activitypub/process/process-update.ts
+++ b/server/lib/activitypub/process/process-update.ts
@@ -10,7 +10,7 @@ import { sequelizeTypescript } from '../../../initializers/database'
 import { ActorModel } from '../../../models/actor/actor'
 import { APProcessorOptions } from '../../../types/activitypub-processor.model'
 import { MActorFull, MActorSignature } from '../../../types/models'
-import { fetchAPObject } from '../activity'
+import { fetchAPObjectIfNeeded } from '../activity'
 import { APActorUpdater } from '../actors/updater'
 import { createOrUpdateCacheFile } from '../cache-file'
 import { createOrUpdateVideoPlaylist } from '../playlists'
@@ -20,7 +20,7 @@ import { APVideoUpdater, getOrCreateAPVideo } from '../videos'
 async function processUpdateActivity (options: APProcessorOptions<ActivityUpdate<ActivityUpdateObject>>) {
   const { activity, byActor } = options
 
-  const object = await fetchAPObject(activity.object)
+  const object = await fetchAPObjectIfNeeded(activity.object)
   const objectType = object.type
 
   if (objectType === 'Video') {

--- a/server/lib/activitypub/send/http.ts
+++ b/server/lib/activitypub/send/http.ts
@@ -23,11 +23,14 @@ async function computeBody <T> (
   return body
 }
 
-async function buildSignedRequestOptions (payload: Payload<any>) {
+async function buildSignedRequestOptions (options: {
+  signatureActorId?: number
+  hasPayload: boolean
+}) {
   let actor: MActor | null
 
-  if (payload.signatureActorId) {
-    actor = await ActorModel.load(payload.signatureActorId)
+  if (options.signatureActorId) {
+    actor = await ActorModel.load(options.signatureActorId)
     if (!actor) throw new Error('Unknown signature actor id.')
   } else {
     // We need to sign the request, so use the server
@@ -40,7 +43,9 @@ async function buildSignedRequestOptions (payload: Payload<any>) {
     authorizationHeaderName: HTTP_SIGNATURE.HEADER_NAME,
     keyId,
     key: actor.privateKey,
-    headers: HTTP_SIGNATURE.HEADERS_TO_SIGN
+    headers: options.hasPayload
+      ? HTTP_SIGNATURE.HEADERS_TO_SIGN_WITH_PAYLOAD
+      : HTTP_SIGNATURE.HEADERS_TO_SIGN_WITHOUT_PAYLOAD
   }
 }
 

--- a/server/lib/activitypub/share.ts
+++ b/server/lib/activitypub/share.ts
@@ -2,11 +2,10 @@ import { map } from 'bluebird'
 import { Transaction } from 'sequelize'
 import { getServerActor } from '@server/models/application/application'
 import { logger, loggerTagsFactory } from '../../helpers/logger'
-import { doJSONRequest } from '../../helpers/requests'
 import { CRAWL_REQUEST_CONCURRENCY } from '../../initializers/constants'
 import { VideoShareModel } from '../../models/video/video-share'
 import { MChannelActorLight, MVideo, MVideoAccountLight, MVideoId } from '../../types/models/video'
-import { getAPId } from './activity'
+import { fetchAP, getAPId } from './activity'
 import { getOrCreateAPActor } from './actors'
 import { sendUndoAnnounce, sendVideoAnnounce } from './send'
 import { checkUrlsSameHost, getLocalVideoAnnounceActivityPubUrl } from './url'
@@ -56,7 +55,7 @@ export {
 // ---------------------------------------------------------------------------
 
 async function addVideoShare (shareUrl: string, video: MVideoId) {
-  const { body } = await doJSONRequest<any>(shareUrl, { activityPub: true })
+  const { body } = await fetchAP<any>(shareUrl)
   if (!body?.actor) throw new Error('Body or body actor is invalid')
 
   const actorUrl = getAPId(body.actor)

--- a/server/lib/activitypub/videos/shared/url-to-object.ts
+++ b/server/lib/activitypub/videos/shared/url-to-object.ts
@@ -1,7 +1,7 @@
 import { sanitizeAndCheckVideoTorrentObject } from '@server/helpers/custom-validators/activitypub/videos'
 import { logger, loggerTagsFactory } from '@server/helpers/logger'
-import { doJSONRequest } from '@server/helpers/requests'
 import { VideoObject } from '@shared/models'
+import { fetchAP } from '../../activity'
 import { checkUrlsSameHost } from '../../url'
 
 const lTags = loggerTagsFactory('ap', 'video')
@@ -9,7 +9,7 @@ const lTags = loggerTagsFactory('ap', 'video')
 async function fetchRemoteVideo (videoUrl: string): Promise<{ statusCode: number, videoObject: VideoObject }> {
   logger.info('Fetching remote video %s.', videoUrl, lTags(videoUrl))
 
-  const { statusCode, body } = await doJSONRequest<any>(videoUrl, { activityPub: true })
+  const { statusCode, body } = await fetchAP<any>(videoUrl)
 
   if (sanitizeAndCheckVideoTorrentObject(body) === false || checkUrlsSameHost(body.id, videoUrl) !== true) {
     logger.debug('Remote video JSON is not valid.', { body, ...lTags(videoUrl) })

--- a/server/lib/job-queue/handlers/activitypub-cleaner.ts
+++ b/server/lib/job-queue/handlers/activitypub-cleaner.ts
@@ -6,8 +6,9 @@ import {
   isLikeActivityValid
 } from '@server/helpers/custom-validators/activitypub/activity'
 import { sanitizeAndCheckVideoCommentObject } from '@server/helpers/custom-validators/activitypub/video-comments'
-import { doJSONRequest, PeerTubeRequestError } from '@server/helpers/requests'
+import { PeerTubeRequestError } from '@server/helpers/requests'
 import { AP_CLEANER } from '@server/initializers/constants'
+import { fetchAP } from '@server/lib/activitypub/activity'
 import { checkUrlsSameHost } from '@server/lib/activitypub/url'
 import { Redis } from '@server/lib/redis'
 import { VideoModel } from '@server/models/video/video'
@@ -85,7 +86,7 @@ async function updateObjectIfNeeded <T> (options: {
   }
 
   try {
-    const { body } = await doJSONRequest<any>(url, { activityPub: true })
+    const { body } = await fetchAP<any>(url)
 
     // If not same id, check same host and update
     if (!body?.id || !bodyValidator(body)) throw new Error(`Body or body id of ${url} is invalid`)

--- a/server/lib/job-queue/handlers/activitypub-http-broadcast.ts
+++ b/server/lib/job-queue/handlers/activitypub-http-broadcast.ts
@@ -38,7 +38,7 @@ export {
 
 async function buildRequestOptions (payload: ActivitypubHttpBroadcastPayload) {
   const body = await computeBody(payload)
-  const httpSignatureOptions = await buildSignedRequestOptions(payload)
+  const httpSignatureOptions = await buildSignedRequestOptions({ signatureActorId: payload.signatureActorId, hasPayload: true })
 
   return {
     method: 'POST' as 'POST',

--- a/server/lib/job-queue/handlers/activitypub-http-unicast.ts
+++ b/server/lib/job-queue/handlers/activitypub-http-unicast.ts
@@ -12,7 +12,7 @@ async function processActivityPubHttpUnicast (job: Job) {
   const uri = payload.uri
 
   const body = await computeBody(payload)
-  const httpSignatureOptions = await buildSignedRequestOptions(payload)
+  const httpSignatureOptions = await buildSignedRequestOptions({ signatureActorId: payload.signatureActorId, hasPayload: true })
 
   const options = {
     method: 'POST' as 'POST',

--- a/server/tests/api/activitypub/security.ts
+++ b/server/tests/api/activitypub/security.ts
@@ -58,7 +58,7 @@ async function makeFollowRequest (to: { url: string }, by: { url: string, privat
     authorizationHeaderName: HTTP_SIGNATURE.HEADER_NAME,
     keyId: by.url,
     key: by.privateKey,
-    headers: HTTP_SIGNATURE.HEADERS_TO_SIGN
+    headers: HTTP_SIGNATURE.HEADERS_TO_SIGN_WITH_PAYLOAD
   }
   const headers = {
     'digest': buildDigest(body),
@@ -82,7 +82,7 @@ describe('Test ActivityPub security', function () {
     authorizationHeaderName: HTTP_SIGNATURE.HEADER_NAME,
     keyId: 'acct:peertube@' + servers[1].host,
     key: keys.privateKey,
-    headers: HTTP_SIGNATURE.HEADERS_TO_SIGN
+    headers: HTTP_SIGNATURE.HEADERS_TO_SIGN_WITH_PAYLOAD
   })
 
   // ---------------------------------------------------------------

--- a/support/docker/production/config/custom-environment-variables.yaml
+++ b/support/docker/production/config/custom-environment-variables.yaml
@@ -12,6 +12,11 @@ webserver:
     __name: "PEERTUBE_WEBSERVER_HTTPS"
     __format: "json"
 
+federation:
+  sign_federated_fetches:
+    __name: "PEERTUBE_SIGN_FEDERATED_FETCHES"
+    __format: "json"
+
 secrets:
   peertube: "PEERTUBE_SECRET"
 


### PR DESCRIPTION
## Description

Add a minimal set of changes to have remote comments, follows, and likes working with a mastodon instance with AUTHORIZED_FETCH enabled, guarded by a config flag.

Considering this a draft due to missing test coverage and only light manual testing, but uploading in case somebody is in a hurry to try to apply this to their setup. It is also possible that some federated functionality I have not considered is still failing.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/4226

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] partially, by the existing test suite and a manual deployment 
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

The existing suite passed for me with flag enabled in test config (and caught an initial mistake, so some of the affected paths are exercised). I've also deployed it in a docker container built on top of v5.2.0 and it seems to pass initial manual testing i.e. comments, likes, and follow requests work with a secure fetch mastodon instance. I am not sure what tests to update/create (also I don't have Node experience), so the functionality is put behind a config flag. Marking this as need help in case contributing required testing coverage turns out to be easy for me to follow up on.
