### PR TITLE
Update peertube-player.ts

### DIFF
--- a/client/src/assets/player/peertube-player.ts
+++ b/client/src/assets/player/peertube-player.ts
@@ -424,7 +424,7 @@ export class PeerTubePlayer {
 
       poster: this.currentLoadOptions.poster,
       inactivityTimeout: this.options.inactivityTimeout,
-      playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2 ],
+      playbackRates: [ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2 ],
 
       plugins,
 

--- a/client/src/assets/player/peertube-player.ts
+++ b/client/src/assets/player/peertube-player.ts
@@ -424,7 +424,7 @@ export class PeerTubePlayer {
 
       poster: this.currentLoadOptions.poster,
       inactivityTimeout: this.options.inactivityTimeout,
-      playbackRates: [ 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2 ],
+      playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2 ],
 
       plugins,
 


### PR DESCRIPTION
Added 0.25x playback option
Fixed issue : #6743 
## Description
Created the 0.25x speed option for video playback

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
