### PR TITLE
Reverting va-driver-all changes

### DIFF
--- a/support/docker/production/Dockerfile
+++ b/support/docker/production/Dockerfile
@@ -4,9 +4,7 @@ ARG ALREADY_BUILT=0
 
 # Install dependencies
 RUN apt update \
- && apt install -y --no-install-recommends openssl ffmpeg python3 python3-pip ca-certificates gnupg gosu build-essential curl git \
-  # We must install recommended packages
- && apt install -y va-driver-all \
+ && apt install -y --no-install-recommends openssl ffmpeg python3 python3-pip ca-certificates gnupg gosu build-essential curl git va-driver-all \
  && gosu nobody true \
  && rm /var/lib/apt/lists/* -fR
 


### PR DESCRIPTION
## Description

I deeply apologize, I got confused.

There was in fact nothing wrong with the original addition.

It just hadn't gone live yet in 8.0.2 and I assumed I did it wrong!

I re-checked the doc & re-tested on my system, and can confirm va-driver-all doesn't have any recs. Only deps and enh.

https://packages.debian.org/en/trixie/va-driver-all

So sorry for the hassle and confusion!

## Has this been tested?

Yes, on my machine.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ X ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
