### PR TITLE
fix(live): add FFmpeg `temp_file` HLS flag to prevent incomplete segment reads

### DIFF
--- a/packages/ffmpeg/src/ffmpeg-live.ts
+++ b/packages/ffmpeg/src/ffmpeg-live.ts
@@ -253,7 +253,7 @@ export class FFmpegLive {
 
     command.outputOption('-hls_time ' + segmentDuration)
     command.outputOption('-hls_list_size ' + segmentListSize)
-    command.outputOption('-hls_flags delete_segments+independent_segments+program_date_time')
+    command.outputOption('-hls_flags delete_segments+independent_segments+program_date_time+temp_file')
     command.outputOption(`-hls_segment_filename ${join(outPath, '%v-%06d.ts')}`)
     command.outputOption('-master_pl_name ' + masterPlaylistName)
     command.outputOption(`-f hls`)


### PR DESCRIPTION
Ping @Chocobozzz, here's your genius solution from https://github.com/Chocobozzz/PeerTube/issues/7328#issuecomment-3646543213, I was dying to try it out! 😎 

## Description

When FFmpeg writes HLS segments, the segment file is created before all data is written. This can potentially cause HTTP 416 (Range Not Satisfiable) errors when players request byte ranges that don't yet exist in the file. The `temp_file` flag makes FFmpeg write segments to a temporary file and atomically rename to the final name only when the segment is complete.

## Related issues

Resolves: #7328

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help, I don't know how we'd test this meaningfully!
