### PR TITLE
🔊 — [peertube-runner] Disable log coloring when TTY does not support it

### DIFF
--- a/apps/peertube-runner/src/shared/logger.ts
+++ b/apps/peertube-runner/src/shared/logger.ts
@@ -2,7 +2,7 @@ import { pino } from 'pino'
 import pretty from 'pino-pretty'
 
 const logger = pino(pretty({
-  colorize: true
+  colorize: pretty.isColorSupported
 }))
 
 logger.level = 'info'


### PR DESCRIPTION
## Description

Use pino-prettyprint ability to detect if the TTY supports colors to choose when coloring logs.

## Related issues

Issue discussed directly with @Chocobozzz: if using rsyslog to store prunner logs, the logs are polluted with color escape sequences. This PR allows to avoid that, but keep colors when executing the runner from the command line.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

![image](https://github.com/user-attachments/assets/9e678eeb-2e89-4438-b2e4-7696c9849c4a)
