### PR TITLE
Switch from debian bullseye to bookworm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,8 @@ jobs:
           # FIXME: https://github.com/actions/checkout/issues/290
           git fetch --force --tags
 
-          one="{ \"file\": \"./support/docker/production/Dockerfile.bullseye\", \"ref\": \"develop\", \"tags\": \"chocobozzz/peertube:develop-bullseye\" }"
-          two="{ \"file\": \"./support/docker/production/Dockerfile.bullseye\", \"ref\": \"master\", \"tags\": \"chocobozzz/peertube:production-bullseye,chocobozzz/peertube:$(git describe --abbrev=0)-bullseye\" }"
+          one="{ \"file\": \"./support/docker/production/Dockerfile.bookworm\", \"ref\": \"develop\", \"tags\": \"chocobozzz/peertube:develop-bookworm\" }"
+          two="{ \"file\": \"./support/docker/production/Dockerfile.bookworm\", \"ref\": \"master\", \"tags\": \"chocobozzz/peertube:production-bookworm,chocobozzz/peertube:$(git describe --abbrev=0)-bookworm\" }"
           three="{ \"file\": \"./support/docker/production/Dockerfile.nginx\", \"ref\": \"master\", \"tags\": \"chocobozzz/peertube-webserver:latest\" }"
 
           matrix="[$one,$two,$three]"

--- a/support/doc/docker.md
+++ b/support/doc/docker.md
@@ -165,7 +165,7 @@ docker compose up -d
 ```shell
 git clone https://github.com/chocobozzz/PeerTube /tmp/peertube
 cd /tmp/peertube
-docker build . -f ./support/docker/production/Dockerfile.bullseye
+docker build . -f ./support/docker/production/Dockerfile.bookworm
 ```
 
 ### Development

--- a/support/docker/production/Dockerfile.bookworm
+++ b/support/docker/production/Dockerfile.bookworm
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim
+FROM node:16-bookworm-slim
 
 # Install dependencies
 RUN apt update \

--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -44,8 +44,8 @@ services:
     # If you don't want to use the official image and build one from sources:
     # build:
     #   context: .
-    #   dockerfile: ./support/docker/production/Dockerfile.bullseye
-    image: chocobozzz/peertube:production-bullseye
+    #   dockerfile: ./support/docker/production/Dockerfile.bookworm
+    image: chocobozzz/peertube:production-bookworm
     # Use a static IP for this container because nginx does not handle proxy host change without reload
     # This container could be restarted on crash or until the postgresql database is ready for connection
     networks:


### PR DESCRIPTION
## Description

Switch docker base from bullseye to bookworm

## Related issues

My motivation was to get ffmpeg >= 5.1 which is available in bookworm while bullseye still has 4.3.x

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
