### PR TITLE
Fix the escapeAttribute function using HTML entities instead of backslash escapes

### DIFF
--- a/packages/core-utils/src/renderer/html.ts
+++ b/packages/core-utils/src/renderer/html.ts
@@ -73,5 +73,5 @@ export function escapeHTML (stringParam: string) {
 export function escapeAttribute (value: string) {
   if (!value) return ''
 
-  return String(value).replace(/"/g, '\\"')
+  return String(value).replace(/"/g, '&quot;')
 }

--- a/packages/tests/src/client/og-twitter-tags.ts
+++ b/packages/tests/src/client/og-twitter-tags.ts
@@ -273,8 +273,8 @@ describe('Test Open Graph and Twitter cards HTML tags', function () {
       const res = await makeGetRequest({ url: servers[0].url, path: '/a/root', accept: 'text/html', expectedStatus: HttpStatusCode.OK_200 })
       const text = res.text
 
-      expect(text).to.contain(`<meta property="twitter:description" content="\\"super description\\"" />`)
-      expect(text).to.contain(`<meta property="og:description" content="\\"super description\\"" />`)
+      expect(text).to.contain(`<meta property="twitter:description" content="&quot;super description&quot;" />`)
+      expect(text).to.contain(`<meta property="og:description" content="&quot;super description&quot;" />`)
     })
   })
 


### PR DESCRIPTION
## Description

HTML attributes used for rendering embeds break if they contain double quote characters. The commit edc6952 attempts to address this issue using backslash escapes. However, this does not work because inserting backslash characters does not actually escape the problematic double quote character from the HTML value.

The current, resultant behavior is that the truncated description gets cut short early after the first backslash character, terminating where the double quote character would be.

![improperescape](https://github.com/Chocobozzz/PeerTube/assets/48048071/a5502398-0a07-43fe-96f2-a294c12af8f4)

The expected behavior is for the truncated description to render with the embed in its entirety.

![properescape](https://github.com/Chocobozzz/PeerTube/assets/48048071/3066d9b5-d80f-41fe-a05e-5ac3c873755b).

This would require for double quote characters to be replaced with the  `&quot;` HTML entity instead of being backslash-escaped, which is what this PR does.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/6205

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [X] 🙋 no, because I need help <!-- Detail how we can help you -->

Sorry, I'm not sure which box I should check here. I'm really new to GitHub and any kind of code dev in general if I'm being quite honest, and parts of the testing guide still go over my head.

I have tested this fix on my own personal PeerTube server. My fix can be confirmed by checking the [HTML meta tags for this video](https://peertube.doesstuff.social/w/xsUNWzuuDcTPy3hQBL5crK) and then posting that link somewhere that would generate an embed that contains the truncated description. The example I used in my screenshots is Discord.

A video on any other PeerTube server with a similar description to mine would have its embed's description terminate early at the first double quote character.
