### PR TITLE
feat(plugins): add filter:api.user.me.get.result

### DIFF
--- a/packages/models/src/plugins/server/server-hook.model.ts
+++ b/packages/models/src/plugins/server/server-hook.model.ts
@@ -137,7 +137,9 @@ export const serverFilterHookObject = {
   // Peertube >= 5.2
   'filter:feed.podcast.channel.create-custom-tags.result': true,
   // Peertube >= 5.2
-  'filter:feed.podcast.video.create-custom-tags.result': true
+  'filter:feed.podcast.video.create-custom-tags.result': true,
+  // Peertube >= 6.1
+  'filter:api.user.me.get.result': true
 }
 
 export type ServerFilterHookName = keyof typeof serverFilterHookObject

--- a/packages/tests/fixtures/peertube-plugin-test/main.js
+++ b/packages/tests/fixtures/peertube-plugin-test/main.js
@@ -104,6 +104,15 @@ async function register ({ registerHook, registerSetting, settingsManager, stora
   })
 
   registerHook({
+    target: 'filter:api.user.me.get.result',
+    handler: (result) => {
+      result.customParam = 'Customized'
+
+      return result
+    }
+  })
+
+  registerHook({
     target: 'filter:api.user.me.subscription-videos.list.params',
     handler: obj => addToCount(obj)
   })

--- a/packages/tests/src/plugins/filter-hooks.ts
+++ b/packages/tests/src/plugins/filter-hooks.ts
@@ -3,6 +3,7 @@
 import { expect } from 'chai'
 import {
   HttpStatusCode,
+  MyUser,
   PeerTubeProblemDocument,
   VideoDetails,
   VideoImportState,
@@ -466,6 +467,14 @@ describe('Test plugin filter hooks', function () {
       await waitJobs(servers)
 
       await checkIsBlacklisted(uuid, true)
+    })
+  })
+
+  describe('Users', function () {
+    it('Should run filter:api.user.me.get.result', async function () {
+      const user = await servers[0].users.getMyInfo() as MyUser & { customParam: string }
+
+      expect(user.customParam).to.equal('Customized')
     })
   })
 

--- a/server/core/controllers/api/users/me.ts
+++ b/server/core/controllers/api/users/me.ts
@@ -160,7 +160,13 @@ async function getUserInformation (req: express.Request, res: express.Response) 
   // We did not load channels in res.locals.user
   const user = await UserModel.loadForMeAPI(res.locals.oauth.token.user.id)
 
-  return res.json(user.toMeFormattedJSON())
+  const result = await Hooks.wrapObject(
+    user.toMeFormattedJSON(),
+    'filter:api.user.me.get.result',
+    { user }
+  )
+
+  return res.json(result)
 }
 
 async function getUserVideoQuotaUsed (req: express.Request, res: express.Response) {


### PR DESCRIPTION
## Description
Adds `filter:api.user.me.get.result` to let plugins modify the response of GET /api/v1/users/me

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
relates to #6219

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite

## Screenshots

<!-- delete if not relevant -->
