### PR TITLE
fix(server/video-view): log invalid currentTime req

### DIFF
--- a/server/core/middlewares/error.ts
+++ b/server/core/middlewares/error.ts
@@ -1,11 +1,11 @@
+import { HttpStatusCode } from '@peertube/peertube-models'
+import { logger } from '@server/helpers/logger.js'
 import express from 'express'
 import { ProblemDocument, ProblemDocumentExtension } from 'http-problem-details'
-import { logger } from '@server/helpers/logger.js'
-import { HttpStatusCode } from '@peertube/peertube-models'
 
 function apiFailMiddleware (req: express.Request, res: express.Response, next: express.NextFunction) {
   res.fail = options => {
-    const { status = HttpStatusCode.BAD_REQUEST_400, message, title, type, data, instance, tags } = options
+    const { status = HttpStatusCode.BAD_REQUEST_400, message, title, type, data, instance, tags, logLevel = 'debug' } = options
 
     const extension = new ProblemDocumentExtension({
       ...data,
@@ -29,7 +29,7 @@ function apiFailMiddleware (req: express.Request, res: express.Response, next: e
         : undefined
     }, extension)
 
-    logger.debug('Bad HTTP request.', { json, tags })
+    logger.log(logLevel, 'Bad HTTP request.', { json, tags })
 
     res.status(status)
 

--- a/server/core/middlewares/validators/videos/video-view.ts
+++ b/server/core/middlewares/validators/videos/video-view.ts
@@ -6,6 +6,7 @@ import { getCachedVideoDuration } from '@server/lib/video.js'
 import { LocalVideoViewerModel } from '@server/models/view/local-video-viewer.js'
 import { isIdValid, toIntOrNull } from '../../../helpers/custom-validators/misc.js'
 import { areValidationErrors, doesVideoExist, isValidVideoIdParam } from '../shared/index.js'
+import { logger } from '@server/helpers/logger.js'
 
 const getVideoLocalViewerValidator = [
   param('localViewerId')
@@ -43,6 +44,8 @@ const videoViewValidator = [
     const { duration } = await getCachedVideoDuration(video.id)
 
     if (!isVideoTimeValid(req.body.currentTime, duration)) {
+      logger.warn('Current time is invalid', { duration, currentTime: req.body.currentTime, videoId: video.id })
+
       return res.fail({
         status: HttpStatusCode.BAD_REQUEST_400,
         message: 'Current time is invalid'

--- a/server/core/middlewares/validators/videos/video-view.ts
+++ b/server/core/middlewares/validators/videos/video-view.ts
@@ -1,12 +1,11 @@
-import express from 'express'
-import { body, param } from 'express-validator'
 import { HttpStatusCode } from '@peertube/peertube-models'
 import { isVideoTimeValid } from '@server/helpers/custom-validators/video-view.js'
 import { getCachedVideoDuration } from '@server/lib/video.js'
 import { LocalVideoViewerModel } from '@server/models/view/local-video-viewer.js'
+import express from 'express'
+import { body, param } from 'express-validator'
 import { isIdValid, toIntOrNull } from '../../../helpers/custom-validators/misc.js'
 import { areValidationErrors, doesVideoExist, isValidVideoIdParam } from '../shared/index.js'
-import { logger } from '@server/helpers/logger.js'
 
 const getVideoLocalViewerValidator = [
   param('localViewerId')
@@ -43,12 +42,12 @@ const videoViewValidator = [
     const video = res.locals.onlyImmutableVideo
     const { duration } = await getCachedVideoDuration(video.id)
 
-    if (!isVideoTimeValid(req.body.currentTime, duration)) {
-      logger.warn('Current time is invalid', { duration, currentTime: req.body.currentTime, videoId: video.id })
-
+    const currentTime = req.body.currentTime
+    if (!isVideoTimeValid(currentTime, duration)) {
       return res.fail({
         status: HttpStatusCode.BAD_REQUEST_400,
-        message: 'Current time is invalid'
+        message: `Current time ${currentTime} is invalid (video ${video.uuid} duration: ${duration})`,
+        logLevel: 'warn'
       })
     }
 
@@ -59,6 +58,6 @@ const videoViewValidator = [
 // ---------------------------------------------------------------------------
 
 export {
-  videoViewValidator,
-  getVideoLocalViewerValidator
+  getVideoLocalViewerValidator, videoViewValidator
 }
+

--- a/server/core/types/express.d.ts
+++ b/server/core/types/express.d.ts
@@ -1,4 +1,4 @@
-import { HttpMethodType, PeerTubeProblemDocumentData, VideoCreate } from '@peertube/peertube-models'
+import { HttpMethodType, PeerTubeProblemDocumentData, ServerLogLevel, VideoCreate } from '@peertube/peertube-models'
 import { RegisterServerAuthExternalOptions } from '@server/types/index.js'
 import {
   MAbuseMessage,
@@ -109,6 +109,7 @@ declare module 'express' {
 
       data?: PeerTubeProblemDocumentData
 
+      logLevel?: ServerLogLevel // Default debug
       tags?: string[]
     }) => void
 


### PR DESCRIPTION
## Description
Log a warning when a POST request is done to /api/v1/videos/{id}/views with an invalid currentTime.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
#6285

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
