### PR TITLE
feat: add resend verification email functionality to admin users list

### DIFF
--- a/client/src/app/+admin/overview/users/user-list/user-list.component.ts
+++ b/client/src/app/+admin/overview/users/user-list/user-list.component.ts
@@ -2,7 +2,7 @@ import { CommonModule, NgClass } from '@angular/common'
 import { Component, OnDestroy, OnInit, inject, viewChild } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { RouterLink } from '@angular/router'
-import { AuthService, ConfirmService, HooksService, Notifier, PluginService } from '@app/core'
+import { AuthService, ConfirmService, HooksService, Notifier, PluginService, UserService } from '@app/core'
 import { formatICU, getBackendHost } from '@app/helpers'
 import { Actor } from '@app/shared/shared-main/account/actor.model'
 import { PTDatePipe } from '@app/shared/shared-main/common/date.pipe'
@@ -72,6 +72,7 @@ export class UserListComponent implements OnInit, OnDestroy {
   private userAdminService = inject(UserAdminService)
   private hooks = inject(HooksService)
   private pluginService = inject(PluginService)
+  private userService = inject(UserService)
 
   readonly userBanModal = viewChild<UserBanModalComponent>('userBanModal')
   readonly table = viewChild<TableComponent<User, ColumnName>>('table')
@@ -154,7 +155,6 @@ export class UserListComponent implements OnInit, OnDestroy {
         },
         {
           label: $localize`Re-send verification emails`,
-          description: $localize`Send verification emails to unverified users`,
           handler: users => this.resendVerificationEmails(users),
           isDisplayed: users => {
             return users.every(u => this.authUser.canManage(u) && !u.blocked && u.emailVerified !== true && !u.pluginAuth)
@@ -274,7 +274,7 @@ export class UserListComponent implements OnInit, OnDestroy {
   }
 
   resendVerificationEmails (users: User[]) {
-    this.userAdminService.resendVerificationEmails(users.map(u => u.email))
+    this.userService.askSendVerifyEmail(users.map(u => u.email))
       .subscribe({
         next: () => {
           this.notifier.success(

--- a/client/src/app/shared/shared-moderation/user-moderation-dropdown.component.ts
+++ b/client/src/app/shared/shared-moderation/user-moderation-dropdown.component.ts
@@ -1,6 +1,6 @@
 import { NgIf } from '@angular/common'
 import { Component, OnChanges, OnInit, inject, input, output, viewChild } from '@angular/core'
-import { AuthService, ConfirmService, HooksService, Notifier, ServerService } from '@app/core'
+import { AuthService, ConfirmService, HooksService, Notifier, ServerService, UserService } from '@app/core'
 import { BulkRemoveCommentsOfBody, User, UserRight } from '@peertube/peertube-models'
 import { Account } from '../shared-main/account/account.model'
 import { ActionDropdownComponent, DropdownAction } from '../shared-main/buttons/action-dropdown.component'
@@ -33,6 +33,7 @@ export class UserModerationDropdownComponent implements OnInit, OnChanges {
   private userAdminService = inject(UserAdminService)
   private blocklistService = inject(BlocklistService)
   private bulkService = inject(BulkService)
+  private userService = inject(UserService)
   private hooks = inject(HooksService)
 
   readonly userBanModal = viewChild<UserBanModalComponent>('userBanModal')
@@ -136,7 +137,7 @@ export class UserModerationDropdownComponent implements OnInit, OnChanges {
   }
 
   resendVerificationEmail (user: User) {
-    this.userAdminService.resendVerificationEmail(user.email)
+    this.userService.askSendVerifyEmail(user.email)
       .subscribe({
         next: () => {
           this.notifier.success($localize`Verification email sent to ${user.email}`)
@@ -387,7 +388,6 @@ export class UserModerationDropdownComponent implements OnInit, OnChanges {
         },
         {
           label: $localize`Re-send verification email`,
-          description: $localize`Send email verification link to user`,
           handler: ({ user }) => this.resendVerificationEmail(user),
           isDisplayed: ({ user }) => !user.blocked && user.emailVerified !== true && !user.pluginAuth
         }

--- a/client/src/app/shared/shared-users/user-admin.service.ts
+++ b/client/src/app/shared/shared-users/user-admin.service.ts
@@ -119,20 +119,6 @@ export class UserAdminService {
       )
   }
 
-  resendVerificationEmail (userEmail: string) {
-    return this.authHttp.post(UserService.BASE_USERS_URL + 'ask-send-verify-email', { email: userEmail })
-      .pipe(catchError(err => this.restExtractor.handleError(err)))
-  }
-
-  resendVerificationEmails (userEmails: string[]) {
-    return from(userEmails)
-      .pipe(
-        concatMap(email => this.resendVerificationEmail(email)),
-        toArray(),
-        catchError(err => this.restExtractor.handleError(err))
-      )
-  }
-
   private formatUser (user: UserServerModel, translations: { [id: string]: string } = {}): UserAdmin {
     let videoQuota
     if (user.videoQuota === -1) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, with motivation and context -->
- Add 'Resend verification email' action to user moderation dropdown
- Add bulk 'Resend verification emails' action to admin users list
- Reuse existing `/api/v1/users/ask-send-verify-email` endpoint
- Proper error handling and success notifications
- Rate limiting: Existing email throttling applies

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
- fixes #5381

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Testing Instructions for Maintainers

**Individual Resend**
1. Navigate to Admin → Users
2. Locate user with unverified email (✗ icon)
3. Click Actions dropdown → "Re-send verification email"
4. Verify success notification appears
5. Check user's email inbox for verification message

**Bulk Resend**
1. In Admin → Users, select multiple unverified users (checkboxes)
2. Click "Re-send verification emails" in batch actions
3. Verify plural success notification: "X verification emails sent"
4. Confirm all selected users received emails

## Edge Cases
- Verified users: Actions should not appear
- Plugin auth users: Actions should not appear
- Blocked users: Actions should not appear
- SMTP disabled: Should show appropriate error message