### PR TITLE
[docs] Fix mismatching sql backup filename and database name

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -417,9 +417,9 @@ sudo systemctl restart peertube && sudo journalctl -fu peertube
 Change `peertube-latest` destination to the previous version and restore your SQL backup:
 
 ```bash
-OLD_VERSION="v0.42.42" && SQL_BACKUP_PATH="backup/sql-peertube_prod-2018-01-19T10:18+01:00.bak" && \
+OLD_VERSION="v0.42.42" && SQL_BACKUP_PATH="backup/sql-peertube_prod-20180119-1018.bak" && \
   cd /var/www/peertube && sudo -u peertube unlink ./peertube-latest && \
   sudo -u peertube ln -s "versions/peertube-$OLD_VERSION" peertube-latest && \
-  sudo -u postgres pg_restore -c -C -d postgres "$SQL_BACKUP_PATH" && \
+  sudo -u postgres pg_restore -c -C -d peertube_prod "$SQL_BACKUP_PATH" && \
   sudo systemctl restart peertube
 ```


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

The command to downgrade PeerTube doesn't match today's SQL backup filenames, nor the database name at all. This corrects that.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->