### PR TITLE
Loudness normalization

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -635,6 +635,10 @@ transcoding:
   web_videos:
     enabled: false
 
+  # Apply dynamic loudness normalization when transcoding audio
+  audio_loudnorm:
+    enabled: false
+
   # /!\ Requires ffmpeg >= 4.1
   # Generate HLS playlists and fragmented MP4 files. Better playback than with Web Videos:
   #     * Resolution change is smoother
@@ -725,6 +729,10 @@ live:
     # New profiles can be added by plugins
     # Available in core PeerTube: 'default'
     profile: 'default'
+
+    # Apply dynamic loudness normalization when transcoding audio in live
+    audio_loudnorm:
+      enabled: false
 
     resolutions:
       0p: false # Audio only

--- a/packages/ffmpeg/src/ffmpeg-vod.ts
+++ b/packages/ffmpeg/src/ffmpeg-vod.ts
@@ -203,7 +203,7 @@ export class FFmpegVOD {
 
     const videoPath = this.getHLSVideoPath(options)
 
-    if (options.copyCodecs) {
+    if (options.copyCodecs && !this.commandWrapper.isAudioLoudnormEnabled()) {
       presetCopy(this.commandWrapper, {
         withAudio: !options.separatedAudio || !options.resolution,
         withVideo: !options.separatedAudio || !!options.resolution

--- a/packages/models/src/server/custom-config.model.ts
+++ b/packages/models/src/server/custom-config.model.ts
@@ -199,6 +199,10 @@ export interface CustomConfig {
       enabled: boolean
       splitAudioAndVideo: boolean
     }
+
+    audioLoudnorm?: {
+      enabled: boolean
+    }
   }
 
   live: {
@@ -227,6 +231,10 @@ export interface CustomConfig {
 
       fps: {
         max: number
+      }
+
+      audioLoudnorm?: {
+        enabled: boolean
       }
     }
   }

--- a/packages/models/src/videos/transcoding/video-transcoding.model.ts
+++ b/packages/models/src/videos/transcoding/video-transcoding.model.ts
@@ -20,6 +20,9 @@ export type EncoderOptionsBuilderParams = {
 
   // For lives
   streamNum?: number
+
+  // Flag to enforce audio loudness normalization
+  audioLoudnorm?: boolean
 }
 
 export type EncoderOptionsBuilder = (params: EncoderOptionsBuilderParams) => Promise<EncoderOptions> | EncoderOptions

--- a/server/core/controllers/api/config.ts
+++ b/server/core/controllers/api/config.ts
@@ -422,6 +422,9 @@ function customConfig (): CustomConfig {
       originalFile: {
         keep: CONFIG.TRANSCODING.ORIGINAL_FILE.KEEP
       },
+      audioLoudnorm: {
+        enabled: CONFIG.TRANSCODING.AUDIO_LOUDNORM.ENABLED
+      },
       remoteRunners: {
         enabled: CONFIG.TRANSCODING.REMOTE_RUNNERS.ENABLED
       },
@@ -466,6 +469,9 @@ function customConfig (): CustomConfig {
         enabled: CONFIG.LIVE.TRANSCODING.ENABLED,
         remoteRunners: {
           enabled: CONFIG.LIVE.TRANSCODING.REMOTE_RUNNERS.ENABLED
+        },
+        audioLoudnorm: {
+          enabled: CONFIG.LIVE.TRANSCODING.AUDIO_LOUDNORM.ENABLED
         },
         threads: CONFIG.LIVE.TRANSCODING.THREADS,
         profile: CONFIG.LIVE.TRANSCODING.PROFILE,

--- a/server/core/helpers/ffmpeg/ffmpeg-options.ts
+++ b/server/core/helpers/ffmpeg/ffmpeg-options.ts
@@ -21,7 +21,12 @@ export function getFFmpegCommandWrapperOptions (type: CommandType, availableEnco
       warn: logger.warn.bind(logger),
       error: logger.error.bind(logger)
     },
-    lTags: { tags: [ 'ffmpeg' ] }
+    lTags: { tags: [ 'ffmpeg' ] },
+    audioLoudnorm: type === 'vod'
+      ? CONFIG.TRANSCODING.AUDIO_LOUDNORM.ENABLED
+      : type === 'live'
+        ? CONFIG.LIVE.TRANSCODING.AUDIO_LOUDNORM.ENABLED
+        : false
   }
 }
 

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -578,6 +578,12 @@ const CONFIG = {
     get PROFILE () {
       return config.get<string>('transcoding.profile')
     },
+
+    AUDIO_LOUDNORM: {
+      get ENABLED () {
+        return config.get<boolean>('transcoding.audio_loudnorm.enabled')
+      }
+    },
     get ALWAYS_TRANSCODE_ORIGINAL_RESOLUTION () {
       return config.get<boolean>('transcoding.always_transcode_original_resolution')
     },
@@ -704,6 +710,12 @@ const CONFIG = {
       },
       get PROFILE () {
         return config.get<string>('live.transcoding.profile')
+      },
+
+      AUDIO_LOUDNORM: {
+        get ENABLED () {
+          return config.get<boolean>('live.transcoding.audio_loudnorm.enabled')
+        }
       },
 
       get ALWAYS_TRANSCODE_ORIGINAL_RESOLUTION () {


### PR DESCRIPTION
## Description

This PR adds loudness normalization through ffmpeg audi filter options. Normalization can be toggled via PeerTube config options separately for VOD and Live. If we decide to add it or proceed with better implementation i'm ready to pour more time to help get this done

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/3651

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help

