### PR TITLE
fix(runner): wait for `.ts` segments to be fully written before upload

### DIFF
--- a/packages/tests/src/peertube-runner/await-write-finish.ts
+++ b/packages/tests/src/peertube-runner/await-write-finish.ts
@@ -1,0 +1,117 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions,@typescript-eslint/require-await */
+
+import { expect } from 'chai'
+import { watch } from 'chokidar'
+import { ensureDir, remove } from 'fs-extra/esm'
+import { appendFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { buildUUID } from '@peertube/peertube-node-utils'
+import { wait } from '@peertube/peertube-core-utils'
+
+/**
+ * Test for awaitWriteFinish configuration in file watcher.
+ *
+ * This test verifies the fix for issue #7328:
+ * Without awaitWriteFinish, chokidar triggers 'add' events immediately when a file
+ * is created, even if it's still being written. This caused HTTP 416 errors during
+ * live streaming because incomplete .ts segments were uploaded to the server.
+ *
+ * With awaitWriteFinish, chokidar waits for the file size to stabilize before
+ * triggering the event, ensuring complete files are processed.
+ */
+describe('Test awaitWriteFinish file watcher behavior', function () {
+  let testDir: string
+  let watcher: ReturnType<typeof watch>
+
+  beforeEach(async function () {
+    // Use unique directory for each test to avoid cross-test interference
+    testDir = join(tmpdir(), 'peertube-test-' + buildUUID())
+    await ensureDir(testDir)
+  })
+
+  afterEach(async function () {
+    if (watcher) {
+      await watcher.close()
+      watcher = undefined
+    }
+    await remove(testDir)
+  })
+
+  it('Should wait for file to be fully written before triggering add event', async function () {
+    this.timeout(10000)
+
+    const events: { event: string, path: string, time: number }[] = []
+    const startTime = Date.now()
+    const testFile = join(testDir, 'test-segment.ts')
+
+    // Create watcher with awaitWriteFinish (same config as in process-live.ts)
+    watcher = watch(testDir, {
+      ignored: (path: string) => path !== testDir && !path.endsWith('.ts'),
+      awaitWriteFinish: {
+        stabilityThreshold: 500,
+        pollInterval: 100
+      }
+    })
+
+    watcher.on('add', (path) => {
+      events.push({ event: 'add', path, time: Date.now() - startTime })
+    })
+
+    // Wait for watcher to be ready
+    await new Promise<void>(resolve => watcher.on('ready', resolve))
+
+    // Simulate slow file write (like FFmpeg writing a segment)
+    await writeFile(testFile, 'chunk1')
+    await wait(100)
+    await appendFile(testFile, 'chunk2')
+    await wait(100)
+    await appendFile(testFile, 'chunk3')
+
+    const writeEndTime = Date.now() - startTime
+
+    // Wait for awaitWriteFinish to detect stability (500ms + buffer)
+    await wait(800)
+
+    // Verify: event should have fired AFTER writes completed + stability threshold
+    expect(events).to.have.lengthOf(1)
+    expect(events[0].event).to.equal('add')
+    expect(events[0].path).to.equal(testFile)
+
+    // The event should fire after stability threshold (500ms) from last write
+    // Last write was at ~200ms, so event should be around 700ms+
+    expect(events[0].time).to.be.greaterThan(writeEndTime + 400)
+  })
+
+  it('Should trigger immediately without awaitWriteFinish', async function () {
+    this.timeout(5000)
+
+    if (watcher) await watcher.close()
+
+    const events: { event: string, path: string, time: number }[] = []
+    const startTime = Date.now()
+    const testFile = join(testDir, 'test-immediate.ts')
+
+    // Create watcher WITHOUT awaitWriteFinish (old behavior)
+    watcher = watch(testDir, {
+      ignored: (path: string) => path !== testDir && !path.endsWith('.ts')
+      // No awaitWriteFinish - triggers immediately
+    })
+
+    watcher.on('add', (path) => {
+      events.push({ event: 'add', path, time: Date.now() - startTime })
+    })
+
+    await new Promise<void>(resolve => watcher.on('ready', resolve))
+
+    // Write file
+    await writeFile(testFile, 'chunk1')
+
+    // Give a small window for the event
+    await wait(200)
+
+    // Verify: event should have fired almost immediately (< 200ms)
+    expect(events).to.have.lengthOf(1)
+    expect(events[0].time).to.be.lessThan(200)
+  })
+})

--- a/packages/tests/src/peertube-runner/index.ts
+++ b/packages/tests/src/peertube-runner/index.ts
@@ -1,3 +1,4 @@
+export * from './await-write-finish.js'
 export * from './client-cli.js'
 export * from './custom-upload.js'
 export * from './generate-storyboard.js'


### PR DESCRIPTION

## Description

<!-- Please include a summary of the change, with motivation and context -->

In my analysis of 416 errors mentioned in #7328, I've seen this related to the use of Remote Runners. I have [a runner solution](https://github.com/OwnTube-tv/peertube-runner) that I'm using, and I suspect that it could produce incomplete segments as input for PeerTube. See illustrations below on how I understand the race conditions.

**The Race Condition**

```plain
┌─────────────────────────────────────────────────────────────────────┐
│                    [[ Remote Runner ]]                              │
│                                                                     │
│   FFmpeg ──writes──► segment-001.ts (incomplete)                    │
│                           │                                         │
│                           ▼                                         │
│  chokidar ────'add'────► triggers IMMEDIATELY (no awaitWriteFinish) │
│                           │                                         │
│                           ▼                                         │
│  sendPendingChunks() ──► reads incomplete file                      │
│                           │                                         │
└───────────────────────────┼─────────────────────────────────────────┘
                            │ HTTP POST /jobs/:uuid/update
                            ▼
┌─────────────────────────────────────────────────────────────────────┐
│                   [[ PeerTube Server ]]                             │
│                                                                     │
│   Receives incomplete segment ──► writes to disk ──► Nginx serves   │
│                                                                     │
└─────────────────────────────────────────────────────────────────────┘
```

Line 74 in `PeerTube/apps/peertube-runner/src/server/process/shared/process-live.ts` is the culprit:

```typescript
const tsWatcher = watch(this.outputPath, { ignored: ... })
// No awaitWriteFinish! File detected immediately while FFmpeg still writing!
```

**The Fix**

The fix is to add `awaitWriteFinish` to the watcher:

```typescript
const tsWatcher = watch(this.outputPath, {
  ignored: path => path !== this.outputPath && !path.endsWith('.ts'),
  awaitWriteFinish: {
    stabilityThreshold: 500,  // Wait 500ms for file size to stabilize
    pollInterval: 100
  }
})
```

This makes chokidar wait until FFmpeg finishes writing before triggering the event. Without this option, my AI tools says that chokidar triggers the 'add' event immediately when FFmpeg creates the segment file, before FFmpeg finishes writing to it. This could cause the runner to occasionally upload incomplete segments, which then leads to HTTP 416 "Requested Range Not Satisfiable" errors when players request byte ranges beyond what was actually written.

Thank you for considering my theory here. PeerTube is the best! 🤗

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes: #7328

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

<!-- ## Screenshots -->

<!-- delete if not relevant -->
