### PR TITLE
Fix: Server config not refreshing after admin settings save

### DIFF
--- a/client/src/app/shared/shared-admin/admin-config.service.ts
+++ b/client/src/app/shared/shared-admin/admin-config.service.ts
@@ -134,12 +134,14 @@ export class AdminConfigService {
     const { currentConfig, form, formConfig, success } = options
 
     this.updateCustomConfig(formConfig)
-      .subscribe({
-        next: newConfig => {
-          this.serverService.resetConfig()
-
+      .pipe(
+        switchMap(newConfig => {
           Object.assign(currentConfig, newConfig)
-
+          return this.serverService.resetConfig()
+        })
+      )
+      .subscribe({
+        next: () => {
           form.markAsPristine()
 
           this.notifier.success(success)


### PR DESCRIPTION
## Description
Fixes a critical bug where admin configuration changes were not taking effect until the page was manually refreshed or the server was restarted.

## Problem
The `saveAndUpdateCurrent()` method in `AdminConfigService` was calling `serverService.resetConfig()` but not subscribing to the returned Observable. In RxJS, Observables are lazy and don't execute unless subscribed to.

## Impact
This affects **all** admin configuration pages, not just live settings. Any configuration change requires a manual page refresh to take effect.

## Solution
Properly chain the `resetConfig()` call using `switchMap` to ensure the server config is fetched and updated before completing the save operation.

**Before (buggy):**
```typescript
this.updateCustomConfig(formConfig)
  .subscribe({
    next: newConfig => {
      this.serverService.resetConfig()  // Not subscribed!
      Object.assign(currentConfig, newConfig)
      form.markAsPristine()
      this.notifier.success(success)
    }
  })
```

**After (fixed):**
```typescript
this.updateCustomConfig(formConfig)
  .pipe(
    switchMap(newConfig => {
      Object.assign(currentConfig, newConfig)
      return this.serverService.resetConfig()  // Properly subscribed
    })
  )
  .subscribe({
    next: () => {
      form.markAsPristine()
      this.notifier.success(success)
    },
    error: err => this.notifier.handleError(err)
  })
```
## Testing Steps
Go to /admin/settings/config/live
Check "Automatically publish a replay by default"
Click Save
Go to /videos/upload#go-live
Click "Go Live"
The "Automatically publish a replay when your live ends" checkbox should now be checked by default

## Related Issues
fixes #7411 
related to #6304  