### PR TITLE
Add missing i18n parameters

### DIFF
--- a/client/src/app/+videos-publish-manage/shared-manage/common/thumbnail-manager.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/common/thumbnail-manager.component.html
@@ -13,7 +13,7 @@
       @if (imageSrc) {
         <img [src]="imageSrc" alt="Current thumbnail" i18n-alt />
 
-        <div class="muted-2 fs-8 mt-1">Current thumbnail</div>
+        <div class="muted-2 fs-8 mt-1" i18n>Current thumbnail</div>
       } @else {
         <div class="no-image">
           <svg width="28" height="20" viewBox="0 0 28 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -25,7 +25,7 @@
     </div>
 
     <div class="mt-3">
-      <div class="muted-1">
+      <div class="muted-1" i18n>
         <strong>Drag and drop your thumbnail here</strong> or click on the button below to modify it:
       </div>
 


### PR DESCRIPTION
## Description

Adding two missing i18n parameters in order to make the thumbnail modal translations more complete.

## Related issues

#7448

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help (how to check if Angular catches up on the new additions?)
