### PR TITLE
Update Dockerfile for VAAPI

### DIFF
--- a/support/docker/production/Dockerfile
+++ b/support/docker/production/Dockerfile
@@ -4,7 +4,7 @@ ARG ALREADY_BUILT=0
 
 # Install dependencies
 RUN apt update \
- && apt install -y --no-install-recommends openssl ffmpeg python3 python3-pip ca-certificates gnupg gosu build-essential curl git \
+ && apt install -y --no-install-recommends openssl ffmpeg python3 python3-pip ca-certificates gnupg gosu build-essential curl git va-driver-all \
  && gosu nobody true \
  && rm /var/lib/apt/lists/* -fR
 


### PR DESCRIPTION
added to install va-driver-all for Intel and AMD users of VAAPI

## Description

Insalling va-driver-all metapackage will install all the needed components for VAAPI support for Intel and AMD users.


## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

it's an exceedingly simply change of just installing some drivers. i do have a homespun build which includes this change and everything works as expected.