### PR TITLE
Fix unprotected JSON.parse in Redis.getObject() crashing viewer stats processing

### DIFF
--- a/server/core/lib/redis.ts
+++ b/server/core/lib/redis.ts
@@ -528,7 +528,7 @@ class Redis {
     try {
       return JSON.parse(value)
     } catch (err) {
-      logger.warn('Cannot parse Redis key %s.', key, { err })
+      logger.warn('Cannot parse Redis key %s.', key, { err, ...lTags() })
       return null
     }
   }

--- a/server/core/lib/redis.ts
+++ b/server/core/lib/redis.ts
@@ -525,7 +525,12 @@ class Redis {
     const value = await this.getValue(key)
     if (!value) return null
 
-    return JSON.parse(value)
+    try {
+      return JSON.parse(value)
+    } catch (err) {
+      logger.warn('Cannot parse Redis key %s.', key, { err })
+      return null
+    }
   }
 
   private setObject (key: string, value: { [id: string]: number | string }, expirationMilliseconds?: number) {

--- a/server/core/lib/stats/shared/video-viewer-stats.ts
+++ b/server/core/lib/stats/shared/video-viewer-stats.ts
@@ -156,6 +156,12 @@ export class VideoViewerStats {
       for (const key of allKeys) {
         const stats: LocalViewerStats = await this.getLocalVideoViewerByKey(key)
 
+        if (!stats) {
+          logger.warn('Cannot read viewer stats for Redis key %s, removing invalid entry.', key, lTags())
+          await this.deleteLocalVideoViewersKeys(key)
+          continue
+        }
+
         // Process expired stats
         if (stats.lastUpdated > now - VIEW_LIFETIME.VIEWER_STATS) {
           continue

--- a/server/core/lib/stats/shared/video-viewer-stats.ts
+++ b/server/core/lib/stats/shared/video-viewer-stats.ts
@@ -158,7 +158,11 @@ export class VideoViewerStats {
 
         if (!stats) {
           logger.warn('Cannot read viewer stats for Redis key %s, removing invalid entry.', key, lTags())
-          await this.deleteLocalVideoViewersKeys(key)
+          try {
+            await this.deleteLocalVideoViewersKeys(key)
+          } catch (err) {
+            logger.error('Cannot delete invalid viewer stats for Redis key %s.', key, { err, ...lTags() })
+          }
           continue
         }
 


### PR DESCRIPTION
## Description

Noticed while reading through the viewer stats processing code that `Redis.getObject()` calls `JSON.parse()` without any error handling. On a self-hosted instance, if a Redis value gets corrupted (partial write during a crash, data from a different PeerTube version, manual Redis intervention), the unhandled parse error propagates up through `getLocalVideoViewerByKey()` in `processViewerStats()`.

Since `getLocalVideoViewerByKey()` is called *outside* the inner try/catch block (line 157, before the transaction at line 164), the exception is caught by the outer catch at line 181 — which exits the entire `for` loop. This means a single corrupted entry blocks all remaining viewer stats from being persisted to the database.

Minimal reproduction:
```js
// getObject behavior without fix:
JSON.parse('{"lastUpdated": 0, "corrupt')
// => SyntaxError — crashes the whole batch
```

The same codebase already handles this correctly in `server/core/models/server/plugin.ts` (lines 209–213):
```ts
try {
  return JSON.parse(value)
} catch {
  return value
}
```

**Before:** One corrupted Redis viewer stats entry crashes `processViewerStats()`, preventing all remaining entries from being saved to the database.

**After:** Corrupted entries are logged, cleaned up from Redis, and skipped. The remaining entries are processed normally.

### Changes

- **`redis.ts`**: Wrap `JSON.parse` in `getObject()` with try/catch, log warning, return null
- **`video-viewer-stats.ts`**: Add null check in `processViewerStats()` loop — log, delete the invalid key, and continue

## Related issues

<!-- This is a straightforward defensive fix, no prior issue -->

## Has this been tested?

- [x] 👍 Verified with a minimal reproduction script that a corrupted JSON value crashes `JSON.parse` and the fix returns null instead
- [ ] 💭 Full integration test would require a running Redis instance; the fix follows the same pattern already validated in `plugin.ts`

## Screenshots

N/A