### PR TITLE
feat(server): dont client cache HTML files

### DIFF
--- a/server/core/lib/html/client-html.ts
+++ b/server/core/lib/html/client-html.ts
@@ -54,6 +54,7 @@ class ClientHtml {
 
 function sendHTML (html: string, res: express.Response, localizedHTML: boolean = false) {
   res.set('Content-Type', 'text/html; charset=UTF-8')
+  res.set('Cache-Control', 'max-age=0, no-cache, must-revalidate')
 
   if (localizedHTML) {
     res.set('Vary', 'Accept-Language')


### PR DESCRIPTION
## Description
Tell the clients to not cache the HTML response.


<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #6393