### PR TITLE
Additional localisation improvements

### DIFF
--- a/client/src/app/shared/shared-video-miniature/download/video-generate-download.component.html
+++ b/client/src/app/shared/shared-video-miniature/download/video-generate-download.component.html
@@ -16,7 +16,7 @@
       <input type="radio" name="video-file" [id]="'file-' + file.id" [(ngModel)]="videoFileChosen" [value]="'file-' + file.id">
 
       <label [for]="'file-' + file.id">
-        <strong>{{ getLabel(file) }}</strong>
+        <strong i18n>{{ getLabel(file) }}</strong>
 
         <span class="muted">
           {{ getFileSize(file) | bytes: 1 }}

--- a/packages/core-utils/src/videos/common.ts
+++ b/packages/core-utils/src/videos/common.ts
@@ -53,7 +53,7 @@ export function getResolutionLabel (options: {
 }) {
   const { height, width } = options
 
-  if (options.resolution === 0) return $localize`Audio only`
+  if (options.resolution === 0) return 'Audio only'
 
   let resolution = options.resolution
 


### PR DESCRIPTION
## Description

In regards to issue #7453 the `Audio only` resolution label can be localised as shown in this PR. If I am wrong please correct me.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->
