### PR TITLE
Use SVG filter for thumbnail blurs and fix thumbnail corner coloring

### DIFF
--- a/client/src/sass/include/_miniature.scss
+++ b/client/src/sass/include/_miniature.scss
@@ -27,7 +27,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background-color: #ececec;
+  background-color: transparent;
   transition: filter $play-overlay-transition;
 
   @include disable-outline;

--- a/client/src/sass/include/_miniature.scss
+++ b/client/src/sass/include/_miniature.scss
@@ -87,7 +87,8 @@
     height: inherit;
 
     &.blur-filter {
-      filter: blur(20px);
+      --thumbnailBlur: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><filter id="thumbnailBlur" primitiveUnits="objectBoundingBox"><feGaussianBlur stdDeviation="0.0703 0.125"></feGaussianBlur><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0"></feColorMatrix><feComposite in2="SourceGraphic" operator="in"></feComposite></filter></svg>#thumbnailBlur');
+      filter: var(--thumbnailBlur);
     }
   }
 }

--- a/client/src/sass/include/_miniature.scss
+++ b/client/src/sass/include/_miniature.scss
@@ -87,7 +87,8 @@
     height: inherit;
 
     &.blur-filter {
-      --thumbnailBlur: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><filter id="thumbnailBlur" primitiveUnits="objectBoundingBox"><feGaussianBlur stdDeviation="0.0703 0.125"></feGaussianBlur><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0"></feColorMatrix><feComposite in2="SourceGraphic" operator="in"></feComposite></filter></svg>#thumbnailBlur');
+      --thumbnailBlur: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><filter id="thumbnailBlur" primitiveUnits="objectBoundingBox"><feGaussianBlur stdDeviation="0.07 0.125"></feGaussianBlur><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0"></feColorMatrix><feComposite in2="SourceGraphic" operator="in"></feComposite></filter></svg>#thumbnailBlur');
+      
       filter: var(--thumbnailBlur);
     }
   }


### PR DESCRIPTION
## Description

Use SVG filter for thumbnail blurs and fix thumbnail corner coloring

The values for the SVG filter were derived from the current `filter: blur(20px);` property. I took the video height from the video miniatures on channel pages and rounded up to 160.

<img src="https://github.com/user-attachments/assets/826c971c-ec41-4541-b81a-331932e51f00" height="270" />

`0.125` comes from `20 ÷ 160`, and `0.07` comes from `20 ÷ ( 160 ÷ 9 × 16)`.

## Related issues

Chocobozzz/PeerTube#7104

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] ❔yes, but only locally on my own server
- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
