### PR TITLE
Fix TypeError crash when receiving actors without publicKey via federation

### DIFF
--- a/packages/tests/src/server-helpers/validator.ts
+++ b/packages/tests/src/server-helpers/validator.ts
@@ -2,9 +2,49 @@
 
 import { isStableOrUnstableVersionValid, isStableVersionValid } from '@peertube/peertube-server/core/helpers/custom-validators/misc.js'
 import {} from '@peertube/peertube-server/core/helpers/custom-validators/plugins.js'
+import {
+  isActorPublicKeyObjectValid,
+  sanitizeAndCheckActorObject
+} from '@peertube/peertube-server/core/helpers/custom-validators/activitypub/actor.js'
 import { expect } from 'chai'
 
 describe('Validators', function () {
+
+  describe('ActivityPub actor validators', function () {
+
+    it('Should return false for null/undefined publicKey without crashing', async function () {
+      expect(isActorPublicKeyObjectValid(null)).to.be.false
+      expect(isActorPublicKeyObjectValid(undefined)).to.be.false
+      expect(isActorPublicKeyObjectValid(0)).to.be.false
+      expect(isActorPublicKeyObjectValid('')).to.be.false
+    })
+
+    it('Should return false for a publicKey object with missing fields', async function () {
+      expect(isActorPublicKeyObjectValid({})).to.be.false
+      expect(isActorPublicKeyObjectValid({ id: 'not-a-url' })).to.be.false
+      expect(isActorPublicKeyObjectValid({ id: 'https://example.com/key', owner: 'not-a-url' })).to.be.false
+    })
+
+    it('Should return true for a valid publicKey object', async function () {
+      const validKey = {
+        id: 'https://example.com/accounts/user#main-key',
+        owner: 'https://example.com/accounts/user',
+        publicKeyPem: '-----BEGIN PUBLIC KEY-----\nMIIBIjANB...fake...key\n-----END PUBLIC KEY-----'
+      }
+      expect(isActorPublicKeyObjectValid(validKey)).to.be.true
+    })
+
+    it('Should return false for sanitizeAndCheckActorObject with missing publicKey', async function () {
+      const actorWithoutPublicKey: any = {
+        type: 'Person',
+        id: 'https://example.com/accounts/user',
+        inbox: 'https://example.com/accounts/user/inbox',
+        preferredUsername: 'user',
+        publicKey: null
+      }
+      expect(sanitizeAndCheckActorObject(actorWithoutPublicKey)).to.be.false
+    })
+  })
   it('Should correctly check stable plugin versions', async function () {
     expect(isStableVersionValid('3.4.0')).to.be.true
     expect(isStableVersionValid('0.4.0')).to.be.true

--- a/server/core/helpers/custom-validators/activitypub/actor.ts
+++ b/server/core/helpers/custom-validators/activitypub/actor.ts
@@ -17,6 +17,8 @@ export function isActorEndpointsObjectValid (endpointObject: any) {
 }
 
 export function isActorPublicKeyObjectValid (publicKeyObject: any) {
+  if (!publicKeyObject) return false
+
   return isActivityPubUrlValid(publicKeyObject.id) &&
     isActivityPubUrlValid(publicKeyObject.owner) &&
     isActorPublicKeyValid(publicKeyObject.publicKeyPem)


### PR DESCRIPTION
## Problem

Was investigating a federation issue on a self-hosted instance and noticed that `isActorPublicKeyObjectValid()` in `server/core/helpers/custom-validators/activitypub/actor.ts` accesses `publicKeyObject.id` directly without first checking if the input is null or undefined.

When a remote ActivityPub server sends an actor object where the `publicKey` field is missing or null (which can happen with incomplete implementations, server bugs, or during transitions), `sanitizeAndCheckActorObject()` throws a `TypeError: Cannot read properties of null (reading 'id')` instead of returning `false`.

This causes the federation handler to crash rather than gracefully rejecting the malformed actor.

### Before

```
sanitizeAndCheckActorObject({ ..., publicKey: null })
// => TypeError: Cannot read properties of null (reading 'id')
```

### After

```
sanitizeAndCheckActorObject({ ..., publicKey: null })
// => false (graceful rejection)
```

## Fix

Added a null guard at the top of `isActorPublicKeyObjectValid()`, matching the pattern already used by `isActorEndpointsObjectValid()` in the same file — which safely handles null/undefined via optional chaining on line 11.

## Tests

Added unit tests to `packages/tests/src/server-helpers/validator.ts` covering:
- null, undefined, and other falsy inputs → returns `false` without throwing
- incomplete publicKey objects with missing fields → returns `false`
- valid publicKey objects → returns `true`
- `sanitizeAndCheckActorObject` with null publicKey → returns `false` without throwing