### PR TITLE
Fix header hit box

### DIFF
--- a/client/src/app/header/header.component.scss
+++ b/client/src/app/header/header.component.scss
@@ -41,7 +41,7 @@
 .peertube-title {
   flex-shrink: 1;
   min-width: var(--co-logo-size);
-  flex-grow: 1;
+  flex-grow: 0;
   font-size: 24px;
   font-weight: $font-bold;
   color: inherit !important;
@@ -50,7 +50,8 @@
   min-height: 46px; // Prevent layout shifting when waiting for the right part of the header to load
 
   @include padding-left(18px);
-  @include margin-right(0.5rem);
+  @include padding-right(0.5rem);
+  @include margin-right(auto);
   @include disable-default-a-behaviour;
 }
 


### PR DESCRIPTION
## Description

Hitbox of logo + title `<a>` link is too large

This is how it is currently:
![Screenshot 2025-03-06 at 10 07 03](https://github.com/user-attachments/assets/bc3b4fdd-b476-448b-acb6-66e4cb8d5093)

This fix changes it to so:
![Screenshot 2025-03-06 at 10 06 42](https://github.com/user-attachments/assets/0420d0e5-13d2-4c06-b533-ea29d2a8c4b6)




## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help: I edited a live instance and saved the changes (for such a small fix I thought it wouldn't be necessary)

