### PR TITLE
nginx http2

### DIFF
--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -20,8 +20,9 @@ upstream backend {
 }
 
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
   server_name ${WEBSERVER_HOST};
 
   access_log /var/log/nginx/peertube.access.log; # reduce I/0 with buffer=10m flush=5m


### PR DESCRIPTION
## Description

nginx http2 is no longer supported in the listen line, it needs to be on it's own line now

- https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2

## Related issues
N/A

## Has this been tested?


- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

Not necessary