### PR TITLE
putVideo tags encoding fix

### DIFF
--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -3192,6 +3192,9 @@ paths:
                 contentType: image/jpeg
               previewfile:
                 contentType: image/jpeg
+              tags:
+                style: form
+                explode: true
     get:
       summary: Get a video
       operationId: getVideo


### PR DESCRIPTION
## Description

When using openapi-generator to build an API from the spec, `tags` would have a `_collection_format` set to `csv`, which caused the API to submit eg "tags=tag1,tag2,tag3", instead of submitting multiple `tag` parameters, eg `tag=tag1,tag=tag2,tag=tag3`

Setting the encoding this way sets the `_collection_format` to `multi`, which works.

## Related issues

I didn't file a bug, but it happens.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->