### PR TITLE
fix: add missing dot to .ts extension in video/mp2t MIME type mapping

### DIFF
--- a/server/core/initializers/constants.ts
+++ b/server/core/initializers/constants.ts
@@ -1478,7 +1478,7 @@ function buildVideoMimetypeExt () {
 
         // The standard video format used by many Sony and Panasonic HD camcorders.
         // It is also used for storing high definition video on Blu-ray discs.
-        'video/mp2t': [ '.mts', 'ts' ],
+        'video/mp2t': [ '.mts', '.ts' ],
         'video/vnd.dlna.mpeg-tts': '.mts',
 
         'video/m2ts': '.m2ts',


### PR DESCRIPTION
Fixes #7456

## Problem

The MIME type `video/mp2t` was mapped to `[ '.mts', 'ts' ]` — note the **missing leading dot** on the second entry.

This caused two user-visible bugs:

1. **Uploading `.ts` files via `peertube-cli` returned HTTP 415** (Unsupported Media Type), because `'ts'` (without the dot) was never matched against the actual file extension `'.ts'`.

2. **The error message listed `ts` instead of `.ts`**, making it look like a UI typo rather than a rejected file.

## Fix

```diff
- 'video/mp2t': [ '.mts', 'ts' ],
+ 'video/mp2t': [ '.mts', '.ts' ],
```

One character change, consistent with every other extension entry in the map.