### PR TITLE
Video list filters labelling, button and sort select UI improvements

### DIFF
--- a/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
+++ b/client/src/app/shared/shared-video-miniature/video-filters-header.component.html
@@ -1,10 +1,10 @@
 <ng-template #updateSettings let-fragment>
   <div class="label-description muted" i18n>
-    Update
+    Updates
     <a routerLink="/my-account/settings" [fragment]="fragment">
       <button class="button-unstyle" (click)="onAccountSettingsClick($event)">your settings</button>
-    </a
-  ></div>
+    </a>
+  </div>
 </ng-template>
 
 
@@ -28,7 +28,7 @@
         class="active-filter pastille button-unstyle" [ngClass]="{ 'can-remove': activeFilter.canRemove }" [title]="getFilterTitle(activeFilter.canRemove)"
       >
         <span>
-          {{ activeFilter.label }}
+          <span class="muted">{{ activeFilter.label }}</span>
 
           <ng-container *ngIf="activeFilter.value">: {{ activeFilter.value }}</ng-container>
         </span>
@@ -42,16 +42,22 @@
       formControlName="sort"
       [clearable]="false"
       [searchable]="false"
-      [bindValue]="null"
+      [items]="getSortOptions()"
+      bindLabel="label"
+      bindValue="value"
+      groupBy="group"
     >
-      <ng-option i18n value="-publishedAt">Sort by <strong>"Recently Added"</strong></ng-option>
-      <ng-option i18n value="-originallyPublishedAt">Sort by <strong>"Original Publication Date"</strong></ng-option>
-
-      <ng-option i18n value="name">Sort by <strong>"Name"</strong></ng-option>
-      <ng-option i18n *ngIf="isTrendingSortEnabled('most-viewed')" value="-trending">Sort by <strong>"Recent Views"</strong></ng-option>
-      <ng-option i18n *ngIf="isTrendingSortEnabled('hot')" value="-hot">Sort by <strong>"Hot"</strong></ng-option>
-      <ng-option i18n *ngIf="isTrendingSortEnabled('most-liked')" value="-likes">Sort by <strong>"Likes"</strong></ng-option>
-      <ng-option i18n value="-views">Sort by <strong>"Global Views"</strong></ng-option>
+      <ng-template ng-optgroup-tmp let-item="item" i18n>
+        {{ "Sort by " + item.group || 'Unnamed group'}}
+      </ng-template>
+      <ng-template ng-label-tmp let-item="item" i18n>
+        Sort by <strong>"{{item.label}}"</strong>
+      </ng-template>
+      <ng-template ng-option-tmp let-item="item" i18n>
+        Sort by <strong>"{{item.label}}"</strong>
+        <br/>
+        <span class="muted">{{item.description}}</span>
+      </ng-template>
     </ng-select>
 
   </div>
@@ -83,12 +89,24 @@
       <div class="form-group" *ngIf="!hideScope" role="radiogroup">
         <label for="scope" i18n>Scope:</label>
 
-        <div class="peertube-radio-container">
+        <my-peertube-checkbox i18n-labelText labelText="Local" [disabled]="true" [checked]="true">
+          <ng-container ngProjectAs="description">
+            <span i18n>Videos from this instance.</span>
+          </ng-container>
+        </my-peertube-checkbox>
+
+        <my-peertube-checkbox inputName="scopeFederatedToggle" formControlName="scopeToggle" i18n-labelText labelText="Federated">
+          <ng-container ngProjectAs="description">
+            <span i18n>Videos from servers followed by this instance.</span>
+          </ng-container>
+        </my-peertube-checkbox>
+
+        <div class="peertube-radio-container" [hidden]="true">
           <input formControlName="scope" type="radio" name="scope" id="scopeLocal" value="local" />
           <label for="scopeLocal" i18n>Local videos (this instance)</label>
         </div>
 
-        <div class="peertube-radio-container">
+        <div class="peertube-radio-container" [hidden]="true">
           <input formControlName="scope" type="radio" name="scope" id="scopeFederated" value="federated" />
           <label for="scopeFederated" i18n>Federated videos (this instance + followed instances)</label>
         </div>
@@ -122,11 +140,11 @@
       <div class="form-group" *ngIf="canSeeAllVideos()">
         <label for="allVideos" i18n>Moderation:</label>
 
-        <my-peertube-checkbox
-          formControlName="allVideos"
-          inputName="allVideos"
-          i18n-labelText labelText="Display all videos (private, unlisted, password protected or not yet published)"
-        ></my-peertube-checkbox>
+        <my-peertube-checkbox formControlName="allVideos" inputName="allVideos" i18n-labelText labelText="Display all videos">
+          <ng-container ngProjectAs="description">
+            <span i18n>Even private, unlisted, password protected or not yet published.</span>
+          </ng-container>
+        </my-peertube-checkbox>
       </div>
     </div>
   </div>

--- a/client/src/app/shared/shared-video-miniature/video-filters-header.component.scss
+++ b/client/src/app/shared/shared-video-miniature/video-filters-header.component.scss
@@ -1,6 +1,19 @@
 @use '_variables' as *;
 @use '_mixins' as *;
 
+@mixin pastille {
+  @include margin-right(15px);
+
+  border-radius: 24px;
+  padding: 4px 15px;
+  margin-bottom: 15px;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: pvar(--mainColor) auto 1px;
+  }
+}
+
 .root {
   margin-bottom: 45px;
 }
@@ -44,20 +57,12 @@
 }
 
 .pastille {
-  @include margin-right(15px);
-
-  border-radius: 24px;
-  padding: 4px 15px;
-  margin-bottom: 15px;
-  cursor: pointer;
-
-  &:focus-visible {
-    outline: pvar(--mainColor) auto 1px;
-  }
+  @include pastille();
 }
 
 .filters-toggle {
-  border: 2px solid pvar(--mainForegroundColor);
+  border: 1px solid;
+  border-color: #adadad #C6C6C6 lightgray;
 
   my-global-icon {
     @include margin-left(5px);
@@ -109,7 +114,9 @@
 
   ::ng-deep {
     .ng-select-container {
-      height: 33px !important;
+      @include pastille();
+      height: 37px !important;
+      margin-bottom: 0 !important;
     }
 
     .ng-value strong {

--- a/client/src/app/shared/shared-video-miniature/video-filters.model.ts
+++ b/client/src/app/shared/shared-video-miniature/video-filters.model.ts
@@ -30,6 +30,9 @@ export class VideoFilters {
 
   search: string
 
+  availableLanguages: { id: string, label: string }[] = []
+  availableCategories: { id: string, label: string }[] = []
+
   private defaultValues = new Map<keyof VideoFilters, any>([
     [ 'sort', '-publishedAt' ],
     [ 'nsfw', 'false' ],
@@ -146,7 +149,9 @@ export class VideoFilters {
         key: 'languageOneOf',
         canRemove: true,
         label: $localize`Languages`,
-        value: this.languageOneOf.map(l => l.toUpperCase()).join(', ')
+        value: this.languageOneOf.map(
+          l => this.availableLanguages.find(lang => lang.id === l)?.label || l.toUpperCase()
+        ).join(', ')
       })
     }
 
@@ -155,7 +160,9 @@ export class VideoFilters {
         key: 'categoryOneOf',
         canRemove: true,
         label: $localize`Categories`,
-        value: this.categoryOneOf.join(', ')
+        value: this.categoryOneOf.map(
+          c => this.availableCategories.find(cat => cat.id === c + '')?.label || c
+        ).join(', ')
       })
     }
 
@@ -243,9 +250,9 @@ export class VideoFilters {
   }
 
   getNSFWDisplayLabel () {
-    if (this.defaultNSFWPolicy === 'blur') return $localize`Blurred`
+    if (this.defaultNSFWPolicy === 'blur') return $localize`Blur`
 
-    return $localize`Displayed`
+    return $localize`Display`
   }
 
   private getNSFWValue () {


### PR DESCRIPTION
## Description

Displays labels for languages and categories instead of the raw ids.
Changes radio buttons to checkboxes for scope selection.
Clearer sort selection with description and grouping by type of sort.
Rely on `peertube-checkbox` whenever possible for uniformity of style and conciseness.

This PR might be improved by applying the same treatement as scope radio buttons to the type of video (live/vod) radio buttons.

## Screenshots

![Capture d’écran 2023-12-21 à 15 04 46](https://github.com/Chocobozzz/PeerTube/assets/6329880/9e617991-329c-4e8c-8a2c-0491bdaee55f)
