### PR TITLE
Bump object storage dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "swagger-cli": "swagger-cli"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.190.0",
-    "@aws-sdk/lib-storage": "^3.190.0",
+    "@aws-sdk/client-s3": "^3.414.0",
+    "@aws-sdk/lib-storage": "^3.414.0",
     "@aws-sdk/s3-request-presigner": "^3.345.0",
     "@babel/parser": "^7.17.8",
     "@commander-js/extra-typings": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,7 +136,7 @@
     "@aws-sdk/util-utf8-browser" "^3.0.0"
     tslib "^1.11.1"
 
-"@aws-sdk/client-s3@^3.190.0":
+"@aws-sdk/client-s3@^3.414.0":
   version "3.427.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.427.0.tgz#ae99d9e780d7d30e17247e78b18afcd32af3cdca"
   integrity sha512-YKjJ9zgn0oE393HURKgvjNoX6lxUjb+dkTBE1GymFnGCPl6VxQbKXajXWNqUyN+oPPlZ2osEiljPaN0RserUjA==
@@ -358,7 +358,7 @@
     "@smithy/types" "^2.3.4"
     tslib "^2.5.0"
 
-"@aws-sdk/lib-storage@^3.190.0":
+"@aws-sdk/lib-storage@^3.414.0":
   version "3.427.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.427.0.tgz#ad7f5d0e7639b98d959363b2a99baf4a66d9b8c0"
   integrity sha512-JE26Zo4SMMY2SGlD/FilF5MpLuP8D2IrW+ye/J77dwh91gyGnNa/lubJ7WbVjIAxgeaDHsAkcpNO4VR5k6JCKg==


### PR DESCRIPTION
## Description

This PR bumps object storage dependencies. I had sporadic problems moving data to object storage using MinIO as backend. Bumping the dependencies seem to fix the issue. This runs in my instance for some weeks now without any problems.

## Related issues

See https://framacolibri.org/t/move-to-object-storage-failed-script-not-working/18702/2 for more details.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
