### PR TITLE
Fix invalid error when summary is undefined

### DIFF
--- a/server/core/lib/activitypub/videos/shared/object-to-model-attributes.ts
+++ b/server/core/lib/activitypub/videos/shared/object-to-model-attributes.ts
@@ -277,7 +277,7 @@ export function getVideoAttributesFromObject (videoChannel: MChannelId, videoObj
 
     nsfw: videoObject.sensitive,
     nsfwSummary: videoObject.sensitive
-      ? videoObject.summary
+      ? (videoObject.summary ?? null)
       : null,
     nsfwFlags: videoObject.sensitive
       ? getNSFWFlags(videoObject.tag)


### PR DESCRIPTION
## Description

Fix a validation error occurring when updating remote videos on `nsfwSummary`

## Related issues

Closes #7070 

## Has this been tested?

I did an hotfix on my server and it seems to have fixed the issue, but I'd need directions on how to write a proper test if maintainers feels there is a need for one.
