### PR TITLE
Allow auth plugins to redirect to external url

### DIFF
--- a/server/core/lib/auth/external-auth.ts
+++ b/server/core/lib/auth/external-auth.ts
@@ -45,7 +45,7 @@ async function onExternalUserAuthenticated (options: {
     return
   }
 
-  const { res } = authResult
+  const { res, externalRedirectUrl } = authResult
 
   if (!isAuthResultValid(npmName, authName, authResult)) {
     res.redirect('/login?externalAuthError=true')
@@ -76,7 +76,8 @@ async function onExternalUserAuthenticated (options: {
     }
   }
 
-  res.redirect(`/login?externalAuthToken=${bypassToken}&username=${user.username}`)
+  const base = externalRedirectUrl || '/login'
+  res.redirect(`${base}?externalAuthToken=${bypassToken}&username=${user.username}`)
 }
 
 async function getAuthNameFromRefreshGrant (refreshToken?: string) {

--- a/server/core/types/plugins/register-server-auth.model.ts
+++ b/server/core/types/plugins/register-server-auth.model.ts
@@ -33,6 +33,8 @@ export interface RegisterServerAuthenticatedResult {
 export interface RegisterServerExternalAuthenticatedResult extends RegisterServerAuthenticatedResult {
   req: express.Request
   res: express.Response
+  // Redirect the user to this external URL after the external auth has been verified.
+  externalRedirectUrl: [string]
 }
 
 interface RegisterServerAuthBase {


### PR DESCRIPTION
## Description

Add a new optional field to `RegisterServerExternalAuthenticatedResult`, the object passed to the `userAuthenticated` callback used by auth plugins.

The server code uses this to redirect to an external website if it is set.

Left TODO:

- This code has been tested manually but a test case is still missing.
- Here or in the plugin, the redirect urls must be limited to values configurable by admins.

## Related issues

#6258

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
