### PR TITLE
Update dependencies.md for redis >=6.2

### DIFF
--- a/support/doc/dependencies.md
+++ b/support/doc/dependencies.md
@@ -7,7 +7,7 @@ Main dependencies supported by PeerTube:
  * `node` LTS (**>= 20.19 and < 21** or **>= 22.12 and <23**)
  * `yarn` 1.x for **PeerTube <= 7.3** or `pnpm` >= 10.x for **PeerTube >= 8.0**
  * `postgres` >=10.x
- * `redis-server` >=6.x
+ * `redis-server` >=6.2
  * `ffmpeg` >=4.3 (using a ffmpeg static build [is not recommended](https://github.com/Chocobozzz/PeerTube/issues/6308))
  * `python` >=3.8
  * `pip`


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->

small change in dependencies

the comment on updating redis can be found here https://github.com/Chocobozzz/PeerTube/releases/tag/v8.0.0

the v8.0.1 the logs reported:

```
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
```


## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
