### PR TITLE
Add Drag-and-Drop to Replace File

### DIFF
--- a/client/src/app/+videos-publish-manage/shared-manage/common/video-manage-page-common.scss
+++ b/client/src/app/+videos-publish-manage/shared-manage/common/video-manage-page-common.scss
@@ -75,6 +75,10 @@ p-calendar {
   }
 }
 
+.dragover {
+    border: 3px dashed pvar(--primary);
+}
+
 .plugin-fields {
   display: flex;
   flex-wrap: wrap;

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.html
@@ -1,39 +1,42 @@
-<h2>
-  <my-global-icon iconName="upload"></my-global-icon>
+<div myDragDrop (fileDropped)="onFileDropped($event)">
+	<h2>
+		<my-global-icon iconName="upload"></my-global-icon>
 
-  <ng-container i18n>Replace file</ng-container>
-</h2>
+		<ng-container i18n>Replace file</ng-container>
+	</h2>
 
-@if (getUnavailability()) {
-  <my-alert type="primary" i18n>{{ getUnavailability() }}</my-alert>
-} @else {
-  <div [formGroup]="form">
-    <div class="form-columns reverse">
-      <div>
-        <div *ngIf="videoEdit.getVideoSource()" class="form-group">
-          <label i18n for="filename">Current uploaded file</label>
+	@if (getUnavailability()) {
+		<my-alert type="primary" i18n>{{ getUnavailability() }}</my-alert>
+	} @else {
+		<div [formGroup]="form">
+			<div class="form-columns reverse">
+				<div>
+					<div *ngIf="videoEdit.getVideoSource()" class="form-group">
+						<label i18n for="filename">Current uploaded file</label>
 
-          <input type="text" [disabled]="true" id="filename" class="form-control" [value]="videoEdit.getVideoSource().filename" />
-        </div>
-      </div>
+						<input type="text" [disabled]="true" id="filename" class="form-control" [value]="videoEdit.getVideoSource().filename" />
+					</div>
+				</div>
 
-      <div>
-        <div class="form-group">
-          <label i18n for="videofile">Replace video file</label>
+				<div>
+					<div class="form-group">
+						<label i18n for="videofile">Replace video file</label>
 
-          <div i18n class="form-group-description">⚠️ Uploading a new version of your video will completely erase the current version</div>
+						<div i18n class="form-group-description">⚠️ Uploading a new version of your video will completely erase the current version</div>
 
-          <div>
-            <my-reactive-file
-              formControlName="replaceFile"
-              i18n-inputLabel inputLabel="Select the file to upload"
-              inputName="videofile" [extensions]="getVideoExtensions()" [displayFilename]="true" [displayReset]="true"
-              [buttonTooltip]="'(extensions: ' + getVideoExtensions() + ')'"
-              theme="primary"
-            ></my-reactive-file>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-}
+						<div>
+							<my-reactive-file
+								#reactiveFileInput
+								formControlName="replaceFile"
+								i18n-inputLabel inputLabel="Select the file to upload"
+								inputName="videofile" [extensions]="getVideoExtensions()" [displayFilename]="true" [displayReset]="true"
+								[buttonTooltip]="'(extensions: ' + getVideoExtensions() + ')'"
+								theme="primary"
+							></my-reactive-file>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	}
+</div>

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.html
@@ -1,42 +1,41 @@
-<div myDragDrop (fileDropped)="onFileDropped($event)">
-	<h2>
-		<my-global-icon iconName="upload"></my-global-icon>
+<h2 class="replace-title">
+    <my-global-icon iconName="upload"></my-global-icon>
 
-		<ng-container i18n>Replace file</ng-container>
-	</h2>
+    <ng-container i18n>Replace file</ng-container>
+</h2>
+<div class="root" myDragDrop (fileDropped)="onFileDropped($event)">
 
-	@if (getUnavailability()) {
-		<my-alert type="primary" i18n>{{ getUnavailability() }}</my-alert>
-	} @else {
-		<div [formGroup]="form">
-			<div class="form-columns reverse">
-				<div>
-					<div *ngIf="videoEdit.getVideoSource()" class="form-group">
-						<label i18n for="filename">Current uploaded file</label>
+    @if (getUnavailability()) {
+    <my-alert type="primary" i18n>{{ getUnavailability() }}</my-alert>
+    } @else {
+    <div class="current-filename-container">
 
-						<input type="text" [disabled]="true" id="filename" class="form-control" [value]="videoEdit.getVideoSource().filename" />
-					</div>
-				</div>
+        <strong id="filename">{{ videoEdit.getVideoSource().filename }}</strong>
 
-				<div>
-					<div class="form-group">
-						<label i18n for="videofile">Replace video file</label>
+        <label i18n for="filename">Current uploaded file</label>
 
-						<div i18n class="form-group-description">⚠️ Uploading a new version of your video will completely erase the current version</div>
+    </div>
 
-						<div>
-							<my-reactive-file
-								#reactiveFileInput
-								formControlName="replaceFile"
-								i18n-inputLabel inputLabel="Select the file to upload"
-								inputName="videofile" [extensions]="getVideoExtensions()" [displayFilename]="true" [displayReset]="true"
-								[buttonTooltip]="'(extensions: ' + getVideoExtensions() + ')'"
-								theme="primary"
-							></my-reactive-file>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	}
+    <div class="mt-3">
+        <div class="muted-1">
+            <strong>Drag and drop your new video file here</strong> or click on the button below to replace your video:
+        </div>
+
+        <div class="muted-2 fs-7">
+            <div i18n class="form-group-description">⚠️ Uploading a new version of your video will completely erase the current version</div>
+        </div>
+
+        <div class="d-flex flex-wrap mt-4 justify-content-center gap-3">
+            <my-reactive-file
+                #reactiveFileInput 
+                class="d-inline-block me-3" 
+                inputName="videoFile" 
+                i18n-inputLabel inputLabel="Upload" 
+                (fileChanged)="onFileChanged($event)"
+                [extensions]="getVideoExtensions()" [displayFilename]="true" [displayReset]="false"
+                placement="right" theme="secondary" icon="upload">
+            </my-reactive-file>
+        </div>
+    </div>
+    }
 </div>

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.html
@@ -1,41 +1,34 @@
-<h2 class="replace-title">
-    <my-global-icon iconName="upload"></my-global-icon>
+<h2>
+  <my-global-icon iconName="upload"></my-global-icon>
 
-    <ng-container i18n>Replace file</ng-container>
+  <ng-container i18n>Replace file</ng-container>
 </h2>
-<div class="root" myDragDrop (fileDropped)="onFileDropped($event)">
 
-    @if (getUnavailability()) {
-    <my-alert type="primary" i18n>{{ getUnavailability() }}</my-alert>
-    } @else {
-    <div class="current-filename-container">
+@if (getUnavailability()) {
+  <my-alert type="primary" i18n>{{ getUnavailability() }}</my-alert>
+} @else {
+  <div class="root" myDragDrop (fileDropped)="onFileDropped($event)">
+    <div class="current-filename">
+      <div class="fs-7" i18n>Current uploaded file:</div>
 
-        <strong id="filename">{{ videoEdit.getVideoSource().filename }}</strong>
-
-        <label i18n for="filename">Current uploaded file</label>
-
+      <strong class="fs-5">{{ videoEdit.getVideoSource().filename }}</strong>
     </div>
 
     <div class="mt-3">
-        <div class="muted-1">
-            <strong>Drag and drop your new video file here</strong> or click on the button below to replace your video:
-        </div>
+      <div class="muted-1">
+        <strong>Drag and drop your new video file here</strong> or click on the button below to replace your video:
+      </div>
 
-        <div class="muted-2 fs-7">
-            <div i18n class="form-group-description">⚠️ Uploading a new version of your video will completely erase the current version</div>
-        </div>
+      <div class="muted-2 fs-7">
+        <div i18n class="form-group-description">⚠️ Uploading a new version of your video will completely erase the current version</div>
+      </div>
 
-        <div class="d-flex flex-wrap mt-4 justify-content-center gap-3">
-            <my-reactive-file
-                #reactiveFileInput 
-                class="d-inline-block me-3" 
-                inputName="videoFile" 
-                i18n-inputLabel inputLabel="Upload" 
-                (fileChanged)="onFileChanged($event)"
-                [extensions]="getVideoExtensions()" [displayFilename]="true" [displayReset]="false"
-                placement="right" theme="secondary" icon="upload">
-            </my-reactive-file>
-        </div>
+      <div class="d-flex flex-wrap mt-4 justify-content-center gap-3">
+        <my-reactive-file #reactiveFileInput class="d-inline-block me-3" inputName="videoFile" i18n-inputLabel
+          inputLabel="Upload" (fileChanged)="onFileChanged($event)" [extensions]="getVideoExtensions()"
+          [displayFilename]="true" [displayReset]="false" placement="right" theme="secondary" icon="upload">
+        </my-reactive-file>
+      </div>
     </div>
-    }
-</div>
+  </div>
+}

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.scss
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.scss
@@ -1,0 +1,94 @@
+@use 'sass:math';
+@use '_variables' as *;
+@use '_mixins' as *;
+@use '_form-mixins' as *;
+
+h2 {
+    font-weight: $font-bold;
+    color: pvar(--fg-350);
+    line-height: 1;
+  
+    @include font-size(2rem);
+    @include rfs(2rem, margin-bottom);
+  
+    my-global-icon {
+      @include global-icon-size(28px);
+      @include margin-right(0.5rem);
+    }
+  
+    @include on-small-main-col {
+      text-align: center;
+    }
+  }
+
+  .current-filename-container {
+    text-align: center;
+    margin-top: 1.5rem;
+  
+    strong {
+      display: block;
+      font-size: 1.1rem;
+    }
+  
+    label {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.9rem;
+    }
+  }
+
+  .root {
+    min-height: 260px;
+    text-align: center;
+    padding: 2rem 1.5rem;
+    border-radius: 4px;
+    border: 1px dashed pvar(--secondary-icon-color);
+  
+    @include on-mobile-main-col {
+      border: 0;
+    }
+  }
+
+my-embed {
+  max-width: 500px;
+  width: 500px;
+
+  max-height: 280px;
+  height: 280px;
+}
+
+.root.dragover {
+  background-color: pvar(--bg-secondary-400);
+  border-color: pvar(--primary);
+
+  .no-image {
+    color: pvar(--primary);
+  }
+}
+
+.form-columns {
+    display: grid;
+    grid-template-columns: fit-content(66%) 1fr;
+  
+    @include rfs(40px, grid-gap);
+  
+    &.disabled {
+      opacity: 0.6;
+      pointer-events: none;
+    }
+  
+    &.reverse {
+      > *:nth-child(1) {
+        order: 1;
+      }
+  
+      > *:nth-child(2) {
+        order: -1;
+      }
+    }
+  
+    @media screen and (max-width: $medium-view) {
+      grid-template-columns: minmax(0, 1fr);
+    }
+}
+

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.scss
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.scss
@@ -3,92 +3,24 @@
 @use '_mixins' as *;
 @use '_form-mixins' as *;
 
-h2 {
-    font-weight: $font-bold;
-    color: pvar(--fg-350);
-    line-height: 1;
-  
-    @include font-size(2rem);
-    @include rfs(2rem, margin-bottom);
-  
-    my-global-icon {
-      @include global-icon-size(28px);
-      @include margin-right(0.5rem);
-    }
-  
-    @include on-small-main-col {
-      text-align: center;
-    }
-  }
-
-  .current-filename-container {
-    text-align: center;
-    margin-top: 1.5rem;
-  
-    strong {
-      display: block;
-      font-size: 1.1rem;
-    }
-  
-    label {
-      display: block;
-      margin-top: 0.25rem;
-      font-size: 0.9rem;
-    }
-  }
-
-  .root {
-    min-height: 260px;
-    text-align: center;
-    padding: 2rem 1.5rem;
-    border-radius: 4px;
-    border: 1px dashed pvar(--secondary-icon-color);
-  
-    @include on-mobile-main-col {
-      border: 0;
-    }
-  }
-
-my-embed {
-  max-width: 500px;
-  width: 500px;
-
-  max-height: 280px;
-  height: 280px;
+.current-filename {
+  text-align: center;
+  margin-top: 1.5rem;
 }
 
-.root.dragover {
+.root {
+  min-height: 260px;
+  text-align: center;
+  padding: 2rem 1.5rem;
+  border-radius: 4px;
+  border: 1px dashed pvar(--secondary-icon-color);
+
+  @include on-mobile-main-col {
+    border: 0;
+  }
+}
+
+.dragover {
   background-color: pvar(--bg-secondary-400);
   border-color: pvar(--primary);
-
-  .no-image {
-    color: pvar(--primary);
-  }
 }
-
-.form-columns {
-    display: grid;
-    grid-template-columns: fit-content(66%) 1fr;
-  
-    @include rfs(40px, grid-gap);
-  
-    &.disabled {
-      opacity: 0.6;
-      pointer-events: none;
-    }
-  
-    &.reverse {
-      > *:nth-child(1) {
-        order: 1;
-      }
-  
-      > *:nth-child(2) {
-        order: -1;
-      }
-    }
-  
-    @media screen and (max-width: $medium-view) {
-      grid-template-columns: minmax(0, 1fr);
-    }
-}
-

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
@@ -24,7 +24,7 @@ type Form = {
 @Component({
   selector: 'my-video-replace-file',
   styleUrls: [
-    '../common/video-manage-page-common.scss'
+    './video-replace-file.component.scss',
   ],
   templateUrl: './video-replace-file.component.html',
   imports: [
@@ -96,9 +96,23 @@ export class VideoReplaceFileComponent implements OnInit, OnDestroy {
 
   @ViewChild('reactiveFileInput') reactiveFile: ReactiveFileComponent
   onFileDropped (files: FileList) {
-    if (!files || files.length === 0) return
-
     this.reactiveFile.fileChange({ target: { files } })
+    //this.onFileChanged(files[0])
+  }
+
+  onFileChanged (file: File | Blob) {
+    if (!file) return
+
+    if (!(file instanceof File)) {
+        //console.error('Received unexpected non-File:', file)
+        return
+    }
+
+    // Put the file in the form control to activate the save button
+    this.form.controls.replaceFile.setValue(file)
+    this.form.controls.replaceFile.markAsDirty()
+    this.form.markAsDirty()
+    this.form.updateValueAndValidity()
   }
 
   getVideoExtensions () {

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
@@ -24,6 +24,7 @@ type Form = {
 @Component({
   selector: 'my-video-replace-file',
   styleUrls: [
+    '../common/video-manage-page-common.scss',
     './video-replace-file.component.scss'
   ],
   templateUrl: './video-replace-file.component.html',
@@ -94,7 +95,8 @@ export class VideoReplaceFileComponent implements OnInit, OnDestroy {
     this.updatedSub?.unsubscribe()
   }
 
-  @ViewChild('reactiveFileInput') reactiveFile: ReactiveFileComponent
+  @ViewChild('reactiveFileInput')
+  reactiveFile: ReactiveFileComponent
   onFileDropped (files: FileList) {
     this.reactiveFile.fileChange({ target: { files } })
     // this.onFileChanged(files[0])

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, inject, OnDestroy, OnInit } from '@angular/core'
+import { Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core'
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { ServerService } from '@app/core'
 import { BuildFormArgument } from '@app/shared/form-validators/form-validator.model'
@@ -13,6 +13,7 @@ import { getReplaceFileUnavailability } from '../common/unavailable-features'
 import { VideoEdit } from '../common/video-edit.model'
 import { VideoUploadService } from '../common/video-upload.service'
 import { VideoManageController } from '../video-manage-controller.service'
+import { DragDropDirective } from '@app/+videos-publish-manage/+video-publish/shared/drag-drop.directive'
 
 const debugLogger = debug('peertube:video-manage')
 
@@ -32,7 +33,8 @@ type Form = {
     ReactiveFormsModule,
     ReactiveFileComponent,
     AlertComponent,
-    GlobalIconComponent
+    GlobalIconComponent,
+    DragDropDirective
   ]
 })
 export class VideoReplaceFileComponent implements OnInit, OnDestroy {
@@ -90,6 +92,13 @@ export class VideoReplaceFileComponent implements OnInit, OnDestroy {
 
   ngOnDestroy (): void {
     this.updatedSub?.unsubscribe()
+  }
+
+  @ViewChild('reactiveFileInput') reactiveFile: ReactiveFileComponent;
+  onFileDropped (files: FileList) {
+    if (!files || files.length === 0) return;
+
+    this.reactiveFile.fileChange({ target: { files } })
   }
 
   getVideoExtensions () {

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
@@ -94,9 +94,9 @@ export class VideoReplaceFileComponent implements OnInit, OnDestroy {
     this.updatedSub?.unsubscribe()
   }
 
-  @ViewChild('reactiveFileInput') reactiveFile: ReactiveFileComponent;
+  @ViewChild('reactiveFileInput') reactiveFile: ReactiveFileComponent
   onFileDropped (files: FileList) {
-    if (!files || files.length === 0) return;
+    if (!files || files.length === 0) return
 
     this.reactiveFile.fileChange({ target: { files } })
   }

--- a/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/replace-file/video-replace-file.component.ts
@@ -24,7 +24,7 @@ type Form = {
 @Component({
   selector: 'my-video-replace-file',
   styleUrls: [
-    './video-replace-file.component.scss',
+    './video-replace-file.component.scss'
   ],
   templateUrl: './video-replace-file.component.html',
   imports: [
@@ -97,15 +97,15 @@ export class VideoReplaceFileComponent implements OnInit, OnDestroy {
   @ViewChild('reactiveFileInput') reactiveFile: ReactiveFileComponent
   onFileDropped (files: FileList) {
     this.reactiveFile.fileChange({ target: { files } })
-    //this.onFileChanged(files[0])
+    // this.onFileChanged(files[0])
   }
 
   onFileChanged (file: File | Blob) {
     if (!file) return
 
     if (!(file instanceof File)) {
-        //console.error('Received unexpected non-File:', file)
-        return
+      // console.error('Received unexpected non-File:', file)
+      return
     }
 
     // Put the file in the form control to activate the save button


### PR DESCRIPTION
Added the drag and drop functionality (that was already used for publishing videos) for replacing the video files

## Description

Now there is the possibility to drag a file from the file exporer to the "Replace file" area to replace a video (add a new version of the video), as well as upload that file using the button.

## Related issues

Solves issue "Add hint for drag and drop for replace video #6094".
Note: When dragging the file over other elements in the drop area, the DnD hint flickers, and if you happen to drop the file in between the flickers (when the hint does not appear), the file will not be selected. As far as I looked into that, that has to do with hovering over nested components within the drop area which messes with the onEnter and onLeave methods of the Drag and Drop directive. The exact same thing happens for the "Publish video" section, where the DnD directive is also used, therefore I think a separate issue should be opened to fix that problem with the DnD component.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<img width="838" alt="image" src="https://github.com/user-attachments/assets/15814b27-3cf9-4812-ac48-e1c9f7fa2edc" />
