### PR TITLE
Fix upgrade.sh when Peertube is installed outside the standard path

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4,4 +4,4 @@ set -eu
 
 # Backward path compatibility now upgrade.sh is in dist/scripts since v6
 
-/bin/sh ../dist/scripts/upgrade.sh
+/bin/sh ../dist/scripts/upgrade.sh $1


### PR DESCRIPTION
fixes #6063