### PR TITLE
fix: 7317 support pg ssl

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -80,8 +80,8 @@ trust_proxy:
 database:
   hostname: '127.0.0.1'
   port: 5432
+  ssl: false
   ssl_settings: 
-    enabled: false
     reject_unauthorized: false
     ca: '/absolute/path/to/server-certificates/root.crt'
     cert: '/absolute/path/to/client-certificates/postgresql.crt'

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -78,8 +78,8 @@ trust_proxy:
 database:
   hostname: '127.0.0.1'
   port: 5432
+  ssl: false
   ssl_settings: 
-    enabled: false
     reject_unauthorized: false
     ca: '/absolute/path/to/server-certificates/root.crt'
     cert: '/absolute/path/to/client-certificates/postgresql.crt'

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -37,10 +37,8 @@ const CONFIG = {
     DBNAME: config.has('database.name') ? config.get<string>('database.name') : 'peertube' + config.get<string>('database.suffix'),
     HOSTNAME: config.get<string>('database.hostname'),
     PORT: config.get<number>('database.port'),
+    SSL: config.get<boolean>('database.ssl'),
     SSL_SETTINGS: {
-      get ENABLED () {
-        return config.has('database.ssl_settings.enabled') ? config.get<boolean>('database.ssl_settings.enabled') : false
-      },
       get REJECT_UNAUTHORIZED () {
         return config.has('database.ssl_settings.reject_unauthorized') 
           ? config.get<boolean>('database.ssl_settings.reject_unauthorized') 

--- a/server/core/initializers/database.ts
+++ b/server/core/initializers/database.ts
@@ -86,10 +86,13 @@ const poolMax = CONFIG.DATABASE.POOL.MAX
 
 let dialectOptions: any = {}
 
-if (CONFIG.DATABASE.SSL_SETTINGS.ENABLED) {
+if (CONFIG.DATABASE.SSL) {
   // For reference: https://node-postgres.com/features/ssl
-  dialectOptions = { ssl: { rejectUnauthorized: CONFIG.DATABASE.SSL_SETTINGS.REJECT_UNAUTHORIZED } }
-  
+  dialectOptions = { 
+    ssl: { 
+      rejectUnauthorized: CONFIG.DATABASE.SSL_SETTINGS.REJECT_UNAUTHORIZED
+    }
+  }
   if (CONFIG.DATABASE.SSL_SETTINGS.CA) {
     dialectOptions.ssl.ca = readFileSync(CONFIG.DATABASE.SSL_SETTINGS.CA, { encoding: 'utf8' })
   }


### PR DESCRIPTION
## Description

Added the ability to specify TLS credentials for PostgreSQL. 

## Related issues

#7317

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
