### PR TITLE
Add embed paramaters

### DIFF
--- a/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
+++ b/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
@@ -116,7 +116,11 @@ export class CustomMarkupService {
     const data = el.dataset as EmbedMarkupData
     const { component, loadedPromise } = this.dynamicElementService.createElement(EmbedMarkupComponent)
 
-    this.dynamicElementService.setModel(component, { uuid: data.uuid, type })
+    this.dynamicElementService.setModel(component, {
+      uuid: data.uuid,
+      type,
+      responsive: data.responsive ? this.buildBoolean(data.responsive) : undefined
+    })
 
     return { component, loadedPromise }
   }

--- a/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
+++ b/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
@@ -119,19 +119,19 @@ export class CustomMarkupService {
     this.dynamicElementService.setModel(component, {
       uuid: data.uuid,
       type,
-      responsive: this.buildBoolean(data.responsive) ?? false,
+      responsive: this.buildBoolean(data.responsive),
       startAt: data.startAt,
       stopAt: data.stopAt,
       subtitle: data.subtitle,
-      autoplay: this.buildBoolean(data.autoplay) ?? false,
-      muted: this.buildBoolean(data.muted) ?? false,
-      loop: this.buildBoolean(data.loop) ?? false,
-      title: this.buildBoolean(data.title) ?? true,
-      p2p: this.buildBoolean(data.p2p) ?? true,
-      warningTitle: this.buildBoolean(data.warningTitle) ?? true,
-      controlBar: this.buildBoolean(data.controlBar) ?? true,
-      peertubeLink: this.buildBoolean(data.peertubeLink) ?? true,
-      playlistPosition: this.buildNumber(data.playlistPosition) ?? 1
+      autoplay: this.buildBoolean(data.autoplay),
+      muted: this.buildBoolean(data.muted),
+      loop: this.buildBoolean(data.loop),
+      title: this.buildBoolean(data.title),
+      p2p: this.buildBoolean(data.p2p),
+      warningTitle: this.buildBoolean(data.warningTitle),
+      controlBar: this.buildBoolean(data.controlBar),
+      peertubeLink: this.buildBoolean(data.peertubeLink),
+      playlistPosition: this.buildNumber(data.playlistPosition)
     })
 
     return { component, loadedPromise }

--- a/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
+++ b/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
@@ -126,11 +126,12 @@ export class CustomMarkupService {
       autoplay: this.buildBoolean(data.autoplay) ?? false,
       muted: this.buildBoolean(data.muted) ?? false,
       loop: this.buildBoolean(data.loop) ?? false,
-      title: this.buildBoolean(data.displayTitle) ?? true,
+      title: this.buildBoolean(data.title) ?? true,
       p2p: this.buildBoolean(data.p2p) ?? true,
-      warningTitle: this.buildBoolean(data.privacyWarning) ?? true,
-      controlBar: this.buildBoolean(data.playerControl) ?? true,
-      peertubeLink: this.buildBoolean(data.peertubeLink) ?? true
+      warningTitle: this.buildBoolean(data.warningTitle) ?? true,
+      controlBar: this.buildBoolean(data.controlBar) ?? true,
+      peertubeLink: this.buildBoolean(data.peertubeLink) ?? true,
+      playlistPosition: this.buildNumber(data.playlistPosition) ?? 1
     })
 
     return { component, loadedPromise }

--- a/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
+++ b/client/src/app/shared/shared-custom-markup/custom-markup.service.ts
@@ -119,7 +119,18 @@ export class CustomMarkupService {
     this.dynamicElementService.setModel(component, {
       uuid: data.uuid,
       type,
-      responsive: data.responsive ? this.buildBoolean(data.responsive) : undefined
+      responsive: this.buildBoolean(data.responsive) ?? false,
+      startAt: data.startAt,
+      stopAt: data.stopAt,
+      subtitle: data.subtitle,
+      autoplay: this.buildBoolean(data.autoplay) ?? false,
+      muted: this.buildBoolean(data.muted) ?? false,
+      loop: this.buildBoolean(data.loop) ?? false,
+      title: this.buildBoolean(data.displayTitle) ?? true,
+      p2p: this.buildBoolean(data.p2p) ?? true,
+      warningTitle: this.buildBoolean(data.privacyWarning) ?? true,
+      controlBar: this.buildBoolean(data.playerControl) ?? true,
+      peertubeLink: this.buildBoolean(data.peertubeLink) ?? true
     })
 
     return { component, loadedPromise }

--- a/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
+++ b/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
@@ -14,6 +14,7 @@ export class EmbedMarkupComponent implements CustomMarkupComponent, OnInit {
 
   readonly uuid = input<string>(undefined)
   readonly type = input<'video' | 'playlist'>('video')
+  readonly responsive = input<boolean>(undefined)
 
   loaded: undefined
 
@@ -22,6 +23,10 @@ export class EmbedMarkupComponent implements CustomMarkupComponent, OnInit {
       ? buildVideoEmbedLink({ uuid: this.uuid() }, environment.originServerUrl)
       : buildPlaylistEmbedLink({ uuid: this.uuid() }, environment.originServerUrl)
 
-    this.el.nativeElement.innerHTML = buildVideoOrPlaylistEmbed({ embedUrl: link, embedTitle: this.uuid() })
+    this.el.nativeElement.innerHTML = buildVideoOrPlaylistEmbed({ 
+      embedUrl: link, 
+      embedTitle: this.uuid(),
+      responsive: this.responsive() ?? false
+    })
   }
 }

--- a/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
+++ b/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
@@ -1,7 +1,7 @@
 import { environment } from 'src/environments/environment'
 import { Component, ElementRef, OnInit, inject, input } from '@angular/core'
 import { buildVideoOrPlaylistEmbed } from '@root-helpers/video'
-import { buildPlaylistEmbedLink, buildVideoEmbedLink } from '@peertube/peertube-core-utils'
+import { buildPlaylistEmbedLink, buildVideoEmbedLink, decorateVideoLink, timeToInt } from '@peertube/peertube-core-utils'
 import { CustomMarkupComponent } from './shared'
 
 @Component({
@@ -15,13 +15,42 @@ export class EmbedMarkupComponent implements CustomMarkupComponent, OnInit {
   readonly uuid = input<string>(undefined)
   readonly type = input<'video' | 'playlist'>('video')
   readonly responsive = input<boolean>(undefined)
+  readonly startAt = input<string>(undefined)
+  readonly stopAt = input<string>(undefined)
+  readonly subtitle = input<string>(undefined)
+  readonly autoplay = input<boolean>(undefined)
+  readonly muted = input<boolean>(undefined)
+  readonly loop = input<boolean>(undefined)
+  readonly title = input<boolean>(undefined)
+  readonly p2p = input<boolean>(undefined)
+  readonly warningTitle = input<boolean>(undefined)
+  readonly controlBar = input<boolean>(undefined)
+  readonly peertubeLink = input<boolean>(undefined)
 
   loaded: undefined
 
   ngOnInit () {
-    const link = this.type() === 'video'
+    const baseLink = this.type() === 'video'
       ? buildVideoEmbedLink({ uuid: this.uuid() }, environment.originServerUrl)
       : buildPlaylistEmbedLink({ uuid: this.uuid() }, environment.originServerUrl)
+
+    const startTime = this.startAt() ? timeToInt(this.startAt()) : undefined
+    const stopTime = this.stopAt() ? timeToInt(this.stopAt()) : undefined
+
+    const link = decorateVideoLink({
+      url: baseLink,
+      startTime,
+      stopTime,
+      subtitle: this.subtitle(),
+      loop: this.loop(),
+      autoplay: this.autoplay(),
+      muted: this.muted(),
+      title: this.title(),
+      warningTitle: this.warningTitle(),
+      controlBar: this.controlBar(),
+      peertubeLink: this.peertubeLink(),
+      p2p: this.p2p()
+    })
 
     this.el.nativeElement.innerHTML = buildVideoOrPlaylistEmbed({ 
       embedUrl: link, 

--- a/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
+++ b/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
@@ -1,7 +1,7 @@
 import { environment } from 'src/environments/environment'
 import { Component, ElementRef, OnInit, inject, input } from '@angular/core'
 import { buildVideoOrPlaylistEmbed } from '@root-helpers/video'
-import { buildPlaylistEmbedLink, buildVideoEmbedLink, decorateVideoLink, timeToInt } from '@peertube/peertube-core-utils'
+import { buildPlaylistEmbedLink, buildVideoEmbedLink, decorateVideoLink, decoratePlaylistLink, timeToInt } from '@peertube/peertube-core-utils'
 import { CustomMarkupComponent } from './shared'
 
 @Component({
@@ -26,31 +26,35 @@ export class EmbedMarkupComponent implements CustomMarkupComponent, OnInit {
   readonly warningTitle = input<boolean>(undefined)
   readonly controlBar = input<boolean>(undefined)
   readonly peertubeLink = input<boolean>(undefined)
+  readonly playlistPosition = input<number>(undefined)
 
   loaded: undefined
 
   ngOnInit () {
-    const baseLink = this.type() === 'video'
-      ? buildVideoEmbedLink({ uuid: this.uuid() }, environment.originServerUrl)
-      : buildPlaylistEmbedLink({ uuid: this.uuid() }, environment.originServerUrl)
-
-    const startTime = this.startAt() ? timeToInt(this.startAt()) : undefined
-    const stopTime = this.stopAt() ? timeToInt(this.stopAt()) : undefined
-
-    const link = decorateVideoLink({
-      url: baseLink,
-      startTime,
-      stopTime,
-      subtitle: this.subtitle(),
-      loop: this.loop(),
-      autoplay: this.autoplay(),
-      muted: this.muted(),
-      title: this.title(),
-      warningTitle: this.warningTitle(),
-      controlBar: this.controlBar(),
-      peertubeLink: this.peertubeLink(),
-      p2p: this.p2p()
-    })
+      let link;
+      if (this.type() === 'video') {
+        const startTime = this.startAt() ? timeToInt(this.startAt()) : undefined
+        const stopTime = this.stopAt() ? timeToInt(this.stopAt()) : undefined
+        link = decorateVideoLink({
+            url: buildVideoEmbedLink({ uuid: this.uuid() }, environment.originServerUrl),
+            startTime,
+            stopTime,
+            subtitle: this.subtitle(),
+            loop: this.loop(),
+            autoplay: this.autoplay(),
+            muted: this.muted(),
+            title: this.title(),
+            warningTitle: this.warningTitle(),
+            controlBar: this.controlBar(),
+            peertubeLink: this.peertubeLink(),
+            p2p: this.p2p()
+        })
+    } else {
+        link = decoratePlaylistLink({
+            url: buildPlaylistEmbedLink({ uuid: this.uuid() }, environment.originServerUrl),
+            playlistPosition: this.playlistPosition()
+        })
+    }
 
     this.el.nativeElement.innerHTML = buildVideoOrPlaylistEmbed({ 
       embedUrl: link, 

--- a/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
+++ b/client/src/app/shared/shared-custom-markup/peertube-custom-tags/embed-markup.component.ts
@@ -1,7 +1,13 @@
-import { environment } from 'src/environments/environment'
 import { Component, ElementRef, OnInit, inject, input } from '@angular/core'
+import {
+  buildPlaylistEmbedLink,
+  buildVideoEmbedLink,
+  decoratePlaylistLink,
+  decorateVideoLink,
+  timeToInt
+} from '@peertube/peertube-core-utils'
 import { buildVideoOrPlaylistEmbed } from '@root-helpers/video'
-import { buildPlaylistEmbedLink, buildVideoEmbedLink, decorateVideoLink, decoratePlaylistLink, timeToInt } from '@peertube/peertube-core-utils'
+import { environment } from 'src/environments/environment'
 import { CustomMarkupComponent } from './shared'
 
 @Component({
@@ -31,35 +37,42 @@ export class EmbedMarkupComponent implements CustomMarkupComponent, OnInit {
   loaded: undefined
 
   ngOnInit () {
-      let link;
-      if (this.type() === 'video') {
-        const startTime = this.startAt() ? timeToInt(this.startAt()) : undefined
-        const stopTime = this.stopAt() ? timeToInt(this.stopAt()) : undefined
-        link = decorateVideoLink({
-            url: buildVideoEmbedLink({ uuid: this.uuid() }, environment.originServerUrl),
-            startTime,
-            stopTime,
-            subtitle: this.subtitle(),
-            loop: this.loop(),
-            autoplay: this.autoplay(),
-            muted: this.muted(),
-            title: this.title(),
-            warningTitle: this.warningTitle(),
-            controlBar: this.controlBar(),
-            peertubeLink: this.peertubeLink(),
-            p2p: this.p2p()
-        })
-    } else {
-        link = decoratePlaylistLink({
-            url: buildPlaylistEmbedLink({ uuid: this.uuid() }, environment.originServerUrl),
-            playlistPosition: this.playlistPosition()
-        })
-    }
-
-    this.el.nativeElement.innerHTML = buildVideoOrPlaylistEmbed({ 
-      embedUrl: link, 
+    this.el.nativeElement.innerHTML = buildVideoOrPlaylistEmbed({
+      embedUrl: this.buildLink(),
       embedTitle: this.uuid(),
       responsive: this.responsive() ?? false
+    })
+  }
+
+  private buildLink () {
+    if (this.type() === 'playlist') {
+      return decoratePlaylistLink({
+        url: buildPlaylistEmbedLink({ uuid: this.uuid() }, environment.originServerUrl),
+        playlistPosition: this.playlistPosition()
+      })
+    }
+
+    const startTime = this.startAt()
+      ? timeToInt(this.startAt())
+      : undefined
+
+    const stopTime = this.stopAt()
+      ? timeToInt(this.stopAt())
+      : undefined
+
+    return decorateVideoLink({
+      url: buildVideoEmbedLink({ uuid: this.uuid() }, environment.originServerUrl),
+      startTime,
+      stopTime,
+      subtitle: this.subtitle(),
+      loop: this.loop(),
+      autoplay: this.autoplay(),
+      muted: this.muted(),
+      title: this.title(),
+      warningTitle: this.warningTitle(),
+      controlBar: this.controlBar(),
+      peertubeLink: this.peertubeLink(),
+      p2p: this.p2p()
     })
   }
 }

--- a/packages/models/src/custom-markup/custom-markup-data.model.ts
+++ b/packages/models/src/custom-markup/custom-markup-data.model.ts
@@ -15,6 +15,7 @@ export type EmbedMarkupData = {
   warningTitle?: StringBoolean
   controlBar?: StringBoolean
   peertubeLink?: StringBoolean
+  playlistPosition?: string // number
 }
 
 export type VideoMiniatureMarkupData = {

--- a/packages/models/src/custom-markup/custom-markup-data.model.ts
+++ b/packages/models/src/custom-markup/custom-markup-data.model.ts
@@ -4,6 +4,17 @@ export type EmbedMarkupData = {
   // Video or playlist uuid
   uuid: string
   responsive?: StringBoolean
+  startAt?: string
+  stopAt?: string
+  subtitle?: string
+  autoplay?: StringBoolean
+  muted?: StringBoolean
+  loop?: StringBoolean
+  title?: StringBoolean
+  p2p?: StringBoolean
+  warningTitle?: StringBoolean
+  controlBar?: StringBoolean
+  peertubeLink?: StringBoolean
 }
 
 export type VideoMiniatureMarkupData = {

--- a/packages/models/src/custom-markup/custom-markup-data.model.ts
+++ b/packages/models/src/custom-markup/custom-markup-data.model.ts
@@ -3,6 +3,7 @@ type StringBoolean = 'true' | 'false'
 export type EmbedMarkupData = {
   // Video or playlist uuid
   uuid: string
+  responsive?: StringBoolean
 }
 
 export type VideoMiniatureMarkupData = {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
Currently, all videos embedded on a page using the `<peertube-video-embed>` tag have hard-coded dimensions. 

Therefore this PR adds the `data-responsive` tag to `<peertube-video-embed>` together with a bunch of other tags (see overview below)

`<peertube-video-embed>`:
`data-start-at`, `data-subtitle`, `data-responsive`, `data-stop-at`, `data-autoplay`, `data-muted`, `data-loop`, `data-title`, `data-p2p`, `data-warning-title`, `data-control-bar`, `data-peertube-link`

`<peertube-playlist-embed>`:
 `data-responsive`,  `data-playlist-position`


## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
#6834 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
embed with and without the data-responsive attribute
![image](https://github.com/user-attachments/assets/56de901f-1115-4c81-bd71-e530540cc7c8)

