### PR TITLE
Add Express req, res to filter:api.search.videos.local.list.params

### DIFF
--- a/server/core/controllers/api/search/search-videos.ts
+++ b/server/core/controllers/api/search/search-videos.ts
@@ -118,7 +118,7 @@ async function searchVideosDB (query: VideosSearchQueryAfterSanitize, req: expre
     user: res.locals.oauth
       ? res.locals.oauth.token.User
       : undefined
-  }, 'filter:api.search.videos.local.list.params')
+  }, 'filter:api.search.videos.local.list.params', { req, res })
 
   const resultList = await Hooks.wrapPromiseFun(
     VideoModel.searchAndPopulateAccountAndServer.bind(VideoModel),


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

Add Express request & response to `filter:api.search.videos.local.list.params`'s hook context.

I believe this was needed because the query given to the hook has already been filtered for unwanted parameters before the hook executes, this adds the request & response to allow access to those query parameters that might've been removed.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
N/A

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

I do not believe this change needs tests written for it

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
