### PR TITLE
client: dont use rel=ugc for plugins markdown

### DIFF
--- a/client/src/app/core/plugins/plugin.service.ts
+++ b/client/src/app/core/plugins/plugin.service.ts
@@ -316,11 +316,11 @@ export class PluginService implements ClientHook {
 
       markdownRenderer: {
         textMarkdownToHTML: (textMarkdown: string) => {
-          return this.markdownRenderer.textMarkdownToHTML({ markdown: textMarkdown })
+          return this.markdownRenderer.textMarkdownToHTML({ markdown: textMarkdown, userGeneratedLinks: false })
         },
 
         enhancedMarkdownToHTML: (enhancedMarkdown: string) => {
-          return this.markdownRenderer.enhancedMarkdownToHTML({ markdown: enhancedMarkdown })
+          return this.markdownRenderer.enhancedMarkdownToHTML({ markdown: enhancedMarkdown, userGeneratedLinks: false })
         }
       },
 


### PR DESCRIPTION
## Description
This PR should only affect markdown generated with custom home page markdown and plugins. Since those fields are only editable by admins they shouldn't be marked as user generated content. 

## Related issues
closes #6959

## Has this been tested?
- [x] 🙅 no, because this PR does not update server code

