### PR TITLE
feat(client/plugins): add getUser to helpers

### DIFF
--- a/client/src/app/core/plugins/plugin.service.ts
+++ b/client/src/app/core/plugins/plugin.service.ts
@@ -250,6 +250,10 @@ export class PluginService implements ClientHook {
         return firstValueFrom(obs)
       },
 
+      getUser: () => {
+        return this.authService.getUser()
+      },
+
       getServerConfig: () => {
         const obs = this.server.getConfig()
           .pipe(catchError(res => this.restExtractor.handleError(res)))

--- a/client/src/app/core/users/user.model.ts
+++ b/client/src/app/core/users/user.model.ts
@@ -74,54 +74,12 @@ export class User implements UserServerModel {
   createdAt: Date
 
   constructor (hash: Partial<UserServerModel>) {
-    this.id = hash.id
-    this.username = hash.username
-    this.email = hash.email
+    const { account, ...mergeProps }: Partial<UserServerModel> = hash
 
-    this.role = hash.role
+    Object.assign(this, mergeProps)
 
-    this.videoChannels = hash.videoChannels
-
-    this.videoQuota = hash.videoQuota
-    this.videoQuotaDaily = hash.videoQuotaDaily
-    this.videoQuotaUsed = hash.videoQuotaUsed
-    this.videoQuotaUsedDaily = hash.videoQuotaUsedDaily
-    this.videosCount = hash.videosCount
-    this.abusesCount = hash.abusesCount
-    this.abusesAcceptedCount = hash.abusesAcceptedCount
-    this.abusesCreatedCount = hash.abusesCreatedCount
-    this.videoCommentsCount = hash.videoCommentsCount
-
-    this.nsfwPolicy = hash.nsfwPolicy
-    this.p2pEnabled = hash.p2pEnabled
-    this.autoPlayVideo = hash.autoPlayVideo
-    this.autoPlayNextVideo = hash.autoPlayNextVideo
-    this.autoPlayNextVideoPlaylist = hash.autoPlayNextVideoPlaylist
-    this.videosHistoryEnabled = hash.videosHistoryEnabled
-    this.videoLanguages = hash.videoLanguages
-
-    this.theme = hash.theme
-
-    this.adminFlags = hash.adminFlags
-
-    this.blocked = hash.blocked
-    this.blockedReason = hash.blockedReason
-
-    this.noInstanceConfigWarningModal = hash.noInstanceConfigWarningModal
-    this.noWelcomeModal = hash.noWelcomeModal
-    this.noAccountSetupWarningModal = hash.noAccountSetupWarningModal
-
-    this.notificationSettings = hash.notificationSettings
-
-    this.twoFactorEnabled = hash.twoFactorEnabled
-
-    this.createdAt = hash.createdAt
-
-    this.pluginAuth = hash.pluginAuth
-    this.lastLoginDate = hash.lastLoginDate
-
-    if (hash.account !== undefined) {
-      this.account = new Account(hash.account)
+    if (account !== undefined) {
+      this.account = new Account(account)
     }
   }
 

--- a/client/src/standalone/videos/shared/peertube-plugin.ts
+++ b/client/src/standalone/videos/shared/peertube-plugin.ts
@@ -54,6 +54,8 @@ export class PeerTubePlugin {
           .then((obj: PublicServerSetting) => obj.publicSettings)
       },
 
+      getUser: unimplemented,
+
       isLoggedIn: () => this.http.isLoggedIn(),
       getAuthHeader: () => {
         if (!this.http.isLoggedIn()) return undefined

--- a/client/src/types/register-client-option.model.ts
+++ b/client/src/types/register-client-option.model.ts
@@ -1,3 +1,4 @@
+import { AuthUser } from '@app/core'
 import {
   RegisterClientFormFieldOptions,
   RegisterClientHookOptions,
@@ -34,6 +35,8 @@ export type RegisterClientHelpers = {
   getAuthHeader: () => { 'Authorization': string } | undefined
 
   getSettings: () => Promise<SettingEntries>
+
+  getUser: () => AuthUser
 
   getServerConfig: () => Promise<ServerConfig>
 

--- a/client/src/types/register-client-option.model.ts
+++ b/client/src/types/register-client-option.model.ts
@@ -1,5 +1,5 @@
-import { AuthUser } from '@app/core'
 import {
+  MyUser,
   RegisterClientFormFieldOptions,
   RegisterClientHookOptions,
   RegisterClientRouteOptions,
@@ -36,7 +36,7 @@ export type RegisterClientHelpers = {
 
   getSettings: () => Promise<SettingEntries>
 
-  getUser: () => AuthUser
+  getUser: () => MyUser
 
   getServerConfig: () => Promise<ServerConfig>
 


### PR DESCRIPTION
## Description
Let plugins access the user object.

## Questions
* I wasn't sure how to handle the plugin helpers for the standalone version, so I set it to unimplemented.
* Should getUser return `ServerMyUserModel` instead of `AuthUser`? By doing that the methods in `AuthUser` doesn't need to be a part of the public API.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #6355


<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

There's no test suites for the client.