### PR TITLE
feat: config option object_storage.max_request_attempts

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -213,6 +213,10 @@ object_storage:
   # Maximum amount to upload in one request to object storage
   max_upload_part: 100MB
 
+  # Maximum attempts to make on a request to object storage. Some object storage providers, for instance Backblaze,
+  # expects the client to retry upload upon 5xx errors. If you're using such a provider then you can increase this value.
+  max_request_attempts: 3
+
   streaming_playlists:
     bucket_name: 'streaming-playlists'
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -213,8 +213,9 @@ object_storage:
   # Maximum amount to upload in one request to object storage
   max_upload_part: 100MB
 
-  # Maximum attempts to make on a request to object storage. Some object storage providers, for instance Backblaze,
-  # expects the client to retry upload upon 5xx errors. If you're using such a provider then you can increase this value.
+  # Maximum number of attempts to make a request to object storage
+  # Some object storage providers (for instance Backblaze) expects the client to retry upload upon 5xx errors
+  # If you're using such a provider then you can increase this value
   max_request_attempts: 3
 
   streaming_playlists:

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -211,6 +211,10 @@ object_storage:
   # Maximum amount to upload in one request to object storage
   max_upload_part: 100MB
 
+  # Maximum attempts to make on a request to object storage. Some object storage providers, for instance Backblaze,
+  # expects the client to retry upload upon 5xx errors. If you're using such a provider then you can increase this value.
+  max_request_attempts: 3
+
   streaming_playlists:
     bucket_name: 'streaming-playlists'
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -211,8 +211,9 @@ object_storage:
   # Maximum amount to upload in one request to object storage
   max_upload_part: 100MB
 
-  # Maximum attempts to make on a request to object storage. Some object storage providers, for instance Backblaze,
-  # expects the client to retry upload upon 5xx errors. If you're using such a provider then you can increase this value.
+  # Maximum number of attempts to make a request to object storage
+  # Some object storage providers (for instance Backblaze) expects the client to retry upload upon 5xx errors
+  # If you're using such a provider then you can increase this value
   max_request_attempts: 3
 
   streaming_playlists:

--- a/server/core/initializers/checker-before-init.ts
+++ b/server/core/initializers/checker-before-init.ts
@@ -67,7 +67,7 @@ function checkMissedConfig () {
     'object_storage.credentials.secret_access_key', 'object_storage.max_upload_part', 'object_storage.streaming_playlists.bucket_name',
     'object_storage.streaming_playlists.prefix', 'object_storage.streaming_playlists.base_url', 'object_storage.web_videos.bucket_name',
     'object_storage.web_videos.prefix', 'object_storage.web_videos.base_url', 'object_storage.original_video_files.bucket_name',
-    'object_storage.original_video_files.prefix', 'object_storage.original_video_files.base_url',
+    'object_storage.original_video_files.prefix', 'object_storage.original_video_files.base_url', 'object_storage.max_request_attempts',
     'theme.default',
     'feeds.videos.count', 'feeds.comments.count',
     'geo_ip.enabled', 'geo_ip.country.database_url', 'geo_ip.city.database_url',

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -132,6 +132,7 @@ const CONFIG = {
   OBJECT_STORAGE: {
     ENABLED: config.get<boolean>('object_storage.enabled'),
     MAX_UPLOAD_PART: bytes.parse(config.get<string>('object_storage.max_upload_part')),
+    MAX_REQUEST_ATTEMPTS: config.get<number>('object_storage.max_request_attempts'),
     ENDPOINT: config.get<string>('object_storage.endpoint'),
     REGION: config.get<string>('object_storage.region'),
     UPLOAD_ACL: {

--- a/server/core/lib/object-storage/shared/client.ts
+++ b/server/core/lib/object-storage/shared/client.ts
@@ -45,7 +45,8 @@ function getClient () {
           secretAccessKey: OBJECT_STORAGE.CREDENTIALS.SECRET_ACCESS_KEY
         }
         : undefined,
-      requestHandler: await getProxyRequestHandler()
+      requestHandler: await getProxyRequestHandler(),
+      maxAttempts: CONFIG.OBJECT_STORAGE.MAX_REQUEST_ATTEMPTS
     })
 
     logger.info('Initialized S3 client %s with region %s.', getEndpoint(), OBJECT_STORAGE.REGION, lTags())


### PR DESCRIPTION
## Description
Backblaze recommends to have a high amount of attempts since they've designed their architecture so that it will return 5xx errors to indicate that the client should do a new attempt.

https://www.backblaze.com/blog/b2-503-500-server-error/

## Related issues

closes #6415


<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

Only manual test with a local Minio server.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

