### PR TITLE
transcoding.web_videos reference and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ We have many important notes in this release. We know it's a pain for sysadmin, 
     * Directory on filesystem must be **renamed** from `videos/` to `web-videos/` to represent the value of `storage.web_videos`
       * Classic installation: `sudo -u peertube mv '/var/www/peertube/storage/videos/' '/var/www/peertube/storage/web-videos/'`
       * Docker installation: `mv '/path-to-docker-installation/docker-volume/data/videos/' '/path-to-docker-installation/docker-volume/data/web-videos/'`
-    * `transcoding.webtorrent` must be **renamed** to `transcoding.web_videos`: https://github.com/Chocobozzz/PeerTube/blob/develop/config/production.yaml.example#L522
+    * `transcoding.webtorrent` must be **renamed** to `transcoding.web_videos`: https://github.com/Chocobozzz/PeerTube/blob/develop/config/production.yaml.example#L532
     * `object_storage.videos` must be **renamed** to `object_storage.web_videos`. The value of `object_storage.web_videos.bucket_name` doesn't need to be changed: https://github.com/Chocobozzz/PeerTube/blob/develop/config/production.yaml.example#L223
     * `storage.storyboards` must be **added**: https://github.com/Chocobozzz/PeerTube/blob/develop/config/production.yaml.example#L157
 
@@ -61,7 +61,7 @@ We have many important notes in this release. We know it's a pain for sysadmin, 
     * `location ~ ^(/static/(webseed|streaming-playlists)/private/)|^/download {` must be updated to `location ~ ^(/static/(webseed|web-videos|streaming-playlists)/private/)|^/download {`
     * `location ~ ^/static/(webseed|redundancy|streaming-playlists)/ {` must be updated to `location ~ ^/static/(webseed|web-videos|redundancy|streaming-playlists)/ {`
 
-  * Tracing requires `--experimental-loader=@opentelemetry/instrumentation/hook.mjs` node option: https://github.com/Chocobozzz/PeerTube/blob/develop/config/production.yaml.example#L263
+  * Tracing requires `--experimental-loader=@opentelemetry/instrumentation/hook.mjs` node option: https://github.com/Chocobozzz/PeerTube/blob/develop/config/production.yaml.example#L264
 
 #### Developers important notes
 

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -9766,10 +9766,10 @@ components:
           description: P2P peers connected (doesn't include WebSeed peers)
         resolutionChanges:
           type: number
-          description: How many resolution changes occured since the last metric creation
+          description: How many resolution changes occurred since the last metric creation
         errors:
           type: number
-          description: How many errors occured since the last metric creation
+          description: How many errors occurred since the last metric creation
         downloadedBytesP2P:
           type: number
           description: How many bytes were downloaded with P2P since the last metric creation

--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -870,7 +870,7 @@ function register ({ registerClientRoute }) {
 }
 ```
 
-You can then access the page on `/p/my-super/route` (please note the additionnal `/p/` in the path).
+You can then access the page on `/p/my-super/route` (please note the additional `/p/` in the path).
 
 ### Publishing
 

--- a/support/doc/tools.md
+++ b/support/doc/tools.md
@@ -185,7 +185,7 @@ peertube-runner list-registered
 
 ## Server tools
 
-Server tools are scripts that interect directly with the code of your PeerTube instance.
+Server tools are scripts that interact directly with the code of your PeerTube instance.
 They must be run on the server, in `peertube-latest` directory.
 
 ### Parse logs


### PR DESCRIPTION
## Description

Reference to `transcoding.web_videos` in `productinonal.yaml` was wrong for update to v.6.0. Corrected it.
 - Was refering to `1080p: false` instead of `web_videos:`

Also corrected some minor typos in the docs and api.


