### PR TITLE
Support alternative web videos CDN base url

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -227,6 +227,9 @@ object_storage:
     prefix: ''
     base_url: ''
 
+cdn:
+  web_videos_base_url: ''
+
 log:
   level: 'info' # 'debug' | 'info' | 'warn' | 'error'
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -225,6 +225,9 @@ object_storage:
     prefix: ''
     base_url: ''
 
+cdn:
+  web_videos_base_url: '' # Example: 'https://mirror.example.com'
+
 log:
   level: 'info' # 'debug' | 'info' | 'warn' | 'error'
 

--- a/server/core/initializers/checker-before-init.ts
+++ b/server/core/initializers/checker-before-init.ts
@@ -65,6 +65,7 @@ function checkMissedConfig () {
     'object_storage.credentials.secret_access_key', 'object_storage.max_upload_part', 'object_storage.streaming_playlists.bucket_name',
     'object_storage.streaming_playlists.prefix', 'object_storage.streaming_playlists.base_url', 'object_storage.web_videos.bucket_name',
     'object_storage.web_videos.prefix', 'object_storage.web_videos.base_url',
+    'cdn.web_videos_base_url',
     'theme.default',
     'feeds.videos.count', 'feeds.comments.count',
     'geo_ip.enabled', 'geo_ip.country.database_url',

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -155,6 +155,9 @@ const CONFIG = {
       BASE_URL: config.get<string>('object_storage.streaming_playlists.base_url')
     }
   },
+  CDN: {
+    WEB_VIDEOS_BASE_URL: config.get<string>('cdn.web_videos_base_url')
+  },
   WEBSERVER: {
     SCHEME: config.get<boolean>('webserver.https') === true ? 'https' : 'http',
     WS: config.get<boolean>('webserver.https') === true ? 'wss' : 'ws',

--- a/server/core/models/video/video-file.ts
+++ b/server/core/models/video/video-file.ts
@@ -540,6 +540,8 @@ export class VideoFileModel extends Model<Partial<AttributesOnly<VideoFileModel>
     if (video.isOwned()) {
       if (this.storage === VideoStorage.OBJECT_STORAGE) {
         return this.getObjectStorageUrl(video)
+      } else if (CONFIG.CDN.WEB_VIDEOS_BASE_URL) {
+        return CONFIG.CDN.WEB_VIDEOS_BASE_URL + this.getFileStaticPath(video)
       }
 
       return WEBSERVER.URL + this.getFileStaticPath(video)
@@ -579,7 +581,12 @@ export class VideoFileModel extends Model<Partial<AttributesOnly<VideoFileModel>
       ? join(STATIC_DOWNLOAD_PATHS.HLS_VIDEOS, `${video.uuid}-${this.resolution}-fragmented${this.extname}`)
       : join(STATIC_DOWNLOAD_PATHS.VIDEOS, `${video.uuid}-${this.resolution}${this.extname}`)
 
-    if (video.isOwned()) return WEBSERVER.URL + path
+    if (video.isOwned()) {
+      if (CONFIG.CDN.WEB_VIDEOS_BASE_URL) {
+        return CONFIG.CDN.WEB_VIDEOS_BASE_URL + path
+      }
+      return WEBSERVER.URL + path
+    }
 
     // FIXME: don't guess remote URL
     return buildRemoteVideoBaseUrl(video, path)

--- a/server/core/models/video/video-streaming-playlist.ts
+++ b/server/core/models/video/video-streaming-playlist.ts
@@ -256,6 +256,8 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
     if (video.isOwned()) {
       if (this.storage === VideoStorage.OBJECT_STORAGE) {
         return this.getMasterPlaylistObjectStorageUrl(video)
+      } else if (CONFIG.CDN.WEB_VIDEOS_BASE_URL) {
+        return CONFIG.CDN.WEB_VIDEOS_BASE_URL + this.getMasterPlaylistStaticPath(video)
       }
 
       return WEBSERVER.URL + this.getMasterPlaylistStaticPath(video)
@@ -278,6 +280,8 @@ export class VideoStreamingPlaylistModel extends Model<Partial<AttributesOnly<Vi
     if (video.isOwned()) {
       if (this.storage === VideoStorage.OBJECT_STORAGE) {
         return this.getSha256SegmentsObjectStorageUrl(video)
+      } else if (CONFIG.CDN.WEB_VIDEOS_BASE_URL) {
+        return CONFIG.CDN.WEB_VIDEOS_BASE_URL + this.getSha256SegmentsStaticPath(video)
       }
 
       return WEBSERVER.URL + this.getSha256SegmentsStaticPath(video)


### PR DESCRIPTION
## Description
This patch introduces the ability to specify an alternate base URL for web video storage in "local", similar to the existing functionality for object storage base URLs. This allows high traffic videos to be distributed across multiple servers or CDNs, reducing the load/cost on the main site/CDN. This is also useful if your video storage and Peertube services are hosted on separate servers.

However, it's important to note one significant limitation: **private and password-protected videos will not have secure protection**. This is because the external server acts purely as a file host without any authentication mechanisms. Thus, anyone with knowledge of the URL can access these videos.

While I'm aware of these drawbacks and doubt the likelihood of this patch being merged, I'm sharing it here for those who may find it useful for their specific needs.

I used this in my peertube and [here](https://v.rincat.ch/w/8tNUvQATwvcSmstPRWdzQg) is a demo if anyone want to check.

## Related issues
https://github.com/Chocobozzz/PeerTube/issues/5460

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
