### PR TITLE
fix: use full width of page for player

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.scss
+++ b/client/src/app/+videos/+video-watch/video-watch.component.scss
@@ -67,7 +67,6 @@ $video-height: 66vh;
 
   ::ng-deep .video-js {
     width: 100%;
-    max-width: getPlayerWidth($video-height);
     height: $video-height;
 
     // VideoJS create an inner video player


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

Could we consider dropping the `max-width` on the player? This impedes on videos that have an aspect ratio higher than 1.78 (16:9). For example, 21:9 content gets black bars on both the top and bottom.

PeerTube performs very well with a variety of content as different aspect ratios. The primary side effect of this change is that it allows the player's controls to span the full width, but this is more inline with what other sites do anyway.

Observe 21:9 content on other sites:

### YouTube

![](https://github.com/Chocobozzz/PeerTube/assets/22801583/9920813a-85d2-429a-abf8-757a0ec86a7f)
> A 21:9 video on YouTube in theatre mode. There is only a single set of black bars, and the player controls span the full width of the player.

### Invidious

![](https://github.com/Chocobozzz/PeerTube/assets/22801583/8ef1ecaf-44bd-46af-a06a-c2042782e391)
> The same 21:9 video on Invidious. Similar results to above.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

* Closes https://github.com/Chocobozzz/PeerTube/issues/5915

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

### Before

![](https://github.com/Chocobozzz/PeerTube/assets/22801583/f6a986ef-49d6-4fd6-8e52-8a797ef5c8f7)

### After

![](https://github.com/Chocobozzz/PeerTube/assets/22801583/69aa596c-e347-4a22-aa3e-5bbc41588d28)
> Observe that the content is wider, and the player controls fill the player width. This is inline with what other sites do, like YouTube and Invidious. (Demos included in the original issue.)

I can only confirm that I and one other PeerTube user prefer the change. However, it may warrant broader discussion or the input of a designer. If you dislike this, please let me know and I'd be happy to ask one to take a look.