### PR TITLE
docs: fix typo in getPlaybackRate() : Promise<number> documentation

### DIFF
--- a/support/doc/api/embeds.md
+++ b/support/doc/api/embeds.md
@@ -242,7 +242,7 @@ Otherwise, `resolutionId` should be the ID of an object returned by `getResoluti
 
 Get the available playback rates, where `1` represents normal speed, `0.5` is half speed, `2` is double speed, etc.
 
-### `getPlaybackRates() : Promise<number>`
+### `getPlaybackRate() : Promise<number>`
 
 Get the current playback rate. See `getPlaybackRates()` for more information.
 


### PR DESCRIPTION
## Description

Fix typo in documentation
getPlaybackRate() : Promise<number> documentation
instead of
getPlaybackRate**s**() : Promise<number> documentation

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
