### PR TITLE
Modernize the OpenRC service with openrc-run and improve production guide

### DIFF
--- a/support/conf.d/peertube
+++ b/support/conf.d/peertube
@@ -1,0 +1,1 @@
+directory="/var/www/peertube/peertube-latest"

--- a/support/conf.d/peertube
+++ b/support/conf.d/peertube
@@ -1,1 +1,6 @@
-directory="/var/www/peertube/peertube-latest"
+BASE_DIR="/var/www/peertube"
+
+directory="${BASE_DIR}/peertube-latest"
+
+export NODE_ENV="production"
+export NODE_CONFIG_DIR="${BASE_DIR}/config"

--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -256,6 +256,7 @@ If your OS uses OpenRC, copy the service script:
 
 ```bash
 sudo cp /var/www/peertube/peertube-latest/support/init.d/peertube /etc/init.d/
+sudo cp /var/www/peertube/peertube-latest/support/conf.d/peertube /etc/conf.d/
 ```
 
 If you want to start PeerTube on boot:
@@ -381,6 +382,16 @@ Check changes in systemd configuration:
 cd /var/www/peertube/versions
 diff -u "$(ls -t | head -2 | tail -1)/support/systemd/peertube.service" "$(ls -t | head -1)/support/systemd/peertube.service"
 ```
+
+<details>
+<summary><strong>If using OpenRC</strong></summary>
+
+```bash
+cd /var/www/peertube/versions
+diff -u "$(ls -t | head -2 | tail -1)/support/init.d/peertube" "$(ls -t | head -1)/support/init.d/peertube"
+diff -u "$(ls -t | head -2 | tail -1)/support/conf.d/peertube" "$(ls -t | head -1)/support/conf.d/peertube"
+```
+</details>
 
 ### Restart PeerTube
 

--- a/support/init.d/peertube
+++ b/support/init.d/peertube
@@ -1,173 +1,25 @@
-#!/bin/sh
+#!/sbin/openrc-run
+supervisor=supervise-daemon
 
-APP_NAME="peertube"
-USER="peertube"
-GROUP="peertube"
-NODE_ENV="production"
-APP_DIR="/var/www/peertube/peertube-latest"
-NODE_APP="dist/server"
-KWARGS=""
-CONFIG_DIR="/var/www/peertube/config"
-PID_DIR="$APP_DIR/pid"
-PID_FILE="$PID_DIR/$APP_NAME.pid"
-LOG_DIR="/var/log/peertube"
-LOG_FILE="$LOG_DIR/$APP_NAME.log"
-NODE_EXEC=$(which node)
+export NODE_ENV="production"
+export NODE_CONFIG_DIR="/var/www/peertube/config"
 
-###############
+name="PeerTube"
+description="PeerTube self-hosted streaming service"
+pidfile=/run/peertube/peertube.pid
+output_log=/var/log/peertube/peertube.log
+error_log="$output_log"
+command_background=true
+command_user="peertube:peertube"
+command=/usr/bin/node
+command_args="${directory}/dist/server"
+required_dirs="$directory $NODE_CONFIG_DIR"
 
-# REDHAT chkconfig header
-
-# chkconfig: - 58 74
-# description: peertube service script.
-### BEGIN INIT INFO
-# Provides: peertube
-# Required-Start:    $network $remote_fs $local_fs
-# Required-Stop:     $network $remote_fs $local_fs
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Short-Description: start and stop peertube
-# Description: Node process for peertube
-### END INIT INFO
-
-###############
-
-USAGE="Usage: $0 {start|stop|restart|status} [--force]"
-FORCE_OP=false
-
-pid_file_exists() {
-    [ -f "$PID_FILE" ]
+depend() {
+	after redis postgresql
 }
 
-get_pid() {
-    echo "$(cat "$PID_FILE")"
+start_pre() {
+	checkpath --directory --owner "$command_user" --mode 0750 "${pidfile%/*}"
+	checkpath --directory --owner "$command_user" --mode 0750 "${output_log%/*}"
 }
-
-is_running() {
-    PID="$(get_pid)"
-    [ -d /proc/$PID ]
-}
-
-start_it() {
-    mkdir -p "$PID_DIR"
-    chown $USER:$GROUP "$PID_DIR"
-    mkdir -p "$LOG_DIR"
-    chown $USER:$GROUP "$LOG_DIR"
-
-    echo "Starting $APP_NAME ..."
-    echo "cd $APP_DIR && NODE_ENV=$NODE_ENV NODE_CONFIG_DIR=$CONFIG_DIR $NODE_EXEC $APP_DIR/$NODE_APP $KWARGS 1>$LOG_FILE 2>&1 & echo \$! > $PID_FILE" | sudo -i -u $USER
-    echo "$APP_NAME started with pid $(get_pid)"
-}
-
-stop_process() {
-    PID=$(get_pid)
-    echo "Killing process $PID"
-    pkill -P $PID
-}
-
-remove_pid_file() {
-    echo "Removing pid file"
-    rm -f "$PID_FILE"
-}
-
-start_app() {
-    if pid_file_exists
-    then
-        if is_running
-        then
-            PID=$(get_pid)
-            echo "$APP_NAME already running with pid $PID"
-            exit 1
-        else
-            echo "$APP_NAME stopped, but pid file exists"
-            if [ $FORCE_OP = true ]
-            then
-                echo "Forcing start anyways"
-                remove_pid_file
-                start_it
-            fi
-        fi
-    else
-        start_it
-    fi
-}
-
-stop_app() {
-    if pid_file_exists
-    then
-        if is_running
-        then
-            echo "Stopping $APP_NAME ..."
-            stop_process
-            remove_pid_file
-            echo "$APP_NAME stopped"
-        else
-            echo "$APP_NAME already stopped, but pid file exists"
-            if [ $FORCE_OP = true ]
-            then
-                echo "Forcing stop anyways ..."
-                remove_pid_file
-                echo "$APP_NAME stopped"
-            else
-                exit 1
-            fi
-        fi
-    else
-        echo "$APP_NAME already stopped, pid file does not exist"
-        exit 1
-    fi
-}
-
-status_app() {
-    if pid_file_exists
-    then
-        if is_running
-        then
-            PID=$(get_pid)
-            echo "$APP_NAME running with pid $PID"
-        else
-            echo "$APP_NAME stopped, but pid file exists"
-        fi
-    else
-        echo "$APP_NAME stopped"
-    fi
-}
-
-case "$2" in
-    --force)
-        FORCE_OP=true
-    ;;
-
-    "")
-    ;;
-
-    *)
-        echo $USAGE
-        exit 1
-    ;;
-esac
-
-case "$1" in
-    start)
-        start_app
-    ;;
-
-    stop)
-        stop_app
-    ;;
-
-    restart)
-        stop_app
-        start_app
-    ;;
-
-    status)
-        status_app
-    ;;
-
-    *)
-        echo $USAGE
-        exit 1
-    ;;
-esac
-

--- a/support/init.d/peertube
+++ b/support/init.d/peertube
@@ -1,9 +1,6 @@
 #!/sbin/openrc-run
 supervisor=supervise-daemon
 
-export NODE_ENV="production"
-export NODE_CONFIG_DIR="/var/www/peertube/config"
-
 name="PeerTube"
 description="PeerTube self-hosted streaming service"
 pidfile=/run/peertube/peertube.pid


### PR DESCRIPTION
## Description

This change uses openrc-run instead of a simple shell script which allows to mainly use a declarative configuration, manages dependencies, pid file, privileges drop and more. It also uses supervise-daemon as supervisor so that the service can be restarted when crashing.

The production guide now also contains instructions when updating on an OpenRC system.

## Related issues

#4678 (This PR doesn't use start-stop-daemon but supervise-daemon that brings actual supervision)

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
