### PR TITLE
Inform the user to remove assets:/app/client/dist if not using the webserver container

### DIFF
--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -58,6 +58,7 @@ services:
      - "1935:1935" # Comment if you don't want to use the live feature
     #  - "9000:9000" # Uncomment if you use another webserver/proxy or test PeerTube in local, otherwise not suitable for production
     volumes:
+      # Remove the following line if you want to use another webserver/proxy or test PeerTube in local
       - assets:/app/client/dist
       - ./docker-volume/data:/data
       - ./docker-volume/config:/config


### PR DESCRIPTION
## Description

Inform the user to remove `assets:/app/client/dist` from the `peertube` container if not using the `webserver` container. 

## Related issues

This should fix #4891

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
