### PR TITLE
Update video-watch.component.html

### DIFF
--- a/client/src/app/+videos/+video-watch/video-watch.component.html
+++ b/client/src/app/+videos/+video-watch/video-watch.component.html
@@ -2,9 +2,9 @@
   <!-- We need the video container for videojs so we just hide it -->
   <div id="video-wrapper">
     <div *ngIf="remoteServerDown" class="remote-server-down">
-      Sorry, but this video is not available because the remote instance is not responding.
+      Sorry, but this video did not load because the remote instance did not respond.
       <br />
-      Please try again later.
+      Please try refreshing the page, or try again later.
     </div>
 
     <div id="videojs-wrapper">


### PR DESCRIPTION
Tweaked error message so that users realise that refreshing the page may help the video to load properly.

## Description

If an instance doesn't immediately respond, refreshing the page often allows the video to play properly. This tweak to the error message lets the user know about this option, so that they can watch the video straight away instead of coming back later.

## Related issues


## Has this been tested?


- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots
