### PR TITLE
feat: support disabling rate limits when max <= 0

### DIFF
--- a/packages/tests/src/api/server/rate-limit.ts
+++ b/packages/tests/src/api/server/rate-limit.ts
@@ -7,8 +7,8 @@ import { cleanupTests, createSingleServer, PeerTubeServer, setAccessTokensToServ
 describe('Test rate limit disabling', function () {
   let server: PeerTubeServer
 
-  async function restartWithConfig(max: number) {
-    if (server) await cleanupTests([server])
+  async function restartWithConfig (max: number) {
+    if (server) await cleanupTests([ server ])
 
     const config = {
       rates_limit: {
@@ -20,11 +20,11 @@ describe('Test rate limit disabling', function () {
     }
 
     server = await createSingleServer(1, config)
-    await setAccessTokensToServers([server])
+    await setAccessTokensToServers([ server ])
   }
 
   after(async function () {
-    await cleanupTests([server])
+    await cleanupTests([ server ])
   })
 
   it('Should rate limit API calls when max > 0', async function () {

--- a/server/core/middlewares/rate-limiter.ts
+++ b/server/core/middlewares/rate-limiter.ts
@@ -8,9 +8,9 @@ import { logger, loggerTagsFactory } from '@server/helpers/logger.js'
 
 const lTags = loggerTagsFactory('rate-limit')
 
-const whitelistRoles = new Set<UserRoleType>([UserRole.ADMINISTRATOR, UserRole.MODERATOR])
+const whitelistRoles = new Set<UserRoleType>([ UserRole.ADMINISTRATOR, UserRole.MODERATOR ])
 
-export function buildRateLimiter(options: {
+export function buildRateLimiter (options: {
   windowMs: number
   max: number
   skipFailedRequests?: boolean
@@ -61,7 +61,7 @@ export const activityPubRateLimiter = buildRateLimiter({
 // Private
 // ---------------------------------------------------------------------------
 
-function sendRateLimited(req: express.Request, res: express.Response, options: RateLimitHandlerOptions) {
+function sendRateLimited (req: express.Request, res: express.Response, options: RateLimitHandlerOptions) {
   logger.debug('Rate limit exceeded for route ' + req.originalUrl, { route: req.originalUrl, ip: req.ip, ...lTags() })
 
   return res.status(options.statusCode).send(options.message)


### PR DESCRIPTION
## Description

This PR adds support for disabling rate limits by allowing configuration values where `max <= 0.`

- Updated `buildRateLimiter` to return a no-op middleware when `max <= 0`
- Preserves existing rate limiting behavior when max > `0`
- No changes to existing handler logic (runner/admin bypass remains intact)

## Related issues

closes : #6089 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

