### PR TITLE
feat(plugins): add peertubeHelpers.loadWithFiles

### DIFF
--- a/packages/tests/fixtures/peertube-plugin-test-four/main.js
+++ b/packages/tests/fixtures/peertube-plugin-test-four/main.js
@@ -30,6 +30,13 @@ async function register ({
 
         if (videoFromDB1.uuid !== videoFromDB2.uuid || videoFromDB2.uuid !== videoFromDB3.uuid) return
 
+        const videoWithFiles = await peertubeHelpers.videos.loadByIdOrUUIDWithFiles(video.id)
+
+        if (videoWithFiles.getHLSPlaylist().getMasterPlaylistUrl(videoWithFiles) === null) {
+          logger.error('Video with files could not be loaded.')
+          return
+        }
+
         logger.info('video from DB uuid is %s.', videoFromDB1.uuid)
 
         await peertubeHelpers.videos.removeVideo(video.id)

--- a/server/core/lib/plugins/plugin-helpers-builder.ts
+++ b/server/core/lib/plugins/plugin-helpers-builder.ts
@@ -88,6 +88,10 @@ function buildVideosHelpers () {
       return VideoModel.load(id)
     },
 
+    loadByIdOrUUIDWithFiles: (id: number | string) => {
+      return VideoModel.loadWithFiles(id)
+    },
+
     removeVideo: (id: number) => {
       return sequelizeTypescript.transaction(async t => {
         const video = await VideoModel.loadFull(id, t)

--- a/server/core/types/plugins/register-server-option.model.ts
+++ b/server/core/types/plugins/register-server-option.model.ts
@@ -17,7 +17,7 @@ import {
   VideoBlacklistCreate
 } from '@peertube/peertube-models'
 import { ActorModel } from '@server/models/actor/actor.js'
-import { MUserDefault, MVideo, MVideoThumbnail, UserNotificationModelForApi } from '../models/index.js'
+import { MUserDefault, MVideo, MVideoThumbnail, MVideoWithAllFiles, UserNotificationModelForApi } from '../models/index.js'
 import {
   RegisterServerAuthExternalOptions,
   RegisterServerAuthExternalResult,
@@ -34,6 +34,7 @@ export type PeerTubeHelpers = {
 
   videos: {
     loadByUrl: (url: string) => Promise<MVideoThumbnail>
+    loadByIdOrUUIDWithFiles: (id: number | string) => Promise<MVideoWithAllFiles>
     loadByIdOrUUID: (id: number | string) => Promise<MVideoThumbnail>
 
     removeVideo: (videoId: number) => Promise<void>


### PR DESCRIPTION
## Description
Let plugin authors to load a video with all its files. This can be useful when a plugin want to switch video files based on the users capabilities.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
