### PR TITLE
add filter:email.template-path.result / filter:email.subject.result

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
     "@types/multer": "^1.3.3",
     "@types/node": "^18.13.0",
     "@types/nodemailer": "^6.2.0",
+    "@types/pug": "^2.0.10",
     "@types/supertest": "^6.0.2",
     "@types/validator": "^13.9.0",
     "@types/webtorrent": "^0.109.0",

--- a/packages/models/src/plugins/server/server-hook.model.ts
+++ b/packages/models/src/plugins/server/server-hook.model.ts
@@ -145,7 +145,11 @@ export const serverFilterHookObject = {
   // Peertube >= 7.1
   'filter:oauth.password-grant.get-user.params': true,
   'filter:api.email-verification.ask-send-verify-email.body': true,
-  'filter:api.users.ask-reset-password.body': true
+  'filter:api.users.ask-reset-password.body': true,
+
+  // Peertube >= 7.2
+  'filter:email.subject.result': true,
+  'filter:email.template-path.result': true
 }
 
 export type ServerFilterHookName = keyof typeof serverFilterHookObject

--- a/packages/tests/fixtures/peertube-plugin-test/emails/password-reset.pug
+++ b/packages/tests/fixtures/peertube-plugin-test/emails/password-reset.pug
@@ -1,0 +1,1 @@
+p Custom password reset email

--- a/packages/tests/fixtures/peertube-plugin-test/main.js
+++ b/packages/tests/fixtures/peertube-plugin-test/main.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 async function register ({ registerHook, registerSetting, settingsManager, storageManager, peertubeHelpers }) {
   {
     registerSetting({
@@ -442,6 +444,28 @@ async function register ({ registerHook, registerSetting, settingsManager, stora
       }
 
       return object
+    }
+  })
+
+  registerHook({
+    target: 'filter:email.template-path.result',
+    handler: (templatePath, { view }) => {
+      if (view === 'password-reset/html') {
+        return path.join(__dirname, 'emails', 'password-reset.pug')
+      }
+
+      return templatePath
+    }
+  })
+
+  registerHook({
+    target: 'filter:email.subject.result',
+    handler: (subject, { template }) => {
+      if (template === 'password-reset') {
+        return 'Custom subject'
+      }
+
+      return subject
     }
   })
 

--- a/packages/tests/src/plugins/filter-hooks.ts
+++ b/packages/tests/src/plugins/filter-hooks.ts
@@ -11,6 +11,7 @@ import {
   VideoPrivacy
 } from '@peertube/peertube-models'
 import {
+  ConfigCommand,
   PeerTubeServer,
   PluginsCommand,
   cleanupTests,
@@ -26,6 +27,7 @@ import {
 import { expectEndWith } from '@tests/shared/checks.js'
 import { expect } from 'chai'
 import { FIXTURE_URLS } from '../shared/fixture-urls.js'
+import { MockSmtpServer } from '@tests/shared/mock-servers/index.js'
 
 describe('Test plugin filter hooks', function () {
   let servers: PeerTubeServer[]
@@ -33,11 +35,13 @@ describe('Test plugin filter hooks', function () {
   let threadId: number
   let videoPlaylistUUID: string
   let importUserToken: string
+  const emails: object[] = []
 
   before(async function () {
     this.timeout(120000)
 
-    servers = await createMultipleServers(2)
+    const emailPort = await MockSmtpServer.Instance.collectEmails(emails)
+    servers = await createMultipleServers(2, ConfigCommand.getEmailOverrideConfig(emailPort))
     await setAccessTokensToServers(servers)
     await setDefaultVideoChannel(servers)
     await doubleFollow(servers[0], servers[1])
@@ -928,6 +932,40 @@ describe('Test plugin filter hooks', function () {
       const { body } = await makeActivityPubGetRequest(servers[0].url, '/w/' + videoUUID)
       expect(body.name).to.equal('default video 0')
       expect(body.videoName).to.equal('default video 0')
+    })
+  })
+
+  describe('Emails', function () {
+    let server: PeerTubeServer
+    const emailAddress = 'plugin-admin@example.com'
+
+    before(async function () {
+      server = servers[0]
+      await server.users.create({ username: 'plugin-admin', email: emailAddress })
+    })
+
+    it('Should run filter:email.template-path.result', async function () {
+      const preEmailCount = emails.length
+      await server.users.askResetPassword({ email: emailAddress })
+
+      await waitJobs(server)
+      expect(emails).to.have.lengthOf(preEmailCount + 1)
+
+      const email = emails[preEmailCount]
+
+      expect(email['html']).to.contain('Custom password reset email')
+    })
+
+    it('Should run filter:email.subject.result', async function () {
+      const preEmailCount = emails.length
+      await server.users.askResetPassword({ email: emailAddress })
+
+      await waitJobs(server)
+      expect(emails).to.have.lengthOf(preEmailCount + 1)
+
+      const email = emails[preEmailCount]
+
+      expect(email['subject']).to.contain('Custom subject')
     })
   })
 

--- a/packages/tests/src/plugins/filter-hooks.ts
+++ b/packages/tests/src/plugins/filter-hooks.ts
@@ -970,6 +970,8 @@ describe('Test plugin filter hooks', function () {
   })
 
   after(async function () {
+    MockSmtpServer.Instance.kill()
+
     await cleanupTests(servers)
   })
 })

--- a/server/core/lib/emailer.ts
+++ b/server/core/lib/emailer.ts
@@ -271,9 +271,8 @@ class Emailer {
           { view }
         )
         const compiledTemplate = pug.compileFile(templatePath)
-        const html = await email.juiceResources(compiledTemplate(locals))
 
-        return html
+        return compiledTemplate(locals)
       },
       message: {
         from: `"${fromDisplayName}" <${CONFIG.SMTP.FROM_ADDRESS}>`

--- a/server/core/lib/emailer.ts
+++ b/server/core/lib/emailer.ts
@@ -6,11 +6,13 @@ import { readFileSync } from 'fs'
 import merge from 'lodash-es/merge.js'
 import { Transporter, createTransport } from 'nodemailer'
 import { join } from 'path'
+import pug from 'pug'
 import { bunyanLogger, logger } from '../helpers/logger.js'
 import { CONFIG, isEmailEnabled } from '../initializers/config.js'
 import { WEBSERVER } from '../initializers/constants.js'
 import { MRegistration, MUser, MUserExport, MUserImport } from '../types/models/index.js'
 import { JobQueue } from './job-queue/index.js'
+import { Hooks } from './plugins/hooks.js'
 
 class Emailer {
 
@@ -260,15 +262,30 @@ class Emailer {
           { selector: 'a', options: { hideLinkHrefIfSameAsText: true } }
         ]
       },
+      render: async (view: string, locals: Record<string, string>) => {
+        if (view.split('/').pop() !== 'html') return undefined
+
+        const templatePath = await Hooks.wrapObject(
+          join(root(), 'dist', 'core', 'assets', 'email-templates', view + '.pug'),
+          'filter:email.template-path.result',
+          { view }
+        )
+        const compiledTemplate = pug.compileFile(templatePath)
+        const html = await email.juiceResources(compiledTemplate(locals))
+
+        return html
+      },
       message: {
         from: `"${fromDisplayName}" <${CONFIG.SMTP.FROM_ADDRESS}>`
       },
       transport: this.transporter,
-      views: {
-        root: join(root(), 'dist', 'core', 'assets', 'email-templates')
-      },
       subjectPrefix: CONFIG.EMAIL.SUBJECT.PREFIX
     })
+    const subject = await Hooks.wrapObject(
+      options.subject,
+      'filter:email.subject.result',
+      { template: 'template' in options ? options.template : undefined }
+    )
 
     const toEmails = arrayify(options.to)
 
@@ -280,7 +297,7 @@ class Emailer {
         message: {
           to,
           from: options.from,
-          subject: options.subject,
+          subject,
           replyTo: options.replyTo
         },
         locals: { // default variables available in all templates
@@ -288,7 +305,7 @@ class Emailer {
           EMAIL: CONFIG.EMAIL,
           instanceName: CONFIG.INSTANCE.NAME,
           text: options.text,
-          subject: options.subject
+          subject
         }
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,6 +2910,11 @@
     pg-protocol "*"
     pg-types "^2.2.0"
 
+"@types/pug@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.10.tgz#52f8dbd6113517aef901db20b4f3fca543b88c1f"
+  integrity sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==
+
 "@types/qs@*":
   version "6.9.18"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.18.tgz#877292caa91f7c1b213032b34626505b746624c2"


### PR DESCRIPTION
## Description
Add `filter:email.template-path.result` / `filter:email.subject.result` in order to get plugins ability to customize emails sent from Peertube.

## Related issues
closes #3392

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
