### PR TITLE
Update OpenAPI library links

### DIFF
--- a/support/doc/api/quickstart.md
+++ b/support/doc/api/quickstart.md
@@ -90,10 +90,4 @@ curl https://peertube.example.com/api/v1/videos
 
 ## Libraries
 
-[Convenience libraries](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi) are generated automatically from the [OpenAPI specification](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/api/openapi.yaml) for the following languages:
-
-- [python](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi/python)
-- [go](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi/go)
-- [kotlin](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi/kotlin)
-
-Other [languages supported by the OpenAPI generator](https://openapi-generator.tech/docs/generators/#client-generators) can be added to the generation, provided they make a common enough use case.
+Convenience libraries can be generated automatically from the [OpenAPI specification](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/api/openapi.yaml) for [languages supported by the OpenAPI generator](https://openapi-generator.tech/docs/generators/#client-generators).

--- a/support/doc/api/quickstart.md
+++ b/support/doc/api/quickstart.md
@@ -90,10 +90,10 @@ curl https://peertube.example.com/api/v1/videos
 
 ## Libraries
 
-[Convenience libraries](https://framagit.org/framasoft/peertube/clients) are generated automatically from the [OpenAPI specification](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/api/openapi.yaml) for the following languages:
+[Convenience libraries](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi) are generated automatically from the [OpenAPI specification](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/api/openapi.yaml) for the following languages:
 
-- [python](https://framagit.org/framasoft/peertube/clients/python)
-- [go](https://framagit.org/framasoft/peertube/clients/go)
-- [kotlin](https://framagit.org/framasoft/peertube/clients/kotlin)
+- [python](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi/python)
+- [go](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi/go)
+- [kotlin](https://framagit.org/framasoft/peertube/PeerTube/-/tree/develop/support/openapi/kotlin)
 
 Other [languages supported by the OpenAPI generator](https://openapi-generator.tech/docs/generators/#client-generators) can be added to the generation, provided they make a common enough use case.


### PR DESCRIPTION
OpenAPI library links directed to repositories that no longer seem to exist. This update links to the relevant folders in the PeerTube repository.

## Description

I'm not able to see what the links used to direct to, but these seem to be relevant/correct replacements.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
