### PR TITLE
oEmbed API should use CORS

### DIFF
--- a/packages/tests/src/api/check-params/services.ts
+++ b/packages/tests/src/api/check-params/services.ts
@@ -201,6 +201,9 @@ function checkParamEmbed (
   return makeGetRequest({
     url: server.url,
     path,
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    },
     query: Object.assign(query, { url: embedUrl }),
     expectedStatus
   })

--- a/packages/tests/src/api/check-params/services.ts
+++ b/packages/tests/src/api/check-params/services.ts
@@ -201,9 +201,6 @@ function checkParamEmbed (
   return makeGetRequest({
     url: server.url,
     path,
-    headers: {
-      'Access-Control-Allow-Origin': '*'
-    },
     query: Object.assign(query, { url: embedUrl }),
     expectedStatus
   })

--- a/server/core/controllers/services.ts
+++ b/server/core/controllers/services.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import cors from 'cors'
 import { escapeHTML, forceNumber } from '@peertube/peertube-core-utils'
 import { MChannelSummary } from '@server/types/models/index.js'
 import { EMBED_SIZE, PREVIEWS_SIZE, THUMBNAILS_SIZE, WEBSERVER } from '../initializers/constants.js'
@@ -10,6 +11,7 @@ const servicesRouter = express.Router()
 servicesRouter.use('/oembed',
   apiRateLimiter,
   asyncMiddleware(oembedValidator),
+  cors({ origin: '*' }),
   generateOEmbed
 )
 servicesRouter.use('/redirect/accounts/:accountName',

--- a/server/core/controllers/services.ts
+++ b/server/core/controllers/services.ts
@@ -9,9 +9,9 @@ import { accountNameWithHostGetValidator } from '../middlewares/validators/index
 const servicesRouter = express.Router()
 
 servicesRouter.use('/oembed',
+  cors(),
   apiRateLimiter,
   asyncMiddleware(oembedValidator),
-  cors({ origin: '*' }),
   generateOEmbed
 )
 servicesRouter.use('/redirect/accounts/:accountName',


### PR DESCRIPTION
## Description

It's handy to be able to access the [oEmbed API](https://oembed.com) from a browser, in order to construct `<iframe>` tags to embed videos. However, web browsers have security policies that prevent cross-domain communication -- unless that security policy is specifically bypassed using a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) header. In this case, the oEmbed API returns no personal data about the logged-in user, so there is no reason to prevent cross-domain communication.

By adding this header, it allows third-party websites to construct `<iframe>` embeds directly in client-side JavaScript, without needing a backend server to act as a proxy.


## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

