### PR TITLE
fix(plugins/hooks): call user delete upon delete me

### DIFF
--- a/packages/tests/src/plugins/action-hooks.ts
+++ b/packages/tests/src/plugins/action-hooks.ts
@@ -230,6 +230,13 @@ describe('Test plugin action hooks', function () {
 
       await checkHook('action:api.user.deleted')
     })
+
+    it('Should run action:api.user.deleted upon delete me', async function () {
+      const token = await servers[0].users.generateUserAndToken('delete_me_user')
+      await servers[0].users.deleteMe({ token })
+
+      await checkHook('action:api.user.deleted', true, 2)
+    })
   })
 
   describe('Playlist hooks', function () {

--- a/server/core/controllers/api/users/me.ts
+++ b/server/core/controllers/api/users/me.ts
@@ -244,6 +244,8 @@ async function deleteMe (req: express.Request, res: express.Response) {
 
   await user.destroy()
 
+  Hooks.runAction('action:api.user.deleted', { user, req, res })
+
   return res.status(HttpStatusCode.NO_CONTENT_204).end()
 }
 


### PR DESCRIPTION
## Description
Call `action:api.user.deleted` upon `DELETE /me`.

<!-- Please include a summary of the change, with motivation and context -->

## Related issues
closes #6859


<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
