### PR TITLE
pass ip address to requires-approval.result hook

### DIFF
--- a/packages/tests/fixtures/peertube-plugin-test/main.js
+++ b/packages/tests/fixtures/peertube-plugin-test/main.js
@@ -344,9 +344,9 @@ async function register ({ registerHook, registerSetting, settingsManager, stora
 
   registerHook({
     target: 'filter:api.user.signup.requires-approval.result',
-    handler: ({ requiresApproval, registrationReason }, { body, headers }) => {
+    handler: ({ requiresApproval, registrationReason }, { body, headers, ip }) => {
       return {
-        requiresApproval: body.username === 'waiting_john',
+        requiresApproval: ip !== undefined && body.username === 'waiting_john',
         registrationReason: 'Marked as spam'
       }
     }

--- a/server/core/middlewares/validators/users/user-registrations.ts
+++ b/server/core/middlewares/validators/users/user-registrations.ts
@@ -63,7 +63,8 @@ const determineSignupMode = [
       'filter:api.user.signup.requires-approval.result',
       {
         body: pick(req.body, [ 'username', 'email', 'registrationReason' ]),
-        headers: req.headers
+        headers: req.headers,
+        ip: req.ip
       }
     )
 


### PR DESCRIPTION
## Description
Add missing IP address param in filter hook.

## Related issues
#6691 

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite

