### PR TITLE
fix: 7317 support redis tls

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -95,16 +95,16 @@ redis:
   port: 6379
   auth: null
   db: 0
+  tls: false
   tls_settings: 
-    enabled: false
     reject_unauthorized: false
     ca: '/absolute/path/to/server-certificates/root.crt'
     cert: '/absolute/path/to/client-certificates/postgresql.crt'
     key: '/absolute/path/to/client-key/postgresql.key'
   sentinel:
     enabled: false
+    enable_tls: false
     tls_settings: 
-      enabled: false
       reject_unauthorized: false
       ca: '/absolute/path/to/server-certificates/root.crt'
       cert: '/absolute/path/to/client-certificates/postgresql.crt'

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -93,16 +93,16 @@ redis:
   port: 6379
   auth: null
   db: 0
+  tls: false
   tls_settings: 
-    enabled: false
     reject_unauthorized: false
     ca: '/absolute/path/to/server-certificates/root.crt'
     cert: '/absolute/path/to/client-certificates/postgresql.crt'
     key: '/absolute/path/to/client-key/postgresql.key'
   sentinel:
     enabled: false
+    enable_tls: false
     tls_settings: 
-      enabled: false
       reject_unauthorized: false
       ca: '/absolute/path/to/server-certificates/root.crt'
       cert: '/absolute/path/to/client-certificates/postgresql.crt'

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -50,10 +50,8 @@ const CONFIG = {
     SOCKET: config.has('redis.socket') ? config.get<string>('redis.socket') : null,
     AUTH: config.has('redis.auth') ? config.get<string>('redis.auth') : null,
     DB: config.has('redis.db') ? config.get<number>('redis.db') : null,
+    TLS: config.has('redis.tls') ? config.get<boolean>('redis.tls') : false,
     TLS_SETTINGS: {
-      get ENABLED () {
-        return config.has('redis.tls_settings.enabled') ? config.get<boolean>('redis.tls_settings.enabled') : false
-      },
       get REJECT_UNAUTHORIZED () {
         return config.has('redis.tls_settings.reject_unauthorized') 
           ? config.get<boolean>('redis.tls_settings.reject_unauthorized') 
@@ -71,10 +69,8 @@ const CONFIG = {
     },
     SENTINEL: {
       ENABLED: config.has('redis.sentinel.enabled') ? config.get<boolean>('redis.sentinel.enabled') : false,
+      ENABLE_TLS: config.has('redis.sentinel.enable_tls') ? config.get<boolean>('redis.sentinel.enable_tls') : false,
       TLS_SETTINGS: {
-        get ENABLED () {
-          return config.has('redis.sentinel.tls_settings.enabled') ? config.get<boolean>('redis.sentinel.tls_settings.enabled') : false
-        },
         get REJECT_UNAUTHORIZED () {
           return config.has('redis.sentinel.tls_settings.reject_unauthorized') 
             ? config.get<boolean>('redis.sentinel.tls_settings.reject_unauthorized') 

--- a/server/core/lib/redis.ts
+++ b/server/core/lib/redis.ts
@@ -73,10 +73,8 @@ class Redis {
         )
       }
 
-      let enableTLSForSentinelMode = false
       let sentinelTLS: ConnectionOptions = undefined
-      if (CONFIG.REDIS.SENTINEL.TLS_SETTINGS.ENABLED) {
-        enableTLSForSentinelMode = true
+      if (CONFIG.REDIS.SENTINEL.ENABLE_TLS) {
         sentinelTLS = { rejectUnauthorized: CONFIG.REDIS.SENTINEL.TLS_SETTINGS.REJECT_UNAUTHORIZED }
 
         if (CONFIG.REDIS.SENTINEL.TLS_SETTINGS.CA) {
@@ -93,7 +91,7 @@ class Redis {
       return {
         connectionName,
         connectTimeout,
-        enableTLSForSentinelMode,
+        enableTLSForSentinelMode: CONFIG.REDIS.SENTINEL.ENABLE_TLS,
         sentinelPassword: CONFIG.REDIS.SENTINEL.PASSWORD,
         password: CONFIG.REDIS.AUTH,
         sentinels: CONFIG.REDIS.SENTINEL.SENTINELS,
@@ -111,7 +109,7 @@ class Redis {
     }
 
     let tls: ConnectionOptions = undefined
-    if (CONFIG.REDIS.SENTINEL.TLS_SETTINGS.ENABLED) {
+    if (CONFIG.REDIS.TLS) {
       tls = { rejectUnauthorized: CONFIG.REDIS.TLS_SETTINGS.REJECT_UNAUTHORIZED }
 
       if (CONFIG.REDIS.TLS_SETTINGS.CA) {


### PR DESCRIPTION
## Description

Added the ability to specify TLS credentials for Redis and Redis Sentinel.

## Related issues

#7317

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->