### PR TITLE
fix(live): add null checks for video and replay settings in live ending handlers

### DIFF
--- a/server/core/lib/job-queue/handlers/video-live-ending.ts
+++ b/server/core/lib/job-queue/handlers/video-live-ending.ts
@@ -130,6 +130,16 @@ async function saveReplayToExternalVideo (options: {
   const liveVideo = await VideoModel.loadFull(options.liveVideo.id)
   const replaySettings = await VideoLiveReplaySettingModel.load(liveSession.replaySettingId)
 
+  if (!liveVideo || !replaySettings) {
+    logger.warn(
+      'Live video %d or its replay settings %d do not exist anymore, skipping external replay creation.',
+      options.liveVideo.id,
+      liveSession.replaySettingId,
+      lTags()
+    )
+    return
+  }
+
   const videoNameSuffix = ` - ${new Date(publishedAt).toLocaleString()}`
   const truncatedVideoName = peertubeTruncate(liveVideo.name, {
     length: CONSTRAINTS_FIELDS.VIDEOS.NAME.max - videoNameSuffix.length
@@ -255,6 +265,17 @@ async function replaceLiveByReplay (options: {
 
   const replaySettings = await VideoLiveReplaySettingModel.load(liveSession.replaySettingId)
   const videoWithFiles = await VideoModel.loadFull(liveVideo.id)
+
+  if (!videoWithFiles || !replaySettings) {
+    logger.warn(
+      'Live video %d or its replay settings %d do not exist anymore, skipping live-to-replay replacement.',
+      liveVideo.id,
+      liveSession.replaySettingId,
+      lTags()
+    )
+    return
+  }
+
   const hlsPlaylist = videoWithFiles.getHLSPlaylist()
   const replayInAnotherDirectory = isVideoInPublicDirectory(liveVideo.privacy) !== isVideoInPublicDirectory(replaySettings.privacy)
 


### PR DESCRIPTION
## Problem

Was reading through `video-live-ending.ts` and noticed an inconsistency in how database load results are handled. The main `processVideoLiveEnding` function correctly guards against missing records at [line 65](https://github.com/Chocobozzz/PeerTube/blob/192210a/server/core/lib/job-queue/handlers/video-live-ending.ts#L65):

```typescript
const video = await VideoModel.loadWithThumbnails(payload.videoId)
const live = await VideoLiveModel.loadByVideoId(payload.videoId)
const liveSession = await VideoLiveSessionModel.load(payload.liveSessionId)

if (!video || !live || !liveSession) {
  logError()
  return
}
```

But the two private functions it calls — `saveReplayToExternalVideo` and `replaceLiveByReplay` — both re-load data from the database without equivalent null checks:

- `saveReplayToExternalVideo` calls `VideoModel.loadFull(id)` and `VideoLiveReplaySettingModel.load(id)` at lines 130–131, then immediately accesses `liveVideo.name` and `replaySettings.privacy` without checking for null.
- `replaceLiveByReplay` does the same at lines 256–257, then accesses `videoWithFiles.getHLSPlaylist()` and `replaySettings.privacy`.

If the video or its replay settings are removed from the database while a live stream is still running (for example, an admin deletes the video during a stream on a self-hosted instance), the live-ending BullMQ job crashes with a `TypeError` when it tries to access properties on `null`. The job then retries indefinitely against a permanently missing record, filling the queue with failures and never cleaning up temporary replay files.

## Fix

Added null checks in both functions following the same warn-and-return pattern already used by the parent function. When the video or replay settings no longer exist, the handler logs a warning with the relevant IDs and returns early instead of crashing.

### Before

Job crashes with `TypeError: Cannot read properties of null (reading 'name')` or `TypeError: Cannot read properties of null (reading 'privacy')`. BullMQ retries the job indefinitely.

### After

Job logs a warning like `Live video 42 or its replay settings 7 do not exist anymore, skipping external replay creation.` and exits cleanly.

## Changes

- `server/core/lib/job-queue/handlers/video-live-ending.ts`
  - `saveReplayToExternalVideo`: guard `liveVideo` and `replaySettings` after load
  - `replaceLiveByReplay`: guard `videoWithFiles` and `replaySettings` after load