### PR TITLE
[fix] remove useless transcription file

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -806,6 +806,11 @@ video_transcription:
   # At least 1 remote runner must be configured to transcribe your videos
   remote_runners:
     enabled: false
+  
+  # Size of transcription files to keep on your server
+  # If the transcription file is smaller than this size, PeerTube will delete it after transcription
+  # With this setting, you can limit the hallucinations of the transcription engine
+  limit_valid_transcription_size: 100
 
 video_file:
   update:

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -750,6 +750,9 @@ const CONFIG = {
     get MODEL_PATH () {
       return config.get<string>('video_transcription.model_path')
     },
+    get LIMIT_VALID_TRANSCRIPTION_SIZE () {
+      return config.get<number>('video_transcription.limit_valid_transcription_size')
+    },
     REMOTE_RUNNERS: {
       get ENABLED () {
         return config.get<boolean>('video_transcription.remote_runners.enabled')


### PR DESCRIPTION
## Description

The automatic transcription creation feature generates hallucinations: videos without subtitles end up with useless subtitles, and a notification indicates the creation of subtitles in a random language. To address this, we simply added the option to keep transcription files only if they exceed a certain size, so the majority of hallucinations are not stored.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/6468 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
