### PR TITLE
Fix file mutex double-release in onVideoStudioEnded

### DIFF
--- a/server/core/lib/video-studio.ts
+++ b/server/core/lib/video-studio.ts
@@ -103,7 +103,6 @@ export async function onVideoStudioEnded (options: {
 
     const outputPath = VideoPathManager.Instance.getFSVideoFileOutputPath(video, newFile)
     await move(editionResultPath, outputPath)
-    videoFileMutexReleaser()
 
     await safeCleanupStudioTMPFiles(tasks)
 


### PR DESCRIPTION
## Description

Was reading through the video studio code and noticed that `onVideoStudioEnded` in `server/core/lib/video-studio.ts` releases the file mutex twice — once explicitly on line 106 inside the `try` block, and then again in the `finally` block on line 142.

This has two effects:

1. **Double-release on async-mutex:** Calling the releaser a second time increments the internal semaphore value past its initial limit, which can allow a subsequent `lockFiles()` call to acquire the mutex even while it should still be held by another operation.

2. **Unprotected file operations:** Everything between the early release and the `finally` block — `createTorrentAndSetInfoHashFromPath`, `removeAllFiles`, `getVideoStreamDuration` — runs without the file lock. If a concurrent job (transcoding, move-to-object-storage) acquires the mutex during this window, it can observe the video's files in an inconsistent state.

The rest of the codebase consistently uses a single release in the `finally` block:

- `video-file.ts` (4 call sites at lines 79, 100, 122, 147) — all use `try { ... } finally { release() }`
- `source.ts` (line 99) — performs the same sequence (move, torrent, remove old files, DB save, create jobs) and holds the lock for the full duration

This change removes the early release so the lock lifecycle matches the established pattern.

## Related issues

N/A — found while reading the code.

## Has this been tested?

- [x] 👍 yes, verified by comparing the lock pattern against 5 other call sites in the codebase that all follow the `try { ... } finally { release() }` pattern
- [ ] 🙅 no, because this PR does not update server code