### PR TITLE
inform about necessity to shut down peertube first

### DIFF
--- a/support/doc/tools.md
+++ b/support/doc/tools.md
@@ -657,6 +657,8 @@ cd /var/www/peertube-docker; \
 
 ### Prune filesystem/object storage
 
+**PeerTube must be stopped before running this script**
+
 Some transcoded videos or shutdown at a bad time can leave some unused files on your storage.
 To delete these files (a confirmation will be demanded first):
 


### PR DESCRIPTION
## Description

The script gives a heads up about peertube needing to be shut down for this command, but it shows for only a few seconds. Given how sensitive it is, it makes sense to inform about it in the docs.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

