### PR TITLE
Add Valencian option for video/captions languages

### DIFF
--- a/server/server/initializers/constants.ts
+++ b/server/server/initializers/constants.ts
@@ -1401,6 +1401,9 @@ async function buildLanguages () {
   languages['zh-Hans'] = 'Simplified Chinese'
   languages['zh-Hant'] = 'Traditional Chinese'
 
+  // Catalan languages
+  languages['ca-valencia'] = 'Valencian'
+
   return languages
 }
 


### PR DESCRIPTION
## Description

Add Valencian option for video/captions languages

<!-- Please include a summary of the change, with motivation and context -->

In KDE community, we started to create subtitles for our videos and upload them automatically to our instance (https://invent.kde.org/websites/video-subtitles). In our community, we have both Brazilian Portuguese translators and Valencian translators.
Brazilian translation is being dealt with in https://github.com/Chocobozzz/PeerTube/pull/5971, but it would be great to also add Valencian.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
