### PR TITLE
Fix path to Peertube installation in upgrade.sh

### DIFF
--- a/server/scripts/upgrade.sh
+++ b/server/scripts/upgrade.sh
@@ -91,10 +91,10 @@ echo "=========================================================="
 echo ""
 
 if [ -x "$(command -v git)" ]; then
-  cd /var/www/peertube
+  cd $PEERTUBE_PATH
 
   git merge-file -p config/production.yaml "$LATEST_VERSION_DIRECTORY/config/production.yaml.example" "peertube-latest/config/production.yaml.example" | tee "config/production.yaml.new" > /dev/null
-  echo "/var/www/peertube/config/production.yaml.new generated"
+  echo "$PEERTUBE_PATH/config/production.yaml.new generated"
   echo "You can review it and replace your existing production.yaml configuration"
 else
   echo "git command not found: unable to generate config/production.yaml.new configuration file based on your existing production.yaml configuration"


### PR DESCRIPTION
## Description

During latest upgrade to 5.2.1, I had a message about /var/www/peertube not existing which is normal, because I'm using a different directory for Peertube.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

