### PR TITLE
Update README.md: adjust copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See our [ActivityPub documentation](https://docs.joinpeertube.org/api/activitypu
 
 ### Code
 
-Copyright (C) 2015-2024 PeerTube Contributors (see [CREDITS.md](/CREDITS.md))
+Copyright (C) 2015-2025 PeerTube Contributors (see [CREDITS.md](/CREDITS.md))
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published


### PR DESCRIPTION
Thanks for your work on peertube. This is a tiny pull request to adapt the copyright year to the current year.

Please let me know if this is not applicable / has been left as is by choice.


Best,

Hannes