### PR TITLE
Allow installing plugins declaratively

### DIFF
--- a/server/core/lib/plugins/yarn.ts
+++ b/server/core/lib/plugins/yarn.ts
@@ -6,7 +6,7 @@ import { logger } from '../../helpers/logger.js'
 import { CONFIG } from '../../initializers/config.js'
 import { getLatestPluginVersion } from './plugin-index.js'
 
-async function installNpmPlugin (npmName: string, versionArg?: string) {
+async function installNpmPlugin (npmName: string, versionArg?: string, extraArgs?: string) {
   // Security check
   checkNpmPluginNameOrThrow(npmName)
   if (versionArg) checkPluginVersionOrThrow(versionArg)
@@ -15,13 +15,15 @@ async function installNpmPlugin (npmName: string, versionArg?: string) {
 
   let toInstall = npmName
   if (version) toInstall += `@${version}`
+  if (extraArgs) toInstall += ` ${extraArgs}`
 
   const { stdout } = await execYarn('add ' + toInstall)
 
   logger.debug('Added a yarn package.', { yarnStdout: stdout })
 }
 
-async function installNpmPluginFromDisk (path: string) {
+async function installNpmPluginFromDisk (path: string, extraArgs?: string) {
+  if (extraArgs) path += ` ${extraArgs}`
   await execYarn('add file:' + path)
 }
 

--- a/server/core/models/server/plugin.ts
+++ b/server/core/models/server/plugin.ts
@@ -86,6 +86,10 @@ export class PluginModel extends SequelizeModel<PluginModel> {
   @Column(DataType.JSONB)
   storage: any
 
+  @AllowNull(true)
+  @Column
+  declarative: boolean
+
   @CreatedAt
   createdAt: Date
 
@@ -96,6 +100,17 @@ export class PluginModel extends SequelizeModel<PluginModel> {
     const query = {
       where: {
         enabled: true,
+        uninstalled: false
+      }
+    }
+
+    return PluginModel.findAll(query)
+  }
+
+  static listDeclarativePluginsAndThemes (): Promise<MPlugin[]> {
+    const query = {
+      where: {
+        declarative: true,
         uninstalled: false
       }
     }

--- a/server/server.ts
+++ b/server/server.ts
@@ -352,6 +352,7 @@ async function startApplication () {
   server.listen(port, hostname, async () => {
     if (cliOptions.plugins) {
       try {
+        await PluginManager.Instance.installDeclarativePlugins()
         await PluginManager.Instance.rebuildNativePluginsIfNeeded()
 
         await PluginManager.Instance.registerPluginsAndThemes()


### PR DESCRIPTION
## Description

Implements the ability for PeerTube to self-install plugins that are declared upfront in a file, checking the file on startup to install/uninstall/update accordingly.

I am not a seasoned TypeScript developer by any stretch of the imagination, so please let me know wherever the code can be improved.

TODO:
- [ ] Add usage to documentation
- [ ] Add unit test

## Related issues

Resolves #6428

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

