### PR TITLE
Missing video privacy value

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -7321,6 +7321,7 @@ components:
         - 2
         - 3
         - 4
+        - 5
       description: privacy id of the video (see [/videos/privacies](#operation/getVideoPrivacyPolicies))
     VideoPrivacyConstant:
       properties:


### PR DESCRIPTION
## Description

The VideoPrivacy value `5` was missing in the documentation: https://docs.joinpeertube.org/api-rest-reference.html#tag/Video/operation/getVideos

## Related issues

No issue created.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
