### PR TITLE
doc: add default values in iFrame api doc

### DIFF
--- a/support/doc/api/embeds.md
+++ b/support/doc/api/embeds.md
@@ -170,7 +170,7 @@ Default: `p2p-media-loader` and fallback to `web-video` mode.
 
 ### api
 
-Enable embed JavaScript API (see methods below).
+Enable/Disable embed JavaScript API (see methods below).
 
 Value must be `0` or `1`.
 

--- a/support/doc/api/embeds.md
+++ b/support/doc/api/embeds.md
@@ -93,7 +93,7 @@ Default: `1`
 Mute the video by default.
 
 Value must be `0` or `1`.
-Default: `0`
+Default: tries to restore the last muted setting set by the user
 
 ### loop
 
@@ -107,7 +107,7 @@ Default: `0`
 Auto select a subtitle by default.
 
 Value must be a valid subtitle ISO code (`fr`, `en`, etc.).
-Default: no subtitle selected
+Default: no subtitle selected and then tries to restore the last subtitle set by the user
 
 ### autoplay
 
@@ -141,7 +141,7 @@ Default: `1`
 Enable/Disable P2P.
 
 Value must be `0` or `1`.
-Default: `1`
+Default: tries to use the user setting and fallbacks to instance setting if user setting is not found
 
 ### bigPlayBackgroundColor
 

--- a/support/doc/api/embeds.md
+++ b/support/doc/api/embeds.md
@@ -138,7 +138,7 @@ Default: `1`
 
 ### p2p
 
-Enable P2P.
+Enable/Disable P2P.
 
 Value must be `0` or `1`.
 Default: `1`

--- a/support/doc/api/embeds.md
+++ b/support/doc/api/embeds.md
@@ -124,14 +124,14 @@ Default: `1`
 
 ### title
 
-Show embed title.
+Show/Hide embed title.
 
 Value must be `0` or `1`.
 Default: `1`
 
 ### warningTitle
 
-Show P2P warning title.
+Show/Hide P2P warning title.
 
 Value must be `0` or `1`.
 Default: `1`
@@ -145,10 +145,10 @@ Default: `1`
 
 ### bigPlayBackgroundColor
 
-Customize settings menu background color.
+Customize big play button background color.
 
 Value must be a valid color (`red` or `rgba(100, 100, 100, 0.5)`).
-Default: ???
+Default: rgba(0, 0, 0, 0.8)
 
 ### foregroundColor
 
@@ -156,7 +156,7 @@ Customize embed font color.
 
 Value must be a valid color (`red` or `rgba(100, 100, 100, 0.5)`).
 
-Default: 'white'
+Default: `white`
 
 ### mode
 
@@ -164,7 +164,9 @@ Force a specific player engine.
 
 Value must be a valid mode (`web-video` or `p2p-media-loader`).
 
-Default: FIXME
+See behaviour description [here](https://docs.joinpeertube.org/admin/configuration#vod-transcoding)
+
+Default: `p2p-media-loader` and fallback to `web-video` mode.
 
 ### api
 
@@ -172,7 +174,7 @@ Enable embed JavaScript API (see methods below).
 
 Value must be `0` or `1`.
 
-Default: FIXME
+Default: `0`
 
 ### waitPasswordFromEmbedAPI
 
@@ -182,7 +184,10 @@ If the video requires a password, PeerTube will wait a password provided by `set
 
 Until you provide a password, `player.ready` is not resolved.
 
-Default: deactivated
+Value must be `0` or `1`.
+
+Default: `0`
+
 
 ## Embed attributes
 

--- a/support/doc/api/embeds.md
+++ b/support/doc/api/embeds.md
@@ -58,11 +58,13 @@ For example `https://my-instance.example.com/videos/embed/52a10666-3a18-4e73-93d
 
 Start the video at a specific time.
 Value must be raw seconds or a duration (`3m4s`)
+Default: starts at `0`
 
 ### stop
 
 Stop the video at a specific time.
 Value must be raw seconds or a duration (`54s`)
+Default: ends at content end
 
 ### controls
 
@@ -70,36 +72,42 @@ Mimics video HTML element `controls` attribute, meaning that all controls (inclu
 It can be useful if you want to have a full control of the PeerTube player.
 
 Value must be `0` or `1`.
+Default: `1`
 
 ### controlBar
 
 Hide control bar when the video is played.
 
 Value must be `0` or `1`.
+Default: `1`
 
 ### peertubeLink
 
 Hide PeerTube instance link in control bar.
 
 Value must be `0` or `1`.
+Default: `1`
 
 ### muted
 
 Mute the video by default.
 
 Value must be `0` or `1`.
+Default: `0`
 
 ### loop
 
 Automatically start again the video when it ends.
 
 Value must be `0` or `1`.
+Default: `0`
 
 ### subtitle
 
 Auto select a subtitle by default.
 
 Value must be a valid subtitle ISO code (`fr`, `en`, etc.).
+Default: no subtitle selected
 
 ### autoplay
 
@@ -107,34 +115,40 @@ Try to automatically play the video.
 Most web browsers disable video autoplay if the user did not interact with the video. You can try to bypass this limitation by muting the video
 
 Value must be `0` or `1`.
+Default: `0`
 
 ### playbackRate
 
 Force the default playback rate (`0.75`, `1.5` etc).
+Default: `1`
 
 ### title
 
-Hide embed title.
+Show embed title.
 
 Value must be `0` or `1`.
+Default: `1`
 
 ### warningTitle
 
-Hide P2P warning title.
+Show P2P warning title.
 
 Value must be `0` or `1`.
+Default: `1`
 
 ### p2p
 
-Disable P2P.
+Enable P2P.
 
 Value must be `0` or `1`.
+Default: `1`
 
 ### bigPlayBackgroundColor
 
-Customize big play button background color.
+Customize settings menu background color.
 
 Value must be a valid color (`red` or `rgba(100, 100, 100, 0.5)`).
+Default: ???
 
 ### foregroundColor
 
@@ -142,17 +156,23 @@ Customize embed font color.
 
 Value must be a valid color (`red` or `rgba(100, 100, 100, 0.5)`).
 
+Default: 'white'
+
 ### mode
 
 Force a specific player engine.
 
 Value must be a valid mode (`web-video` or `p2p-media-loader`).
 
+Default: FIXME
+
 ### api
 
 Enable embed JavaScript API (see methods below).
 
 Value must be `0` or `1`.
+
+Default: FIXME
 
 ### waitPasswordFromEmbedAPI
 
@@ -162,6 +182,7 @@ If the video requires a password, PeerTube will wait a password provided by `set
 
 Until you provide a password, `player.ready` is not resolved.
 
+Default: deactivated
 
 ## Embed attributes
 


### PR DESCRIPTION
## Description

Add default values for all fields in iFrame API documentation.
Also fix description regarding to real usage

Note: This is a draft PR, please give me feedbacks and I will fix it.
See FIXME in the PR please

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help 
