### PR TITLE
update allowfullscreen property

### DIFF
--- a/client/src/root-helpers/video.ts
+++ b/client/src/root-helpers/video.ts
@@ -14,8 +14,8 @@ export function buildVideoOrPlaylistEmbed (options: {
   iframe.width = responsive ? '100%' : '560'
   iframe.height = responsive ? '100%' : '315'
   iframe.src = embedUrl
-  iframe.frameBorder = '0'
-  iframe.allowFullscreen = true
+  iframe.style.border = 'none'
+  iframe.allow = 'fullscreen'
   iframe.sandbox.add('allow-same-origin', 'allow-scripts', 'allow-popups', 'allow-forms')
 
   if (responsive) {

--- a/packages/tests/src/api/server/services.ts
+++ b/packages/tests/src/api/server/services.ts
@@ -80,7 +80,7 @@ describe('Test services', function () {
         const res = await server.services.getOEmbed({ oembedUrl })
         const expectedHtml = '<iframe width="560" height="315" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" ' +
           `title="${video.name}" src="http://${server.host}/videos/embed/${video.shortUUID}${suffix.output}" ` +
-          'frameborder="0" allowfullscreen></iframe>'
+          'style="border:none" allow="fullscreen"></iframe>'
 
         const expectedThumbnailUrl = 'http://' + server.host + video.previewPath
 
@@ -104,7 +104,7 @@ describe('Test services', function () {
         const res = await server.services.getOEmbed({ oembedUrl })
         const expectedHtml = '<iframe width="560" height="315" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" ' +
           `title="${playlistDisplayName}" src="http://${server.host}/video-playlists/embed/${playlistShortUUID}${suffix.output}" ` +
-          'frameborder="0" allowfullscreen></iframe>'
+          'style="border:none" allow="fullscreen"></iframe>'
 
         expect(res.body.html).to.equal(expectedHtml)
         expect(res.body.title).to.equal('The Life and Times of Scrooge McDuck')
@@ -125,7 +125,7 @@ describe('Test services', function () {
 
     const expectedHtml = '<iframe width="560" height="315" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" ' +
       `title="${video.name}" src="http://${server.host}/videos/embed/${video.shortUUID}${query}" ` +
-      'frameborder="0" allowfullscreen></iframe>'
+      'style="border:none" allow="fullscreen"></iframe>'
 
     expect(res.body.html).to.equal(expectedHtml)
   })
@@ -140,7 +140,7 @@ describe('Test services', function () {
       const res = await server.services.getOEmbed({ oembedUrl, format, maxHeight, maxWidth })
       const expectedHtml = '<iframe width="50" height="50" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" ' +
         `title="${video.name}" src="http://${server.host}/videos/embed/${video.shortUUID}" ` +
-        'frameborder="0" allowfullscreen></iframe>'
+        'style="border:none" allow="fullscreen"></iframe>'
 
       expect(res.body.html).to.equal(expectedHtml)
       expect(res.body.title).to.equal(video.name)

--- a/server/core/controllers/services.ts
+++ b/server/core/controllers/services.ts
@@ -137,7 +137,7 @@ function buildOEmbed (options: {
   }
 
   const html = `<iframe width="${embedWidth}" height="${embedHeight}" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" ` +
-    `title="${embedTitle}" src="${embedUrl}" frameborder="0" allowfullscreen></iframe>`
+    `title="${embedTitle}" src="${embedUrl}" style="border:none" allow="fullscreen"></iframe>`
 
   const json: any = {
     type: 'video',


### PR DESCRIPTION
## Description

Based on https://github.com/Chocobozzz/PeerTube/pull/4606

[allowFullScreen](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/allowFullscreen) property is considered legacy and use of allow='fullscreen' is recommended.
[caniuse](https://caniuse.com/mdn-html_elements_iframe_allow)

[HTMLIFrameElement.frameBorder](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement) is deprecated and use of border in CSS is recommended.

## Related issues
fixes #7042 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
