### PR TITLE
feat (docker): Expose NGINX logs folder.

### DIFF
--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ./docker-volume/data:/var/www/peertube/storage
       - certbot-www:/var/www/certbot
       - ./docker-volume/certbot/conf:/etc/letsencrypt
+      - ./docker-volume/nginx/logs:/var/log/nginx
     depends_on:
       - peertube
     restart: "always"

--- a/support/docker/production/docker-compose.yml
+++ b/support/docker/production/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ./docker-volume/data:/var/www/peertube/storage
       - certbot-www:/var/www/certbot
       - ./docker-volume/certbot/conf:/etc/letsencrypt
-      - ./docker-volume/nginx/logs:/var/log/nginx
+      - ./docker-volume/nginx-logs:/var/log/nginx
     depends_on:
       - peertube
     restart: "always"


### PR DESCRIPTION
This commit adds the folder /var/log/ngnix of the webserver container to the volume mount.

## Description

This commit adds the folder /var/log/ngnix of the webserver container to the volume mount. The motivation to add this change is to make it easier for the users to extract logs when asked.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
