### PR TITLE
#5618 - Configuration fields for Thumbnails and Previews

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -468,6 +468,16 @@ thumbnails:
     # Increasing this value will increase CPU and memory usage when generating the thumbnail, especially for high video resolution
     # Minimum value is 2
     frames_to_analyze: 50
+  size:
+    width: 280
+    height: 157
+    min_width: 150
+
+previews:
+  size:
+    width: 850
+    height: 480
+    min_width: 400
 
 stats:
   # Display registration requests stats (average response time, total requests...)

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -370,6 +370,18 @@ const CONFIG = {
   THUMBNAILS: {
     GENERATION_FROM_VIDEO: {
       FRAMES_TO_ANALYZE: config.get<number>('thumbnails.generation_from_video.frames_to_analyze')
+    },
+    SIZE: {
+      WIDTH: config.get<number>('thumbnails.size.width'),
+      HEIGHT: config.get<number>('thumbnails.size.height'),
+      MIN_WIDTH: config.get<number>('thumbnails.size.min_width'),
+    }
+  },
+  PREVIEWS: {
+    SIZE: {
+      WIDTH: config.get<number>('previews.size.width'),
+      HEIGHT: config.get<number>('previews.size.height'),
+      MIN_WIDTH: config.get<number>('previews.size.min_width'),
     }
   },
   STATS: {

--- a/server/core/initializers/constants.ts
+++ b/server/core/initializers/constants.ts
@@ -888,14 +888,14 @@ const STATIC_MAX_AGE = {
 
 // Videos thumbnail size
 const THUMBNAILS_SIZE = {
-  width: 280,
-  height: 157,
-  minWidth: 150
+  width: CONFIG.THUMBNAILS.SIZE.WIDTH || 280,
+  height: CONFIG.THUMBNAILS.SIZE.HEIGHT || 157,
+  minWidth: CONFIG.THUMBNAILS.SIZE.MIN_WIDTH || 150
 }
 const PREVIEWS_SIZE = {
-  width: 850,
-  height: 480,
-  minWidth: 400
+  width: CONFIG.PREVIEWS.SIZE.WIDTH || 850,
+  height: CONFIG.PREVIEWS.SIZE.HEIGHT || 480,
+  minWidth: CONFIG.PREVIEWS.SIZE.MIN_WIDTH || 400
 }
 const ACTOR_IMAGES_SIZE: { [key in ActorImageType_Type]: { width: number, height: number }[] } = {
   [ActorImageType.AVATAR]: [ // 1/1 ratio


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Feature Change:
1. Updated the configurations, so `Thumbnail` and `Preview` image sizes can be configured in `yaml` files. In case the configuration is not there, there are some defaults left there.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/5618

## Has this been tested?


- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Test resuts

```text
> peertube@6.1.0 mocha
> mocha --exit --bail packages/tests/src/api/server/config.ts



  Test static config
    ✔ Should tell the client that edits are not allowed (48ms)
    ✔ Should error when client tries to update

  Test config
    Config keys
      ✔ Should have the correct default config
      ✔ Should have a correct config on a server with registration enabled
      ✔ Should have a correct config on a server with registration enabled and a users limit (168ms)
      ✔ Should have the correct video allowed extensions
      ✔ Should get the customized configuration
      ✔ Should update the customized configuration
      ✔ Should have the correct updated video allowed extensions (1274ms)
      ✔ Should have the configuration updated after a restart (933ms)
      ✔ Should fetch the about information
      ✔ Should remove the custom configuration
      ✔ Should enable/disable security headers (995ms)
    Image files
      Banner
        ✔ Should update instance banner (434ms)
        ✔ Should re-update an existing instance banner (114ms)
        ✔ Should remove instance banner
      Avatar
        ✔ Should update instance avatar (930ms)
        ✔ Should have the avatars in the AP representation of the instance
        ✔ Should remove instance avatar
        ✔ Should not have the avatars anymore in the AP representation of the instance


  20 passing (10s)
```

## Screenshots

![peertube-image-size-changes](https://github.com/Chocobozzz/PeerTube/assets/1750322/9f01459a-fe20-4770-891a-2aad13af711b)

