### PR TITLE
fix: plugin/theme names with scope are not allowed

### DIFF
--- a/server/core/helpers/custom-validators/plugins.ts
+++ b/server/core/helpers/custom-validators/plugins.ts
@@ -6,6 +6,10 @@ import { exists, isArray, isSafePath } from './misc.js'
 
 const PLUGINS_CONSTRAINTS_FIELDS = CONSTRAINTS_FIELDS.PLUGINS
 
+const NPM_VALIDATION_RE = new RegExp(
+	/^(@[^\._][a-z-_\.~0-9]+\/)?([a-z-0-9]+)$/,
+);
+
 function isPluginTypeValid (value: any) {
   return exists(value) &&
     (value === PluginType.PLUGIN || value === PluginType.THEME)
@@ -14,14 +18,16 @@ function isPluginTypeValid (value: any) {
 function isPluginNameValid (value: string) {
   return exists(value) &&
     validator.default.isLength(value, PLUGINS_CONSTRAINTS_FIELDS.NAME) &&
-    validator.default.matches(value, /^[a-z-0-9]+$/)
+    validator.default.matches(value, NPM_VALIDATION_RE)
 }
 
 function isNpmPluginNameValid (value: string) {
+  const match = value.match(NPM_VALIDATION_RE);
   return exists(value) &&
     validator.default.isLength(value, PLUGINS_CONSTRAINTS_FIELDS.NAME) &&
-    validator.default.matches(value, /^[a-z\-._0-9]+$/) &&
-    (value.startsWith('peertube-plugin-') || value.startsWith('peertube-theme-'))
+    validator.default.matches(value, NPM_VALIDATION_RE) &&
+    (match[2].startsWith("peertube-plugin-") ||
+      match[2].startsWith("peertube-theme-"))
 }
 
 function isPluginDescriptionValid (value: string) {


### PR DESCRIPTION
## Description

This PR make validating plugin/theme names with scopes (`@org-name/peertube-plugin-...`) succeed.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/6881

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [X] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [X] 🙋 no, because I need help as the name gets rejected by https://packages.joinpeertube.org afterwards

 
