### PR TITLE
Add smtp.bare_address config option. Solves #7569.

### DIFF
--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -117,7 +117,8 @@ const CONFIG = {
     TLS: config.get<boolean>('smtp.tls'),
     DISABLE_STARTTLS: config.get<boolean>('smtp.disable_starttls'),
     CA_FILE: config.get<string>('smtp.ca_file'),
-    FROM_ADDRESS: config.get<string>('smtp.from_address')
+    FROM_ADDRESS: config.get<string>('smtp.from_address'),
+    BARE_ADDRESS: config.has('smtp.bare_address') ? config.get<bool>('smtp.bare_address') : 'false'
   },
 
   NSFW_FLAGS_SETTINGS: {

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -118,7 +118,7 @@ const CONFIG = {
     DISABLE_STARTTLS: config.get<boolean>('smtp.disable_starttls'),
     CA_FILE: config.get<string>('smtp.ca_file'),
     FROM_ADDRESS: config.get<string>('smtp.from_address'),
-    BARE_ADDRESS: config.has('smtp.bare_address') ? config.get<bool>('smtp.bare_address') : 'false'
+    BARE_ADDRESS: config.has('smtp.bare_address') ? config.get<boolean>('smtp.bare_address') : 'false'
   },
 
   NSFW_FLAGS_SETTINGS: {

--- a/server/core/lib/emailer.ts
+++ b/server/core/lib/emailer.ts
@@ -369,7 +369,7 @@ export class Emailer {
         return compiledTemplate(locals)
       },
       message: {
-        from: `"${fromDisplayName}" <${CONFIG.SMTP.FROM_ADDRESS}>`
+        from: CONFIG.SMTP.BARE_ADDRESS ? `<${CONFIG.SMTP.FROM_ADDRESS}>` : `"${fromDisplayName}" <${CONFIG.SMTP.FROM_ADDRESS}>`
       },
       transport: this.transporter,
       subjectPrefix: this.buildSubjectPrefix()


### PR DESCRIPTION
## Description

Resolve #7569 by providing `smtp.bare_address`.

## Related issues

See #7569.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
