### PR TITLE
feat(plugins/filter): add req to api.video.get.result

### DIFF
--- a/server/core/controllers/api/videos/index.ts
+++ b/server/core/controllers/api/videos/index.ts
@@ -150,11 +150,11 @@ function listVideoPrivacies (_req: express.Request, res: express.Response) {
   res.json(VIDEO_PRIVACIES)
 }
 
-async function getVideo (_req: express.Request, res: express.Response) {
+async function getVideo (req: express.Request, res: express.Response) {
   const videoId = res.locals.videoAPI.id
   const userId = res.locals.oauth?.token.User.id
 
-  const video = await Hooks.wrapObject(res.locals.videoAPI, 'filter:api.video.get.result', { id: videoId, userId })
+  const video = await Hooks.wrapObject(res.locals.videoAPI, 'filter:api.video.get.result', { req, id: videoId, userId })
   // Filter may return null/undefined value to forbid video access
   if (!video) return res.sendStatus(HttpStatusCode.NOT_FOUND_404)
 


### PR DESCRIPTION
## Description
Add req param to `filter:api.video.get.result` hook in order to let a plugin read the request headers.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
