### PR TITLE
add filter:feed.videos.list.result hook

### DIFF
--- a/packages/models/src/plugins/server/server-hook.model.ts
+++ b/packages/models/src/plugins/server/server-hook.model.ts
@@ -149,7 +149,10 @@ export const serverFilterHookObject = {
 
   // Peertube >= 7.2
   'filter:email.subject.result': true,
-  'filter:email.template-path.result': true
+  'filter:email.template-path.result': true,
+
+  // Peertube >= 8.1
+  'filter:feed.videos.list.result': true,
 }
 
 export type ServerFilterHookName = keyof typeof serverFilterHookObject

--- a/packages/tests/fixtures/peertube-plugin-test/main.js
+++ b/packages/tests/fixtures/peertube-plugin-test/main.js
@@ -105,6 +105,15 @@ async function register ({ registerHook, registerSetting, settingsManager, stora
   })
 
   registerHook({
+    target: 'filter:feed.videos.list.result',
+    handler: (result) => {
+      result.data[0].name = 'Custom name by hook'
+
+      return result
+    }
+  })
+
+  registerHook({
     target: 'filter:api.accounts.videos.list.params',
     handler: obj => addToCount(obj)
   })

--- a/packages/tests/src/plugins/filter-hooks.ts
+++ b/packages/tests/src/plugins/filter-hooks.ts
@@ -190,6 +190,17 @@ describe('Test plugin filter hooks', function () {
       expect(total).to.equal(14)
     })
 
+    it('Should run filter:feed.videos.list.result', async function () {
+      const xmlFeed = await servers[0].feed.getXML({ feed: 'videos', ignoreCache: true })
+      expect(xmlFeed).to.contain('Custom name by hook')
+
+      const podcastFeed = await servers[0].feed.getPodcastXML({ channelId: servers[0].store.channel.id, ignoreCache: true })
+      expect(podcastFeed).to.contain('Custom name by hook')
+
+      const jsonFeed = await servers[0].feed.getJSON({ feed: 'videos', ignoreCache: true })
+      expect(jsonFeed).to.contain('Custom name by hook')
+    })
+
     it('Should run filter:api.video.get.result', async function () {
       const video = await servers[0].videos.get({ id: videoUUID })
       expect(video.name).to.contain('<3')

--- a/server/core/controllers/feeds/shared/video-feed-utils.ts
+++ b/server/core/controllers/feeds/shared/video-feed-utils.ts
@@ -3,6 +3,7 @@ import { VideoIncludeType } from '@peertube/peertube-models'
 import { mdToPlainText, toSafeHtml } from '@server/helpers/markdown.js'
 import { CONFIG } from '@server/initializers/config.js'
 import { WEBSERVER } from '@server/initializers/constants.js'
+import { Hooks } from '@server/lib/plugins/hooks.js'
 import { getServerActor } from '@server/models/application/application.js'
 import { getCategoryLabel } from '@server/models/video/formatter/index.js'
 import { DisplayOnlyForFollowerOptions } from '@server/models/video/sql/video/index.js'
@@ -22,7 +23,9 @@ export async function getVideosForFeeds (options: {
 }) {
   const server = await getServerActor()
 
-  const { data } = await VideoModel.listForApi({
+  const { data } = await Hooks.wrapPromiseFun(
+    VideoModel.listForApi.bind(VideoModel),
+    {
     start: 0,
     count: CONFIG.FEEDS.VIDEOS.COUNT,
     displayOnlyForFollower: {
@@ -33,7 +36,9 @@ export async function getVideosForFeeds (options: {
     countVideos: false,
 
     ...options
-  })
+  },
+    'filter:feed.videos.list.result'
+  )
 
   return data
 }


### PR DESCRIPTION
## Description
Pass videos through `filter:feed.videos.list.result` before creating the podcast, XML och JSON feed.

## Related issues
closes #7314


## Has this been tested?

- [x] 👍 yes, I added tests to the test suite

## Screenshots

<!-- delete if not relevant -->
