### PR TITLE
Add missing Docker syntax for prune-storage

### DIFF
--- a/support/doc/tools.md
+++ b/support/doc/tools.md
@@ -611,10 +611,19 @@ docker compose exec -u peertube peertube npm run create-generate-storyboard-job 
 Some transcoded videos or shutdown at a bad time can leave some unused files on your storage.
 To delete these files (a confirmation will be demanded first):
 
-```bash
+::: code-group
+
+```bash [Classic installation]
 cd /var/www/peertube/peertube-latest
 sudo -u peertube NODE_CONFIG_DIR=/var/www/peertube/config NODE_ENV=production npm run prune-storage
 ```
+
+```bash [Docker]
+cd /var/www/peertube-docker
+docker compose exec -u peertube peertube npm run prune-storage
+```
+
+:::
 
 ### Update PeerTube instance domain name
 


### PR DESCRIPTION
## Description

This pull request adds the correct Docker syntax for the `prune-storage` script, which was missing in the previous version of the documentation.

## Related issues

No related issues were reported.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

N/A
