### PR TITLE
feat: add new video password api

### DIFF
--- a/packages/server-commands/src/requests/requests.ts
+++ b/packages/server-commands/src/requests/requests.ts
@@ -183,6 +183,20 @@ export function makePutBodyRequest (options: {
   return buildRequest(req, { accept: 'application/json', expectedStatus: HttpStatusCode.BAD_REQUEST_400, ...options })
 }
 
+export function makePatchBodyRequest (options: {
+  url: string
+  path: string
+  token?: string
+  fields: { [fieldName: string]: any }
+  expectedStatus?: HttpStatusCodeType
+  headers?: { [name: string]: string }
+}) {
+  const req = request(options.url).patch(options.path)
+    .send(options.fields)
+
+  return buildRequest(req, { accept: 'application/json', expectedStatus: HttpStatusCode.BAD_REQUEST_400, ...options })
+}
+
 // ---------------------------------------------------------------------------
 
 export async function getRedirectionUrl (url: string, token?: string) {

--- a/packages/server-commands/src/shared/abstract-command.ts
+++ b/packages/server-commands/src/shared/abstract-command.ts
@@ -8,6 +8,7 @@ import { isAbsolute } from 'path'
 import {
   makeDeleteRequest,
   makeGetRequest,
+  makePatchBodyRequest,
   makePostBodyRequest,
   makePutBodyRequest,
   makeUploadRequest,
@@ -95,6 +96,22 @@ export abstract class AbstractCommand {
     const { fields, headers } = options
 
     return makePutBodyRequest({
+      ...this.buildCommonRequestOptions(options),
+
+      fields,
+      headers
+    })
+  }
+
+  protected patchBodyRequest (
+    options: InternalCommonCommandOptions & {
+      fields?: { [fieldName: string]: any }
+      headers?: { [name: string]: string }
+    }
+  ) {
+    const { fields, headers } = options
+
+    return makePatchBodyRequest({
       ...this.buildCommonRequestOptions(options),
 
       fields,

--- a/packages/server-commands/src/videos/video-passwords-command.ts
+++ b/packages/server-commands/src/videos/video-passwords-command.ts
@@ -38,6 +38,22 @@ export class VideoPasswordsCommand extends AbstractCommand {
     })
   }
 
+  addOne (options: OverrideCommandOptions & {
+    videoId: number | string
+    password: string
+  }) {
+    const { videoId, password } = options
+    const path = `/api/v1/videos/${videoId}/passwords`
+
+    return this.patchBodyRequest({
+      ...options,
+      path,
+      fields: { password },
+      implicitToken: true,
+      defaultExpectedStatus: HttpStatusCode.NO_CONTENT_204
+    })
+  }
+
   remove (options: OverrideCommandOptions & {
     id: number
     videoId: number | string

--- a/packages/tests/src/api/check-params/video-passwords.ts
+++ b/packages/tests/src/api/check-params/video-passwords.ts
@@ -598,6 +598,47 @@ describe('Test video passwords validator', function () {
     })
   })
 
+  describe('When adding a password', async function () {
+    const passwords = (await server.videoPasswords.list({ videoId: video.id })).data
+    const newPassword = "password123"
+    const emptyPassword = ""
+
+    it('Should fail with duplicate password', async function () {
+      await server.videoPasswords.addOne({ videoId: video.id, password: passwords[0].password, expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
+    })
+
+    it('Should fail with empty password', async function () {
+      await server.videoPasswords.addOne({ videoId: video.id, password: emptyPassword, expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
+    })
+
+    it('Should fail for unauthenticated user', async function () {
+      await server.videoPasswords.addOne({
+        password: newPassword,
+        token: null,
+        videoId: video.id,
+        expectedStatus: HttpStatusCode.FORBIDDEN_403
+      })
+    })
+
+    it('Should fail for unauthorized user', async function () {
+      await server.videoPasswords.addOne({
+        password: newPassword,
+        token: userAccessToken,
+        videoId: video.id,
+        expectedStatus: HttpStatusCode.BAD_REQUEST_400
+      })
+    })
+
+    it('Should fail for non password protected video', async function () {
+      publicVideo = await server.videos.quickUpload({ name: 'public video' })
+      await server.videoPasswords.addOne({ password: newPassword, videoId: publicVideo.id, expectedStatus: HttpStatusCode.BAD_REQUEST_400 })
+    })
+
+    it('Should succeed with correct parameter', async function () {
+      await server.videoPasswords.addOne({ password: newPassword, videoId: video.id, expectedStatus: HttpStatusCode.NO_CONTENT_204 })
+    })
+  })
+
   after(async function () {
     await cleanupTests([ server ])
   })

--- a/server/core/controllers/api/videos/passwords.ts
+++ b/server/core/controllers/api/videos/passwords.ts
@@ -13,6 +13,7 @@ import {
   setDefaultSort
 } from '../../../middlewares/index.js'
 import {
+  addVideoPasswordValidator,
   listVideoPasswordValidator,
   paginationValidator,
   removeVideoPasswordValidator,
@@ -37,6 +38,12 @@ videoPasswordRouter.put('/:videoId/passwords',
   authenticate,
   asyncMiddleware(updateVideoPasswordListValidator),
   asyncMiddleware(updateVideoPasswordList)
+)
+
+videoPasswordRouter.patch('/:videoId/passwords',
+  authenticate,
+  asyncMiddleware(addVideoPasswordValidator),
+  asyncMiddleware(addVideoPassword)
 )
 
 videoPasswordRouter.delete('/:videoId/passwords/:passwordId',
@@ -85,6 +92,30 @@ async function updateVideoPasswordList (req: express.Request, res: express.Respo
   )
 
   return res.sendStatus(HttpStatusCode.NO_CONTENT_204)
+}
+
+async function addVideoPassword (req: express.Request, res: express.Response) {
+  const videoInstance = getVideoWithAttributes(res)
+  const videoId = videoInstance.id
+
+  const newPassword = req.body.password as string
+
+  const newPasswordModel = await VideoPasswordModel.sequelize.transaction(async (t: Transaction) => {
+    return await VideoPasswordModel.addPassword(newPassword, videoId, t)
+  })
+
+  logger.info(
+    `Video password for video with name %s and uuid %s have been updated`,
+    videoInstance.name,
+    videoInstance.uuid,
+    lTags(videoInstance.uuid)
+  )
+
+  const result = {
+    password: newPasswordModel.toFormattedJSON()
+  }
+
+  return res.json(result).sendStatus(HttpStatusCode.CREATED_201)
 }
 
 async function removeVideoPassword (req: express.Request, res: express.Response) {

--- a/server/core/middlewares/validators/videos/video-passwords.ts
+++ b/server/core/middlewares/validators/videos/video-passwords.ts
@@ -50,6 +50,27 @@ const updateVideoPasswordListValidator = [
   }
 ]
 
+const addVideoPasswordValidator = [
+  body('password')
+    .isString()
+    .withMessage('Video password should be a string.')
+    .notEmpty()
+    .withMessage("Password string should not be emoty"),
+
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (areValidationErrors(req, res)) return
+
+    if (!await doesVideoExist(req.params.videoId, res)) return
+    if (!isValidPasswordProtectedPrivacy(req, res)) return
+
+    // Check if the user who did the request is able to update video passwords
+    const user = res.locals.oauth.token.User
+    if (!checkUserCanManageVideo(user, res.locals.videoAll, UserRight.UPDATE_ANY_VIDEO, res)) return
+
+    return next()
+  }
+]
+
 const removeVideoPasswordValidator = [
   isValidVideoIdParam('videoId'),
 
@@ -73,5 +94,6 @@ const removeVideoPasswordValidator = [
 export {
   listVideoPasswordValidator,
   updateVideoPasswordListValidator,
-  removeVideoPasswordValidator
+  removeVideoPasswordValidator,
+  addVideoPasswordValidator
 }

--- a/server/core/models/video/video-password.ts
+++ b/server/core/models/video/video-password.ts
@@ -93,11 +93,15 @@ export class VideoPasswordModel extends SequelizeModel<VideoPasswordModel> {
 
   static async addPasswords (passwords: string[], videoId: number, transaction?: Transaction): Promise<void> {
     for (const password of passwords) {
-      await VideoPasswordModel.create({
-        password,
-        videoId
-      }, { transaction })
+      VideoPasswordModel.addPassword(password, videoId, transaction);
     }
+  }
+
+  static async addPassword (password: string, videoId: number, transaction?: Transaction): Promise<VideoPasswordModel> {
+    return await VideoPasswordModel.create({
+      password,
+      videoId
+    }, { transaction })
   }
 
   static async deleteAllPasswords (videoId: number, transaction?: Transaction) {


### PR DESCRIPTION
## Description
Add a new PATCH api to add a password to a video. The api will return the newly created record.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

fixes #6710 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
