### PR TITLE
Bug:fixed Logo previews all disappear after deleting a single logo in…

### DIFF
--- a/server/core/controllers/api/config.ts
+++ b/server/core/controllers/api/config.ts
@@ -224,7 +224,6 @@ function updateInstanceImageFactory (imageType: ActorImageType_Type) {
 
     await updateServerActorImages(imageType)
 
-    getServerActor.clear()
     ClientHtml.invalidateCache()
     ModelCache.Instance.clearCache('server-account')
 
@@ -240,7 +239,6 @@ function deleteInstanceImageFactory (imageType: ActorImageType_Type) {
 
     await updateServerActorImages(imageType)
 
-    getServerActor.clear()
     ClientHtml.invalidateCache()
     ModelCache.Instance.clearCache('server-account')
 
@@ -269,7 +267,6 @@ async function updateInstanceLogo (req: express.Request, res: express.Response) 
     type: logoTypeToUploadImageEnum(req.params.logoType as LogoType)
   })
 
-  getServerActor.clear()
   ClientHtml.invalidateCache()
   ModelCache.Instance.clearCache('server-account')
 
@@ -282,7 +279,6 @@ async function deleteInstanceLogo (req: express.Request, res: express.Response) 
     type: logoTypeToUploadImageEnum(req.params.logoType as LogoType)
   })
 
-  getServerActor.clear()
   ClientHtml.invalidateCache()
   ModelCache.Instance.clearCache('server-account')
 


### PR DESCRIPTION
… admin config

### Current behavior

On the admin logo config page (/admin/settings/config/logo), deleting one of the four logos (Social media, Mobile header, Desktop header, Favicon) and saving causes all logo previews to disappear after reload, instead of only the deleted one.
Storage and database behave correctly: only the deleted image is removed from disk, and only that record is removed from the database. The bug is limited to the admin UI preview.

Current behavior: None of the four logo previews appear after deleting one.


### Steps to reproduce

1. Go to Admin → Configuration → Logo
2. Upload all four logos (Social media, Mobile header, Desktop header, Favicon)
3. Confirm all four previews appear
4. Delete one logo and click Save
5. Reload the page


### Expected behavior

Expected: Only the deleted logo’s preview is gone; the other three still show.


### Proposed Fix
1. server/core/lib/upload-image.ts – only remove deleted images
Replace clearing the entire array with filtering out only the deleted images:
// Only remove the deleted images from the cached actor - do NOT clear the entire// UploadImages array, as actor is the memoized getServerActor() return value.const deletedIds = new Set(imagesToDelete.map(i => i.id))actor.UploadImages = actor.UploadImages.filter(image => !deletedIds.has(image.id))
2. server/core/controllers/api/config.ts – invalidate memoized actor cache
Call getServerActor.clear() after logo, avatar, and banner create/update/delete. Add it alongside the existing ClientHtml.invalidateCache() and ModelCache.Instance.clearCache('server-account') calls.



### Additional information

* PeerTube instance:
  * URL: https://greyhive.com
  * Version: v8.0.2
  * NodeJS version: 20
  * Ffmpeg version:

* Browser name, version and platforms on which you could reproduce the bug: Chrome