### PR TITLE
Clearly mention production.yaml.new before asking to restart

### DIFF
--- a/support/doc/production.md
+++ b/support/doc/production.md
@@ -310,16 +310,22 @@ Run the upgrade script (the password it asks is PeerTube's database user passwor
 
 ```bash [GNU/Linux]
 cd /var/www/peertube/peertube-latest/scripts && sudo -H -u peertube ./upgrade.sh
-sudo systemctl restart peertube # Or use your OS command to restart PeerTube if you don't use systemd
 ```
 
 ```bash [FreeBSD]
 cd /var/www/peertube/peertube-latest/scripts && sudo -H -u peertube ./upgrade.sh
 cd /var/www/peertube/peertube-latest && sudo -H -u peertube npm explore sharp -- npm run build
-sudo systemctl restart peertube # Or use your OS command to restart PeerTube if you don't use systemd
 ```
 
 :::
+
+The upgrade will create a `production.yaml.new` file with differences marked as merge conflicts.
+Review this file and replace your existing `production.yaml` with it before restarting.
+
+```bash
+# Make sure you first updated your configuration per the note above
+sudo systemctl restart peertube # Or use your OS command to restart PeerTube if you don't use systemd
+```
 
 You may want to run `sudo -u peertube pnpm store prune` after several upgrades to free up disk space.
 


### PR DESCRIPTION
## Description

The step with `production.yaml.new` is mentioned much further in the upgrade steps, while the best time to _edit_ that config file is between there two upgrade steps:

```bash
cd /var/www/peertube/peertube-latest/scripts && sudo -H -u peertube ./upgrade.sh
sudo systemctl restart peertube # Or use your OS command to restart PeerTube if you don't use systemd
```

- Removed the restart step from this code block.
- Added a clear explanation of what to do about config.
- Added the restart step separately below, with additional comment so there's no chance to miss the config changes before restarting.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/7496

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
