### PR TITLE
Fix typos in config files and Nginx template

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -827,8 +827,8 @@ import:
         # You can also use a youtube-dl standalone binary (requires python_path: null)
         # GNU/Linux binaries with support for impersonating browser requests (required by some platforms such as Vimeo) examples:
         #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux (x64)
-        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l (ARMv7)
-        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l (ARMv8/AArch64/ARM64)
+        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l.zip (ARMv7)
+        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_aarch64 (ARMv8/AArch64/ARM64)
         url: 'https://api.github.com/repos/yt-dlp/yt-dlp/releases'
 
         # Release binary name: 'yt-dlp' or 'youtube-dl'
@@ -999,7 +999,7 @@ instance:
   # To discourage researchers from testing your instance and disable security.txt integration, set this to an empty string
   securitytxt: |
     Contact: https://github.com/Chocobozzz/PeerTube/blob/develop/SECURITY.md
-    Expires: 2025-12-31T11:00:00.000Z'
+    Expires: 2025-12-31T11:00:00.000Z
 
 services:
   # Cards configuration to format video in Twitter/X

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -837,8 +837,8 @@ import:
         # You can also use a youtube-dl standalone binary (requires python_path: null)
         # GNU/Linux binaries with support for impersonating browser requests (required by some platforms such as Vimeo) examples:
         #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux (x64)
-        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l (ARMv7)
-        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l (ARMv8/AArch64/ARM64)
+        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l.zip (ARMv7)
+        #   * https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_aarch64 (ARMv8/AArch64/ARM64)
         url: 'https://api.github.com/repos/yt-dlp/yt-dlp/releases'
 
         # Release binary name: 'yt-dlp' or 'youtube-dl'
@@ -1009,7 +1009,7 @@ instance:
   # To discourage researchers from testing your instance and disable security.txt integration, set this to an empty string
   securitytxt: |
     Contact: https://github.com/Chocobozzz/PeerTube/blob/develop/SECURITY.md
-    Expires: 2025-12-31T11:00:00.000Z'
+    Expires: 2025-12-31T11:00:00.000Z
 
 services:
   # Cards configuration to format video in Twitter/X

--- a/support/nginx/peertube
+++ b/support/nginx/peertube
@@ -234,7 +234,7 @@ server {
       add_header Access-Control-Allow-Methods 'GET, OPTIONS';
       add_header Access-Control-Allow-Headers 'Range,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
       add_header Access-Control-Max-Age       1728000; # Preflight request can be cached 20 days
-      add_header Content-Type                 'text/plain charset=UTF-8';
+      add_header Content-Type                 'text/plain; charset=UTF-8';
       add_header Content-Length               0;
       return 204;
     }


### PR DESCRIPTION
## Description

Small nags I'm getting from @Copilot AI on my PRs, I think it's better to fix them upstream than diverge forks:
- Add missing semicolon in Content-Type header per [RFC 2045](https://datatracker.ietf.org/doc/html/rfc2045#section-5.1)
- Remove invalid trailing quote in `securitytxt` YAML blocks
- Fix yt-dlp/yt-dlp ARM binary URLs (`armv7l.zip` for ARMv7, `aarch64` for ARM64)

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
