### PR TITLE
Fix typo at log.rotation.enabled

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -249,7 +249,7 @@ log:
   level: 'info' # 'debug' | 'info' | 'warn' | 'error'
 
   rotation:
-    enabled : true # Enabled by default, if disabled make sure that 'storage.logs' is pointing to a folder handled by logrotate
+    enabled: true # Enabled by default, if disabled make sure that 'storage.logs' is pointing to a folder handled by logrotate
     max_file_size: 12MB
     max_files: 20
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -247,7 +247,7 @@ log:
   level: 'info' # 'debug' | 'info' | 'warn' | 'error'
 
   rotation:
-    enabled : true # Enabled by default, if disabled make sure that 'storage.logs' is pointing to a folder handled by logrotate
+    enabled: true # Enabled by default, if disabled make sure that 'storage.logs' is pointing to a folder handled by logrotate
     max_file_size: 12MB
     max_files: 20
 


### PR DESCRIPTION
## Description

In default.yaml and production.yaml.example there is what seems to be a typo at log.rotation.enabled

## Related issues

I'm not sure this typo caused any problem as i couldn't see any config parsing error on my instance but for coherence sake, i though i would still PR that.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

