### PR TITLE
server: hide meta duration when duration is 0

### DIFF
--- a/server/core/lib/html/shared/video-html.ts
+++ b/server/core/lib/html/shared/video-html.ts
@@ -96,7 +96,7 @@ export class VideoHtml {
       ? {
         url: WEBSERVER.URL + video.getEmbedStaticPath(),
         createdAt: video.createdAt.toISOString(),
-        duration: getActivityStreamDuration(video.duration),
+        duration: video.duration ? getActivityStreamDuration(video.duration) : undefined,
         views: video.views
       }
       : undefined


### PR DESCRIPTION
## Description
Currently Google Search Console reports issue with `Value for property duration must be positive` for permanent lives where the duration value is `PT0S`. This PR will hide the duration property when the duration is falsy.