### PR TITLE
feat(API): permissive email check in login, reset & verification

### DIFF
--- a/packages/server-commands/src/users/users-command.ts
+++ b/packages/server-commands/src/users/users-command.ts
@@ -161,6 +161,7 @@ export class UsersCommand extends AbstractCommand {
     videoQuotaDaily?: number
     role?: UserRoleType
     adminFlags?: UserAdminFlagType
+    email?: string
   }) {
     const {
       username,
@@ -168,7 +169,8 @@ export class UsersCommand extends AbstractCommand {
       password = 'password',
       videoQuota,
       videoQuotaDaily,
-      role = UserRole.USER
+      role = UserRole.USER,
+      email = username + '@example.com'
     } = options
 
     const path = '/api/v1/users'
@@ -182,7 +184,7 @@ export class UsersCommand extends AbstractCommand {
         password,
         role,
         adminFlags,
-        email: username + '@example.com',
+        email,
         videoQuota,
         videoQuotaDaily
       },

--- a/packages/tests/src/api/check-params/my-user.ts
+++ b/packages/tests/src/api/check-params/my-user.ts
@@ -60,10 +60,30 @@ describe('Test my user API validators', function () {
 
     it('Should fail with an invalid email attribute', async function () {
       const fields = {
-        email: 'blabla'
+        email: 'blabla',
+        currentPassword: 'password'
       }
 
-      await makePutBodyRequest({ url: server.url, path: path + 'me', token: server.accessToken, fields })
+      await makePutBodyRequest({ url: server.url, path: path + 'me', token: userToken, fields })
+    })
+
+    it('Should fail with an already existing email attribute', async function () {
+      const emails = [ 'moderator1@example.com', 'moderatoR1@example.com' ]
+
+      for (const email of emails) {
+        const fields = {
+          email,
+          currentPassword: 'password'
+        }
+
+        await makePutBodyRequest({
+          url: server.url,
+          path: path + 'me',
+          token: userToken,
+          fields,
+          expectedStatus: HttpStatusCode.CONFLICT_409
+        })
+      }
     })
 
     it('Should fail with a too small password', async function () {

--- a/packages/tests/src/api/check-params/registrations.ts
+++ b/packages/tests/src/api/check-params/registrations.ts
@@ -110,9 +110,16 @@ describe('Test registrations API validators', function () {
       })
 
       it('Should fail if we register a user with the same email', async function () {
-        const fields = { ...baseCorrectParams, email: 'admin' + server.internalServerNumber + '@example.com' }
+        const emails = [
+          'admin' + server.internalServerNumber + '@example.com',
+          'Admin' + server.internalServerNumber + '@example.com'
+        ]
 
-        await check(fields, HttpStatusCode.CONFLICT_409)
+        for (const email of emails) {
+          const fields = { ...baseCorrectParams, email }
+
+          await check(fields, HttpStatusCode.CONFLICT_409)
+        }
       })
 
       it('Should fail with a bad display name', async function () {
@@ -267,16 +274,18 @@ describe('Test registrations API validators', function () {
       })
 
       it('Should fail if the email is already awaiting registration approval', async function () {
-        await server.registrations.requestRegistration({
-          username: 'user42',
-          email: 'user_request_2@example.com',
-          registrationReason: 'tt',
-          channel: {
-            displayName: 'my user request 42 channel',
-            name: 'user_request_42_channel'
-          },
-          expectedStatus: HttpStatusCode.CONFLICT_409
-        })
+        for (const email of [ 'user_request_2@example.com', 'user_requesT_2@example.com' ]) {
+          await server.registrations.requestRegistration({
+            username: 'user42',
+            email,
+            registrationReason: 'tt',
+            channel: {
+              displayName: 'my user request 42 channel',
+              name: 'user_request_42_channel'
+            },
+            expectedStatus: HttpStatusCode.CONFLICT_409
+          })
+        }
       })
 
       it('Should fail if the channel is already awaiting registration approval', async function () {

--- a/packages/tests/src/api/check-params/users-admin.ts
+++ b/packages/tests/src/api/check-params/users-admin.ts
@@ -206,15 +206,22 @@ describe('Test users admin API validators', function () {
     })
 
     it('Should fail if we add a user with the same email', async function () {
-      const fields = { ...baseCorrectParams, email: 'user1@example.com' }
+      const emails = [
+        'user1@example.com',
+        'uSer1@example.com'
+      ]
 
-      await makePostBodyRequest({
-        url: server.url,
-        path,
-        token: server.accessToken,
-        fields,
-        expectedStatus: HttpStatusCode.CONFLICT_409
-      })
+      for (const email of emails) {
+        const fields = { ...baseCorrectParams, email }
+
+        await makePostBodyRequest({
+          url: server.url,
+          path,
+          token: server.accessToken,
+          fields,
+          expectedStatus: HttpStatusCode.CONFLICT_409
+        })
+      }
     })
 
     it('Should fail with an invalid videoQuota', async function () {
@@ -331,6 +338,18 @@ describe('Test users admin API validators', function () {
       }
 
       await makePutBodyRequest({ url: server.url, path: path + userId, token: server.accessToken, fields })
+    })
+
+    it('Should fail with an existing email attribute', async function () {
+      const fields = { email: 'modeRator1@example.com' }
+
+      await makePutBodyRequest({
+        url: server.url,
+        path: path + userId,
+        token: server.accessToken,
+        fields,
+        expectedStatus: HttpStatusCode.CONFLICT_409
+      })
     })
 
     it('Should fail with an invalid emailVerified attribute', async function () {

--- a/packages/tests/src/api/check-params/users-emails.ts
+++ b/packages/tests/src/api/check-params/users-emails.ts
@@ -28,9 +28,21 @@ describe('Test users API validators', function () {
     await server.config.enableSignup(true)
 
     await server.users.generate('moderator2', UserRole.MODERATOR)
+    await server.users.create({ username: 'user' })
+    await server.users.create({ username: 'user_similar', email: 'User@example.com' })
+    await server.users.generate('user2')
 
     await server.registrations.requestRegistration({
       username: 'request1',
+      registrationReason: 'tt'
+    })
+    await server.registrations.requestRegistration({
+      username: 'request_1',
+      email: 'Request1@example.com',
+      registrationReason: 'tt'
+    })
+    await server.registrations.requestRegistration({
+      username: 'request2',
       registrationReason: 'tt'
     })
   })
@@ -48,6 +60,39 @@ describe('Test users API validators', function () {
       const fields = { email: 'hello' }
 
       await makePostBodyRequest({ url: server.url, path, fields })
+    })
+
+    it('Should fail with wrong capitalization when multiple users with similar email exists', async function () {
+      const fields = { email: 'USER@example.com' }
+
+      await makePostBodyRequest({
+        url: server.url,
+        path,
+        fields,
+        expectedStatus: HttpStatusCode.NO_CONTENT_204
+      })
+    })
+
+    it('Should success with correct capitalization when multiple users with similar email exists', async function () {
+      const fields = { email: 'User@example.com' }
+
+      await makePostBodyRequest({
+        url: server.url,
+        path,
+        fields,
+        expectedStatus: HttpStatusCode.NO_CONTENT_204
+      })
+    })
+
+    it('Should success with wrong capitalization when no similar emails exists', async function () {
+      const fields = { email: 'USER2@example.com' }
+
+      await makePostBodyRequest({
+        url: server.url,
+        path,
+        fields,
+        expectedStatus: HttpStatusCode.NO_CONTENT_204
+      })
     })
 
     it('Should success with the correct params', async function () {
@@ -104,7 +149,29 @@ describe('Test users API validators', function () {
       await makePostBodyRequest({ url: server.url, path, fields })
     })
 
-    it('Should succeed with the correct params', async function () {
+    it('Should fail with wrong capitalization when multiple users with similar email exists', async function () {
+      const fields = { email: 'REQUEST1@example.com' }
+
+      await makePostBodyRequest({
+        url: server.url,
+        path,
+        fields,
+        expectedStatus: HttpStatusCode.NO_CONTENT_204
+      })
+    })
+
+    it('Should success with wrong capitalization when no similar emails exists', async function () {
+      const fields = { email: 'REQUEST2@example.com' }
+
+      await makePostBodyRequest({
+        url: server.url,
+        path,
+        fields,
+        expectedStatus: HttpStatusCode.NO_CONTENT_204
+      })
+    })
+
+    it('Should success with correct capitalization when multiple users with similar email exists', async function () {
       const fields = { email: 'request1@example.com' }
 
       await makePostBodyRequest({

--- a/packages/tests/src/api/check-params/users-emails.ts
+++ b/packages/tests/src/api/check-params/users-emails.ts
@@ -28,21 +28,9 @@ describe('Test users API validators', function () {
     await server.config.enableSignup(true)
 
     await server.users.generate('moderator2', UserRole.MODERATOR)
-    await server.users.create({ username: 'user' })
-    await server.users.create({ username: 'user_similar', email: 'User@example.com' })
-    await server.users.generate('user2')
 
     await server.registrations.requestRegistration({
       username: 'request1',
-      registrationReason: 'tt'
-    })
-    await server.registrations.requestRegistration({
-      username: 'request_1',
-      email: 'Request1@example.com',
-      registrationReason: 'tt'
-    })
-    await server.registrations.requestRegistration({
-      username: 'request2',
       registrationReason: 'tt'
     })
   })
@@ -60,28 +48,6 @@ describe('Test users API validators', function () {
       const fields = { email: 'hello' }
 
       await makePostBodyRequest({ url: server.url, path, fields })
-    })
-
-    it('Should success with correct capitalization when multiple users with similar email exists', async function () {
-      const fields = { email: 'User@example.com' }
-
-      await makePostBodyRequest({
-        url: server.url,
-        path,
-        fields,
-        expectedStatus: HttpStatusCode.NO_CONTENT_204
-      })
-    })
-
-    it('Should success with wrong capitalization when no similar emails exists', async function () {
-      const fields = { email: 'USER2@example.com' }
-
-      await makePostBodyRequest({
-        url: server.url,
-        path,
-        fields,
-        expectedStatus: HttpStatusCode.NO_CONTENT_204
-      })
     })
 
     it('Should success with the correct params', async function () {
@@ -138,18 +104,7 @@ describe('Test users API validators', function () {
       await makePostBodyRequest({ url: server.url, path, fields })
     })
 
-    it('Should success with wrong capitalization when no similar emails exists', async function () {
-      const fields = { email: 'REQUEST2@example.com' }
-
-      await makePostBodyRequest({
-        url: server.url,
-        path,
-        fields,
-        expectedStatus: HttpStatusCode.NO_CONTENT_204
-      })
-    })
-
-    it('Should success with correct capitalization when multiple users with similar email exists', async function () {
+    it('Should succeed with the correct params', async function () {
       const fields = { email: 'request1@example.com' }
 
       await makePostBodyRequest({

--- a/packages/tests/src/api/check-params/users-emails.ts
+++ b/packages/tests/src/api/check-params/users-emails.ts
@@ -62,17 +62,6 @@ describe('Test users API validators', function () {
       await makePostBodyRequest({ url: server.url, path, fields })
     })
 
-    it('Should fail with wrong capitalization when multiple users with similar email exists', async function () {
-      const fields = { email: 'USER@example.com' }
-
-      await makePostBodyRequest({
-        url: server.url,
-        path,
-        fields,
-        expectedStatus: HttpStatusCode.NO_CONTENT_204
-      })
-    })
-
     it('Should success with correct capitalization when multiple users with similar email exists', async function () {
       const fields = { email: 'User@example.com' }
 
@@ -147,17 +136,6 @@ describe('Test users API validators', function () {
       const fields = { email: 'hello' }
 
       await makePostBodyRequest({ url: server.url, path, fields })
-    })
-
-    it('Should fail with wrong capitalization when multiple users with similar email exists', async function () {
-      const fields = { email: 'REQUEST1@example.com' }
-
-      await makePostBodyRequest({
-        url: server.url,
-        path,
-        fields,
-        expectedStatus: HttpStatusCode.NO_CONTENT_204
-      })
     })
 
     it('Should success with wrong capitalization when no similar emails exists', async function () {

--- a/packages/tests/src/api/server/email.ts
+++ b/packages/tests/src/api/server/email.ts
@@ -33,7 +33,7 @@ describe('Test emails', function () {
     password: 'super_password'
   }
 
-  const similarUsers = [ { username: 'lowercase_user_1'}, { username: 'lowercase_user__1' } ]
+  const similarUsers = [ { username: 'lowercase_user_1' }, { username: 'lowercase_user__1' } ]
 
   before(async function () {
     this.timeout(120000)

--- a/packages/tests/src/api/server/email.ts
+++ b/packages/tests/src/api/server/email.ts
@@ -31,6 +31,16 @@ describe('Test emails', function () {
     username: 'user_1',
     password: 'super_password'
   }
+  const similarUsers = [
+    {
+      username: 'lowercase_user_1',
+      email: 'lowercase_user_1@example.com'
+    },
+    {
+      username: 'lowercase_user__1',
+      email: 'Lowercase_user_1@example.com'
+    }
+  ]
 
   before(async function () {
     this.timeout(120000)
@@ -40,6 +50,10 @@ describe('Test emails', function () {
 
     await setAccessTokensToServers([ server ])
     await server.config.enableSignup(true)
+
+    for (const user of similarUsers) {
+      await server.users.create(user)
+    }
 
     {
       const created = await server.users.create({ username: user.username, password: user.password })
@@ -99,6 +113,10 @@ describe('Test emails', function () {
         password: 'super_password2',
         expectedStatus: HttpStatusCode.FORBIDDEN_403
       })
+    })
+
+    it('Should fail with wrong capitalization when multiple users with similar email exists', async function () {
+      await server.users.askResetPassword({ email: similarUsers[0].username.toUpperCase(), expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
     })
 
     it('Should reset the password', async function () {
@@ -268,6 +286,13 @@ describe('Test emails', function () {
   })
 
   describe('When verifying a user email', function () {
+
+    it('Should fail with wrong capitalization when multiple users with similar email exists', async function () {
+      await server.users.askSendVerifyEmail({
+        email: similarUsers[0].username.toUpperCase(),
+        expectedStatus: HttpStatusCode.BAD_REQUEST_400
+      })
+    })
 
     it('Should ask to send the verification email', async function () {
       await server.users.askSendVerifyEmail({ email: 'user_1@example.com' })

--- a/packages/tests/src/api/users/oauth.ts
+++ b/packages/tests/src/api/users/oauth.ts
@@ -28,6 +28,8 @@ describe('Test oauth', function () {
     })
 
     await setAccessTokensToServers([ server ])
+    await server.users.create({ username: 'user1', email: 'user@example.com' })
+    await server.users.create({ username: 'user2', email: 'User@example.com', password: 'AdvancedPassword' })
 
     sqlCommand = new SQLCommand(server)
   })
@@ -79,7 +81,7 @@ describe('Test oauth', function () {
     })
 
     it('Should not login with an invalid password', async function () {
-      const user = { username: server.store.user.username, password: 'mew_three' }
+      const user = { username: 'User@example.com', password: 'password' }
       const body = await server.login.login({ user, expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
 
       expectInvalidCredentials(body)
@@ -87,6 +89,9 @@ describe('Test oauth', function () {
 
     it('Should be able to login', async function () {
       await server.login.login({ expectedStatus: HttpStatusCode.OK_200 })
+
+      const user = { username: 'User@example.com', password: 'AdvancedPassword' }
+      await server.login.login({ user, expectedStatus: HttpStatusCode.OK_200 })
     })
 
     it('Should be able to login with an insensitive username', async function () {
@@ -98,6 +103,14 @@ describe('Test oauth', function () {
 
       const user3 = { username: 'ROOt', password: server.store.user.password }
       await server.login.login({ user: user3, expectedStatus: HttpStatusCode.OK_200 })
+    })
+
+    it('Should be able to login with an insensitive email when no similar emails exist', async function () {
+      const user = { username: 'ADMIN' + server.internalServerNumber + '@example.com', password: server.store.user.password }
+      await server.login.login({ user, expectedStatus: HttpStatusCode.OK_200 })
+
+      const user2 = { username: 'admin' + server.internalServerNumber + '@example.com', password: server.store.user.password }
+      await server.login.login({ user: user2, expectedStatus: HttpStatusCode.OK_200 })
     })
   })
 

--- a/packages/tests/src/api/users/oauth.ts
+++ b/packages/tests/src/api/users/oauth.ts
@@ -81,7 +81,7 @@ describe('Test oauth', function () {
     })
 
     it('Should not login with an invalid password', async function () {
-      const user = { username: 'User@example.com', password: 'password' }
+      const user = { username: server.store.user.username, password: 'mew_three' }
       const body = await server.login.login({ user, expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
 
       expectInvalidCredentials(body)
@@ -110,6 +110,14 @@ describe('Test oauth', function () {
       await server.login.login({ user, expectedStatus: HttpStatusCode.OK_200 })
 
       const user2 = { username: 'admin' + server.internalServerNumber + '@example.com', password: server.store.user.password }
+      await server.login.login({ user: user2, expectedStatus: HttpStatusCode.OK_200 })
+    })
+
+    it('Should not be able to login with an insensitive email when similar emails exist', async function () {
+      const user = { username: 'uSer@example.com', password: 'AdvancedPassword' }
+      await server.login.login({ user, expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
+
+      const user2 = { username: 'User@example.com', password: 'AdvancedPassword' }
       await server.login.login({ user: user2, expectedStatus: HttpStatusCode.OK_200 })
     })
   })

--- a/packages/tests/src/api/users/oauth.ts
+++ b/packages/tests/src/api/users/oauth.ts
@@ -28,10 +28,13 @@ describe('Test oauth', function () {
     })
 
     await setAccessTokensToServers([ server ])
-    await server.users.create({ username: 'user1', email: 'user@example.com' })
-    await server.users.create({ username: 'user2', email: 'User@example.com', password: 'AdvancedPassword' })
 
     sqlCommand = new SQLCommand(server)
+
+    await server.users.create({ username: 'user1', email: 'user@example.com' })
+    await server.users.create({ username: 'user2', password: 'AdvancedPassword' })
+
+    await sqlCommand.setUserEmail('user2', 'User@example.com')
   })
 
   describe('OAuth client', function () {

--- a/packages/tests/src/shared/sql-command.ts
+++ b/packages/tests/src/shared/sql-command.ts
@@ -81,6 +81,10 @@ export class SQLCommand {
     await this.updateQuery(`UPDATE "userExport" SET storage = :storage WHERE "userId" = :userId`, { storage, userId })
   }
 
+  async setUserEmail (username: string, email: string) {
+    await this.updateQuery(`UPDATE "user" SET email = :email WHERE "username" = :username`, { email, username })
+  }
+
   // ---------------------------------------------------------------------------
 
   setPluginVersion (pluginName: string, newVersion: string) {

--- a/server/core/lib/auth/oauth-model.ts
+++ b/server/core/lib/auth/oauth-model.ts
@@ -14,7 +14,7 @@ import { OAuthClientModel } from '../../models/oauth/oauth-client.js'
 import { OAuthTokenModel } from '../../models/oauth/oauth-token.js'
 import { UserModel } from '../../models/user/user.js'
 import { findAvailableLocalActorName } from '../local-actor.js'
-import { buildUser, createUserAccountAndChannelAndPlaylist } from '../user.js'
+import { buildUser, createUserAccountAndChannelAndPlaylist, getUserByEmailPermissive } from '../user.js'
 import { ExternalUser } from './external-auth.js'
 import { TokensCache } from './tokens-cache.js'
 
@@ -87,7 +87,7 @@ async function getUser (usernameOrEmail?: string, password?: string, bypassLogin
   if (bypassLogin && bypassLogin.bypass === true) {
     logger.info('Bypassing oauth login by plugin %s.', bypassLogin.pluginName)
 
-    let user = await UserModel.loadByEmail(bypassLogin.user.email)
+    let user = getUserByEmailPermissive(await UserModel.loadByEmailCaseInsensitive(bypassLogin.user.email), bypassLogin.user.email)
 
     if (!user) {
       user = await createUserFromExternal(bypassLogin.pluginName, bypassLogin.user)
@@ -119,7 +119,14 @@ async function getUser (usernameOrEmail?: string, password?: string, bypassLogin
 
   logger.debug('Getting User (username/email: ' + usernameOrEmail + ', password: ******).')
 
-  const user = await UserModel.loadByUsernameOrEmail(usernameOrEmail)
+  const users = await UserModel.loadByUsernameOrEmailCaseInsensitive(usernameOrEmail)
+  let user: MUserDefault
+
+  if (usernameOrEmail.includes('@')) {
+    user = getUserByEmailPermissive(users, usernameOrEmail)
+  } else {
+    user = users[0]
+  }
 
   // If we don't find the user, or if the user belongs to a plugin
   if (!user || user.pluginAuth !== null || !password) return null

--- a/server/core/lib/auth/oauth-model.ts
+++ b/server/core/lib/auth/oauth-model.ts
@@ -124,7 +124,7 @@ async function getUser (usernameOrEmail?: string, password?: string, bypassLogin
 
   if (usernameOrEmail.includes('@')) {
     user = getUserByEmailPermissive(users, usernameOrEmail)
-  } else {
+  } else if (users.length === 1) {
     user = users[0]
   }
 

--- a/server/core/lib/auth/oauth.ts
+++ b/server/core/lib/auth/oauth.ts
@@ -154,12 +154,14 @@ async function handlePasswordGrant (options: {
 
   const user = await getUser(usernameOrEmail, password, bypassLogin)
   if (!user) {
-    const registration = await UserRegistrationModel.loadByEmailOrUsername(usernameOrEmail)
+    const registrations = await UserRegistrationModel.listByEmailCaseInsensitiveOrUsername(usernameOrEmail)
 
-    if (registration?.state === UserRegistrationState.REJECTED) {
-      throw new RegistrationApprovalRejected('Registration approval for this account has been rejected')
-    } else if (registration?.state === UserRegistrationState.PENDING) {
-      throw new RegistrationWaitingForApproval('Registration for this account is awaiting approval')
+    if (registrations.length === 1) {
+      if (registrations[0].state === UserRegistrationState.REJECTED) {
+        throw new RegistrationApprovalRejected('Registration approval for this account has been rejected')
+      } else if (registrations[0].state === UserRegistrationState.PENDING) {
+        throw new RegistrationWaitingForApproval('Registration for this account is awaiting approval')
+      }
     }
 
     throw new InvalidGrantError('Invalid grant: user credentials are invalid')

--- a/server/core/lib/user.ts
+++ b/server/core/lib/user.ts
@@ -237,6 +237,12 @@ async function isUserQuotaValid (options: {
   return true
 }
 
+function getUserByEmailPermissive <T extends { email: string }> (users: T[], email: string): T {
+  if (users.length === 1) return users[0]
+
+  return users.find(r => r.email === email)
+}
+
 // ---------------------------------------------------------------------------
 
 export {
@@ -250,7 +256,8 @@ export {
   sendVerifyRegistrationEmail,
 
   isUserQuotaValid,
-  buildUser
+  buildUser,
+  getUserByEmailPermissive
 }
 
 // ---------------------------------------------------------------------------

--- a/server/core/middlewares/validators/shared/users.ts
+++ b/server/core/middlewares/validators/shared/users.ts
@@ -1,5 +1,6 @@
 import { forceNumber } from '@peertube/peertube-core-utils'
 import { HttpStatusCode, UserRightType } from '@peertube/peertube-models'
+import { getUserByEmailPermissive } from '@server/lib/user.js'
 import { ActorModel } from '@server/models/actor/actor.js'
 import { UserModel } from '@server/models/user/user.js'
 import { MAccountId, MUserAccountId, MUserDefault } from '@server/types/models/index.js'
@@ -10,8 +11,12 @@ export function checkUserIdExist (idArg: number | string, res: express.Response,
   return checkUserExist(() => UserModel.loadByIdWithChannels(id, withStats), res)
 }
 
-export function checkUserEmailExist (email: string, res: express.Response, abortResponse = true) {
-  return checkUserExist(() => UserModel.loadByEmail(email), res, abortResponse)
+export function checkUserEmailExistPermissive (email: string, res: express.Response, abortResponse = true) {
+  return checkUserExist(async () => {
+    const users = await UserModel.loadByEmailCaseInsensitive(email)
+
+    return getUserByEmailPermissive(users, email)
+  }, res, abortResponse)
 }
 
 export async function checkUserNameOrEmailDoNotAlreadyExist (username: string, email: string, res: express.Response) {

--- a/server/core/middlewares/validators/shared/users.ts
+++ b/server/core/middlewares/validators/shared/users.ts
@@ -20,9 +20,10 @@ export function checkUserEmailExistPermissive (email: string, res: express.Respo
 }
 
 export async function checkUserNameOrEmailDoNotAlreadyExist (username: string, email: string, res: express.Response) {
-  const user = await UserModel.loadByUsernameOrEmail(username, email)
+  const existingUser = await UserModel.loadByUsernameOrEmailCaseInsensitive(username)
+  const existingEmail = await UserModel.loadByUsernameOrEmailCaseInsensitive(email)
 
-  if (user) {
+  if (existingUser.length > 0 || existingEmail.length > 0) {
     res.fail({
       status: HttpStatusCode.CONFLICT_409,
       message: 'User with this username or email already exists.'

--- a/server/core/middlewares/validators/shared/users.ts
+++ b/server/core/middlewares/validators/shared/users.ts
@@ -19,7 +19,7 @@ export function checkUserEmailExistPermissive (email: string, res: express.Respo
   }, res, abortResponse)
 }
 
-export async function checkUserNameOrEmailDoNotAlreadyExist (username: string, email: string, res: express.Response) {
+export async function checkUsernameOrEmailDoNotAlreadyExist (username: string, email: string, res: express.Response) {
   const existingUser = await UserModel.loadByUsernameOrEmailCaseInsensitive(username)
   const existingEmail = await UserModel.loadByUsernameOrEmailCaseInsensitive(email)
 
@@ -36,6 +36,20 @@ export async function checkUserNameOrEmailDoNotAlreadyExist (username: string, e
     res.fail({
       status: HttpStatusCode.CONFLICT_409,
       message: 'Another actor (account/channel) with this name on this instance already exists or has already existed.'
+    })
+    return false
+  }
+
+  return true
+}
+
+export async function checkEmailDoesNotAlreadyExist (email: string, res: express.Response) {
+  const user = await UserModel.loadByEmailCaseInsensitive(email)
+
+  if (user.length !== 0) {
+    res.fail({
+      status: HttpStatusCode.CONFLICT_409,
+      message: 'User with this email already exists.'
     })
     return false
   }

--- a/server/core/middlewares/validators/users/shared/user-registrations.ts
+++ b/server/core/middlewares/validators/users/shared/user-registrations.ts
@@ -12,7 +12,7 @@ function checkRegistrationIdExist (idArg: number | string, res: express.Response
 
 function checkRegistrationEmailExistPermissive (email: string, res: express.Response, abortResponse = true) {
   return checkRegistrationExist(async () => {
-    const registrations = await UserRegistrationModel.loadByEmailCaseInsensitive(email)
+    const registrations = await UserRegistrationModel.listByEmailCaseInsensitive(email)
 
     return getUserByEmailPermissive(registrations, email)
   }, res, abortResponse)
@@ -26,9 +26,11 @@ async function checkRegistrationHandlesDoNotAlreadyExist (options: {
 }) {
   const { res } = options
 
-  const registration = await UserRegistrationModel.loadByEmailOrHandle(pick(options, [ 'username', 'email', 'channelHandle' ]))
+  const registrations = await UserRegistrationModel.listByEmailCaseInsensitiveOrHandle(
+    pick(options, [ 'username', 'email', 'channelHandle' ])
+  )
 
-  if (registration) {
+  if (registrations.length !== 0) {
     res.fail({
       status: HttpStatusCode.CONFLICT_409,
       message: 'Registration with this username, channel name or email already exists.'

--- a/server/core/middlewares/validators/users/user-email-verification.ts
+++ b/server/core/middlewares/validators/users/user-email-verification.ts
@@ -1,14 +1,14 @@
+import { HttpStatusCode } from '@peertube/peertube-models'
+import { toBooleanOrNull } from '@server/helpers/custom-validators/misc.js'
+import { Hooks } from '@server/lib/plugins/hooks.js'
 import express from 'express'
 import { body, param } from 'express-validator'
-import { toBooleanOrNull } from '@server/helpers/custom-validators/misc.js'
-import { HttpStatusCode } from '@peertube/peertube-models'
 import { logger } from '../../../helpers/logger.js'
 import { Redis } from '../../../lib/redis.js'
-import { areValidationErrors, checkUserEmailExist, checkUserIdExist } from '../shared/index.js'
-import { checkRegistrationEmailExist, checkRegistrationIdExist } from './shared/user-registrations.js'
-import { Hooks } from '@server/lib/plugins/hooks.js'
+import { areValidationErrors, checkUserEmailExistPermissive, checkUserIdExist } from '../shared/index.js'
+import { checkRegistrationEmailExistPermissive, checkRegistrationIdExist } from './shared/user-registrations.js'
 
-const usersAskSendVerifyEmailValidator = [
+export const usersAskSendVerifyEmailValidator = [
   body('email').isEmail().not().isEmpty().withMessage('Should have a valid email'),
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -19,8 +19,8 @@ const usersAskSendVerifyEmailValidator = [
     }, 'filter:api.email-verification.ask-send-verify-email.body')
 
     const [ userExists, registrationExists ] = await Promise.all([
-      checkUserEmailExist(email, res, false),
-      checkRegistrationEmailExist(email, res, false)
+      checkUserEmailExistPermissive(email, res, false),
+      checkRegistrationEmailExistPermissive(email, res, false)
     ])
 
     if (!userExists && !registrationExists) {
@@ -40,7 +40,7 @@ const usersAskSendVerifyEmailValidator = [
   }
 ]
 
-const usersVerifyEmailValidator = [
+export const usersVerifyEmailValidator = [
   param('id')
     .isInt().not().isEmpty().withMessage('Should have a valid id'),
 
@@ -67,7 +67,7 @@ const usersVerifyEmailValidator = [
 
 // ---------------------------------------------------------------------------
 
-const registrationVerifyEmailValidator = [
+export const registrationVerifyEmailValidator = [
   param('registrationId')
     .isInt().not().isEmpty().withMessage('Should have a valid registrationId'),
 
@@ -88,12 +88,3 @@ const registrationVerifyEmailValidator = [
     return next()
   }
 ]
-
-// ---------------------------------------------------------------------------
-
-export {
-  usersAskSendVerifyEmailValidator,
-  usersVerifyEmailValidator,
-
-  registrationVerifyEmailValidator
-}

--- a/server/core/middlewares/validators/users/user-registrations.ts
+++ b/server/core/middlewares/validators/users/user-registrations.ts
@@ -9,7 +9,7 @@ import { isUserDisplayNameValid, isUserPasswordValid, isUserUsernameValid } from
 import { isVideoChannelDisplayNameValid, isVideoChannelUsernameValid } from '../../../helpers/custom-validators/video-channels.js'
 import { isSignupAllowed, isSignupAllowedForCurrentIP, SignupMode } from '../../../lib/signup.js'
 import { ActorModel } from '../../../models/actor/actor.js'
-import { areValidationErrors, checkUserNameOrEmailDoNotAlreadyExist } from '../shared/index.js'
+import { areValidationErrors, checkUsernameOrEmailDoNotAlreadyExist } from '../shared/index.js'
 import { checkRegistrationHandlesDoNotAlreadyExist, checkRegistrationIdExist } from './shared/user-registrations.js'
 
 const usersDirectRegistrationValidator = usersCommonRegistrationValidatorFactory()
@@ -182,7 +182,7 @@ function usersCommonRegistrationValidatorFactory (additionalValidationChain: Val
 
       const body: UserRegister | UserRegistrationRequest = req.body
 
-      if (!await checkUserNameOrEmailDoNotAlreadyExist(body.username, body.email, res)) return
+      if (!await checkUsernameOrEmailDoNotAlreadyExist(body.username, body.email, res)) return
 
       if (body.channel) {
         if (!body.channel.name || !body.channel.displayName) {

--- a/server/core/middlewares/validators/users/users.ts
+++ b/server/core/middlewares/validators/users/users.ts
@@ -32,7 +32,7 @@ import { ActorModel } from '../../../models/actor/actor.js'
 import {
   areValidationErrors,
   checkUserCanManageAccount,
-  checkUserEmailExist,
+  checkUserEmailExistPermissive,
   checkUserIdExist,
   checkUserNameOrEmailDoNotAlreadyExist,
   doesVideoChannelIdExist,
@@ -339,7 +339,7 @@ export const usersAskResetPasswordValidator = [
       email: req.body.email
     }, 'filter:api.users.ask-reset-password.body')
 
-    const exists = await checkUserEmailExist(email, res, false)
+    const exists = await checkUserEmailExistPermissive(email, res, false)
     if (!exists) {
       logger.debug('User with email %s does not exist (asking reset password).', email)
       // Do not leak our emails

--- a/server/core/middlewares/validators/users/users.ts
+++ b/server/core/middlewares/validators/users/users.ts
@@ -31,10 +31,11 @@ import { Redis } from '../../../lib/redis.js'
 import { ActorModel } from '../../../models/actor/actor.js'
 import {
   areValidationErrors,
+  checkEmailDoesNotAlreadyExist,
   checkUserCanManageAccount,
   checkUserEmailExistPermissive,
   checkUserIdExist,
-  checkUserNameOrEmailDoNotAlreadyExist,
+  checkUsernameOrEmailDoNotAlreadyExist,
   doesVideoChannelIdExist,
   doesVideoExist,
   isValidVideoIdParam
@@ -85,7 +86,7 @@ export const usersAddValidator = [
 
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (areValidationErrors(req, res, { omitBodyLog: true })) return
-    if (!await checkUserNameOrEmailDoNotAlreadyExist(req.body.username, req.body.email, res)) return
+    if (!await checkUsernameOrEmailDoNotAlreadyExist(req.body.username, req.body.email, res)) return
 
     const authUser = res.locals.oauth.token.User
     if (authUser.role !== UserRole.ADMINISTRATOR && req.body.role !== UserRole.USER) {
@@ -199,6 +200,8 @@ export const usersUpdateValidator = [
       return res.fail({ message: 'Cannot change root role.' })
     }
 
+    if (req.body.email && !await checkEmailDoesNotAlreadyExist(req.body.email, res)) return
+
     return next()
   }
 ]
@@ -277,6 +280,8 @@ export const usersUpdateMeValidator = [
     }
 
     if (areValidationErrors(req, res, { omitBodyLog: true })) return
+
+    if (req.body.email && !await checkEmailDoesNotAlreadyExist(req.body.email, res)) return
 
     return next()
   }

--- a/server/core/models/user/user-registration.ts
+++ b/server/core/models/user/user-registration.ts
@@ -8,7 +8,7 @@ import { isVideoChannelDisplayNameValid } from '@server/helpers/custom-validator
 import { cryptPassword } from '@server/helpers/peertube-crypto.js'
 import { USER_REGISTRATION_STATES } from '@server/initializers/constants.js'
 import { MRegistration, MRegistrationFormattable } from '@server/types/models/index.js'
-import { FindOptions, Op, QueryTypes, WhereOptions } from 'sequelize'
+import { col, FindOptions, fn, Op, QueryTypes, where, WhereOptions } from 'sequelize'
 import {
   AllowNull,
   BeforeCreate,
@@ -129,12 +129,16 @@ export class UserRegistrationModel extends SequelizeModel<UserRegistrationModel>
     return UserRegistrationModel.findByPk(id)
   }
 
-  static loadByEmail (email: string): Promise<MRegistration> {
+  static loadByEmailCaseInsensitive (email: string): Promise<MRegistration[]> {
     const query = {
-      where: { email }
+      where: where(
+        fn('LOWER', col('email')),
+        '=',
+        email.toLowerCase()
+      )
     }
 
-    return UserRegistrationModel.findOne(query)
+    return UserRegistrationModel.findAll(query)
   }
 
   static loadByEmailOrUsername (emailOrUsername: string): Promise<MRegistration> {

--- a/server/core/models/user/user-registration.ts
+++ b/server/core/models/user/user-registration.ts
@@ -129,7 +129,7 @@ export class UserRegistrationModel extends SequelizeModel<UserRegistrationModel>
     return UserRegistrationModel.findByPk(id)
   }
 
-  static loadByEmailCaseInsensitive (email: string): Promise<MRegistration[]> {
+  static listByEmailCaseInsensitive (email: string): Promise<MRegistration[]> {
     const query = {
       where: where(
         fn('LOWER', col('email')),
@@ -141,28 +141,37 @@ export class UserRegistrationModel extends SequelizeModel<UserRegistrationModel>
     return UserRegistrationModel.findAll(query)
   }
 
-  static loadByEmailOrUsername (emailOrUsername: string): Promise<MRegistration> {
+  static listByEmailCaseInsensitiveOrUsername (emailOrUsername: string): Promise<MRegistration[]> {
     const query = {
       where: {
         [Op.or]: [
-          { email: emailOrUsername },
+          where(
+            fn('LOWER', col('email')),
+            '=',
+            emailOrUsername.toLowerCase()
+          ),
+
           { username: emailOrUsername }
         ]
       }
     }
 
-    return UserRegistrationModel.findOne(query)
+    return UserRegistrationModel.findAll(query)
   }
 
-  static loadByEmailOrHandle (options: {
+  static listByEmailCaseInsensitiveOrHandle (options: {
     email: string
     username: string
     channelHandle?: string
-  }): Promise<MRegistration> {
+  }): Promise<MRegistration[]> {
     const { email, username, channelHandle } = options
 
     let or: WhereOptions = [
-      { email },
+      where(
+        fn('LOWER', col('email')),
+        '=',
+        email.toLowerCase()
+      ),
       { channelHandle: username },
       { username }
     ]
@@ -180,7 +189,7 @@ export class UserRegistrationModel extends SequelizeModel<UserRegistrationModel>
       }
     }
 
-    return UserRegistrationModel.findOne(query)
+    return UserRegistrationModel.findAll(query)
   }
 
   // ---------------------------------------------------------------------------

--- a/server/core/models/user/user.ts
+++ b/server/core/models/user/user.ts
@@ -701,6 +701,20 @@ export class UserModel extends SequelizeModel<UserModel> {
     return UserModel.findOne(query)
   }
 
+  static loadByUsernameOrEmailCaseInsensitive (usernameOrEmail: string): Promise<MUserDefault[]> {
+    const query = {
+      where: {
+        [Op.or]: [
+          where(fn('lower', col('username')), fn('lower', usernameOrEmail) as any),
+
+          where(fn('lower', col('email')), fn('lower', usernameOrEmail) as any)
+        ]
+      }
+    }
+
+    return UserModel.findAll(query)
+  }
+
   static loadByVideoId (videoId: number): Promise<MUserDefault> {
     const query = {
       include: [

--- a/server/core/models/user/user.ts
+++ b/server/core/models/user/user.ts
@@ -673,6 +673,18 @@ export class UserModel extends SequelizeModel<UserModel> {
     return UserModel.findOne(query)
   }
 
+  static loadByEmailCaseInsensitive (email: string): Promise<MUserDefault[]> {
+    const query = {
+      where: where(
+        fn('LOWER', col('email')),
+        '=',
+        email.toLowerCase()
+      )
+    }
+
+    return UserModel.findAll(query)
+  }
+
   static loadByUsernameOrEmail (username: string, email?: string): Promise<MUserDefault> {
     if (!email) email = username
 

--- a/server/core/models/user/user.ts
+++ b/server/core/models/user/user.ts
@@ -663,16 +663,6 @@ export class UserModel extends SequelizeModel<UserModel> {
     return UserModel.scope(ScopeNames.FOR_ME_API).findOne(query)
   }
 
-  static loadByEmail (email: string): Promise<MUserDefault> {
-    const query = {
-      where: {
-        email
-      }
-    }
-
-    return UserModel.findOne(query)
-  }
-
   static loadByEmailCaseInsensitive (email: string): Promise<MUserDefault[]> {
     const query = {
       where: where(
@@ -683,22 +673,6 @@ export class UserModel extends SequelizeModel<UserModel> {
     }
 
     return UserModel.findAll(query)
-  }
-
-  static loadByUsernameOrEmail (username: string, email?: string): Promise<MUserDefault> {
-    if (!email) email = username
-
-    const query = {
-      where: {
-        [Op.or]: [
-          where(fn('lower', col('username')), fn('lower', username) as any),
-
-          { email }
-        ]
-      }
-    }
-
-    return UserModel.findOne(query)
   }
 
   static loadByUsernameOrEmailCaseInsensitive (usernameOrEmail: string): Promise<MUserDefault[]> {


### PR DESCRIPTION
## Description
In order to not force users to be case sensitive when asking for password reset or resend email verification. When there's multiple emails where the only difference in the local is the capitalized letters, in those cases the users has to be case sensitive.

- [x] When a user tries to login: fetch all emails in the database case insensitive. If there's only one match, then treat it as the correct email even if they differ in capitalized letters.
- [x] When a user tries to reset password: fetch all emails in the database case insensitive. If there's only one match, then treat it as the correct email even if they differ in capitalized letters.
- [x] When a user tries to get a new verification email: fetch all emails in the database case insensitive. If there's only one match, then treat it as the correct email even if they differ in capitalized letters.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #6570


<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
