### PR TITLE
API-access for external auth plugins

### DIFF
--- a/server/core/lib/auth/external-auth.ts
+++ b/server/core/lib/auth/external-auth.ts
@@ -45,7 +45,7 @@ async function onExternalUserAuthenticated (options: {
     return
   }
 
-  const { res, externalRedirectUri } = authResult
+  const { res, externalRedirectUri, returnJsonNoRedirect } = authResult
 
   if (!isAuthResultValid(npmName, authName, authResult)) {
     res.redirect('/login?externalAuthError=true')
@@ -76,7 +76,9 @@ async function onExternalUserAuthenticated (options: {
     }
   }
 
-  if (externalRedirectUri) {
+  if(returnJsonNoRedirect) {
+    res.status(200).json({ externalAuthToken: bypassToken, username: user.username })
+  } else if (externalRedirectUri) {
     const url = new URL(externalRedirectUri)
     url.searchParams.set('externalAuthToken', bypassToken)
     url.searchParams.set('username', user.username)

--- a/server/core/types/plugins/register-server-auth.model.ts
+++ b/server/core/types/plugins/register-server-auth.model.ts
@@ -35,6 +35,8 @@ export interface RegisterServerExternalAuthenticatedResult extends RegisterServe
   res: express.Response
   // Redirect the user to this external URI after the external auth has been verified.
   externalRedirectUri?: string
+  // Respond with a 200 OK and JSON body instead of redirecting, to allow API access.
+  returnJsonNoRedirect?: boolean
 }
 
 interface RegisterServerAuthBase {


### PR DESCRIPTION
This allows auth plugins to return the bypass token as a JSON response, rather than in a redirection.

Using a redirect and putting the bypass token in the query parameter works when the browser goes through the login flow using the PeerTube frontend and redirect back to an external frontend afterwards. But for a purely API based access from an external frontend, the redirect does not work.

See https://framagit.org/framasoft/peertube/official-plugins/-/merge_requests/33 for more details on why it does not work and how the proposed change can be used in a plugin.

## Description

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/7181

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

