### PR TITLE
Fix typo in production.yaml

### DIFF
--- a/support/docker/production/config/production.yaml
+++ b/support/docker/production/config/production.yaml
@@ -60,7 +60,7 @@ storage:
   cache: '../data/cache/'
   plugins: '../data/plugins/'
   well_known: '../data/well-known/'
-  # Overridable client files in client/dist/assets/images :
+  # Overridable client files in client/dist/assets/images:
   # - logo.svg
   # - favicon.png
   # - default-playlist.jpg
@@ -69,7 +69,7 @@ storage:
   # - and icons/*.png (PWA)
   # Could contain for example assets/images/favicon.png
   # If the file exists, peertube will serve it
-  # If not, peertube will fallback to the default fil
+  # If not, peertube will fallback to the default file
   client_overrides: '../data/client-overrides/'
 
 


### PR DESCRIPTION
## Description

Fix typo in production.yaml

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

