### PR TITLE
Adding ability to customize border primary color

### DIFF
--- a/client/src/app/+admin/config/pages/admin-config-customization.component.ts
+++ b/client/src/app/+admin/config/pages/admin-config-customization.component.ts
@@ -56,6 +56,7 @@ type Form = {
 
     customization: FormGroup<{
       primaryColor: FormControl<string>
+      borderPrimaryColor: FormControl<string>
       onPrimaryColor: FormControl<string>
       foregroundColor: FormControl<string>
       backgroundColor: FormControl<string>
@@ -130,6 +131,7 @@ export class AdminConfigCustomizationComponent implements OnInit, OnDestroy, Can
     { label: string, description?: string, type: FieldType, items?: SelectOptionsItem[] }
   > = {
     primaryColor: { label: $localize`Primary color`, type: 'color' },
+    borderPrimaryColor: { label: $localize`Border primary color`, type: 'color' },
     onPrimaryColor: { label: $localize`On primary color`, type: 'color' },
     foregroundColor: { label: $localize`Foreground color`, type: 'color' },
     backgroundColor: { label: $localize`Background color`, type: 'color' },
@@ -275,6 +277,7 @@ export class AdminConfigCustomizationComponent implements OnInit, OnDestroy, Can
         default: null,
         customization: {
           primaryColor: HEX_COLOR_CODE_VALIDATOR,
+          borderPrimaryColor: HEX_COLOR_CODE_VALIDATOR,
           onPrimaryColor: HEX_COLOR_CODE_VALIDATOR,
           foregroundColor: HEX_COLOR_CODE_VALIDATOR,
           backgroundColor: HEX_COLOR_CODE_VALIDATOR,

--- a/client/src/root-helpers/theme-manager.ts
+++ b/client/src/root-helpers/theme-manager.ts
@@ -18,6 +18,7 @@ export class ThemeManager {
 
   private readonly configCSSVariableMap: ConfigCSSVariableMap = {
     primaryColor: '--primary',
+    borderPrimaryColor: '--border-primary',
     onPrimaryColor: '--on-primary',
     foregroundColor: '--fg',
     backgroundColor: '--bg',

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1077,6 +1077,7 @@ theme:
   # If you need more advanced customizations, install or develop a dedicated theme: https://docs.joinpeertube.org/contribute/plugins
   customization:
     primary_color: null # Hex color. Example: '#FF8F37'
+    border_primary_color: null # Hex color
     on_primary_color: null # Hex color
 
     foreground_color: null # Hex color

--- a/packages/models/src/server/custom-config.model.ts
+++ b/packages/models/src/server/custom-config.model.ts
@@ -64,6 +64,7 @@ export interface CustomConfig {
 
     customization: {
       primaryColor: string
+      borderPrimaryColor: string
       onPrimaryColor: string
       foregroundColor: string
       backgroundColor: string

--- a/packages/models/src/server/server-config.model.ts
+++ b/packages/models/src/server/server-config.model.ts
@@ -193,6 +193,7 @@ export interface ServerConfig {
 
     customization: {
       primaryColor: string
+      borderPrimaryColor: string
       onPrimaryColor: string
       foregroundColor: string
       backgroundColor: string

--- a/packages/tests/src/api/server/config.ts
+++ b/packages/tests/src/api/server/config.ts
@@ -209,6 +209,7 @@ function buildNewCustomConfig (server: PeerTubeServer): CustomConfig {
       default: 'default',
       customization: {
         primaryColor: '#001',
+        borderPrimaryColor: '#041',
         onPrimaryColor: '#042',
         foregroundColor: '#002',
         backgroundColor: '#003',

--- a/server/core/controllers/api/config.ts
+++ b/server/core/controllers/api/config.ts
@@ -342,6 +342,7 @@ function customConfig (): CustomConfig {
 
       customization: {
         primaryColor: CONFIG.THEME.CUSTOMIZATION.PRIMARY_COLOR,
+        borderPrimaryColor: CONFIG.THEME.CUSTOMIZATION.BORDER_PRIMARY_COLOR,
         onPrimaryColor: CONFIG.THEME.CUSTOMIZATION.ON_PRIMARY_COLOR,
         foregroundColor: CONFIG.THEME.CUSTOMIZATION.FOREGROUND_COLOR,
         backgroundColor: CONFIG.THEME.CUSTOMIZATION.BACKGROUND_COLOR,

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -1094,6 +1094,9 @@ const CONFIG = {
       get PRIMARY_COLOR () {
         return config.get<string>('theme.customization.primary_color')
       },
+      get BORDER_PRIMARY_COLOR () {
+        return config.get<string>('theme.customization.border_primary_color')
+      },
       get ON_PRIMARY_COLOR () {
         return config.get<string>('theme.customization.on_primary_color')
       },

--- a/server/core/lib/server-config-manager.ts
+++ b/server/core/lib/server-config-manager.ts
@@ -185,6 +185,7 @@ class ServerConfigManager {
         default: defaultTheme,
         customization: {
           primaryColor: CONFIG.THEME.CUSTOMIZATION.PRIMARY_COLOR,
+          borderPrimaryColor: CONFIG.THEME.CUSTOMIZATION.BORDER_PRIMARY_COLOR,
           onPrimaryColor: CONFIG.THEME.CUSTOMIZATION.ON_PRIMARY_COLOR,
           foregroundColor: CONFIG.THEME.CUSTOMIZATION.FOREGROUND_COLOR,
           backgroundColor: CONFIG.THEME.CUSTOMIZATION.BACKGROUND_COLOR,


### PR DESCRIPTION
## Description

Adding ability to customize primary border color. It always bothered me that certain elements remained orange after setting the primary color to something else. Now users can customize that color as well.

## Related issues

#7474

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

Before:
<img width="1728" height="929" alt="image" src="https://github.com/user-attachments/assets/22b33084-cf7a-4faa-b565-a43565c0a8a0" />
After:
<img width="1728" height="929" alt="image" src="https://github.com/user-attachments/assets/4027e8a2-4155-4ce5-90e9-1ea0bee27bbf" />


<!-- delete if not relevant -->

This is my first contribution, so make sure to use extra scrutiny :D