### PR TITLE
Add the ability to specify peertube UID and GID via environment variables

### DIFF
--- a/support/docker/production/Dockerfile.bookworm
+++ b/support/docker/production/Dockerfile.bookworm
@@ -8,9 +8,18 @@ RUN apt update \
  && gosu nobody true \
  && rm /var/lib/apt/lists/* -fR
 
+# Node images hardcode the node uid to 1000 so that number is not available.
+# The "peertube" user is created as a system account which selects a UID from 
+# the range of SYS_UID_MIN to SYS_UID_MAX (-1 to 1000] and consistently
+# selects 999 given the current image build steps. The same is true for the
+# system group range SYS_GID_MIN and SYS_GID_MAX. It is fine to manually assign
+# them an ID outside of that range.
+DEFAULT_PEERTUBE_UID=999
+DEFAULT_PEERTUBE_GID=999
+
 # Add peertube user
-RUN groupadd -r peertube \
-    && useradd -r -g peertube -m peertube
+RUN groupadd -r -g ${PEERTUBE_GID:-${DEFAULT_PEERTUBE_GID}} peertube \
+    && useradd -r -u ${PEERTUBE_UID:-${DEFAULT_PEERTUBE_UID}} -g peertube -m peertube
 
 # Install PeerTube
 COPY --chown=peertube:peertube . /app


### PR DESCRIPTION
## Description

This adds support for specifying the peertube user and group IDs using the standard environment variable pattern similar to linuxserver.io images.  This allows for better external permission management, specifically this makes it easier to support mapping volumes to NFS shares using nfs4 id mapping.

This changes elects *not* to use the linuxserver.io variable names of PUID and PGID since the peertube container ends up having both a "node" and "peertube" user created and it would not be obvious which of those PUID/PGID should apply to.

New variables are `PEERTUBE_UID` and `PEERTUBE_GID` respectively.

## Related issues

[Existing feature request that was closed due to inactivity
](https://github.com/Chocobozzz/PeerTube/issues/2424)

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
