### PR TITLE
Show real `count_view_after` in video stats Views help popup

### DIFF
--- a/client/src/app/+videos-publish-manage/shared-manage/stats/video-stats.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/stats/video-stats.component.ts
@@ -333,11 +333,13 @@ export class VideoStatsComponent implements OnInit {
   }
 
   private buildOverallStatCard (overallStats: VideoStatsOverall) {
+    const countViewAfter = this.serverService.getHTMLConfig().views.videos.countViewAfter
+
     this.globalStatsCards = [
       {
         label: $localize`Views`,
         value: this.numberFormatter.transform(this.videoEdit.getVideoAttributes().views),
-        help: $localize`A view means that someone watched the video for several seconds (10 seconds by default)`
+        help: $localize`A view means that someone watched the video for at least ${countViewAfter} seconds (configured via "count_view_after" in the instance configuration).`
       },
       {
         label: $localize`Downloads`,

--- a/packages/models/src/server/server-config.model.ts
+++ b/packages/models/src/server/server-config.model.ts
@@ -295,6 +295,12 @@ export interface ServerConfig {
     }
   }
 
+  views: {
+    videos: {
+      countViewAfter: number
+    }
+  }
+
   import: {
     videos: {
       http: {

--- a/server/core/controllers/api/config.ts
+++ b/server/core/controllers/api/config.ts
@@ -494,6 +494,11 @@ function customConfig (): CustomConfig {
         enabled: CONFIG.VIDEO_FILE.UPDATE.ENABLED
       }
     },
+    views: {
+      videos: {
+        countViewAfter: CONFIG.VIEWS.VIDEOS.COUNT_VIEW_AFTER / 1000
+      }
+    },
     import: {
       videos: {
         concurrency: CONFIG.IMPORT.VIDEOS.CONCURRENCY,


### PR DESCRIPTION
Closes #7580

## Why

The Views card on the per-video statistics page rendered a help popup that hard-coded `(10 seconds by default)` regardless of the instance's `views.videos.count_view_after` setting in `production.yaml`. Operators who raised that threshold (commonly to 30s for longer-form videos, like the issue reporter) saw help text that contradicted what the server actually counted.

## What

Expose `views.videos.countViewAfter` (in seconds) on the public `ServerConfig` returned by `GET /api/v1/config` and rewrite the help text in `video-stats.component.ts` to interpolate the live value. The new copy also names the underlying setting (`count_view_after`) so operators can find it.

## Files

- `packages/models/src/server/server-config.model.ts` - add `views.videos.countViewAfter: number` to the `ServerConfig` interface (also flows into `HTMLServerConfig` via the existing `Omit`).
- `server/core/controllers/api/config.ts` - populate it from `CONFIG.VIEWS.VIDEOS.COUNT_VIEW_AFTER` (which is in ms internally), divided by 1000 for seconds-on-the-wire.
- `client/src/app/+videos-publish-manage/shared-manage/stats/video-stats.component.ts` - read `serverService.getHTMLConfig().views.videos.countViewAfter` in `buildOverallStatCard` and use it in the `$localize` help template.

## Notes

- Translation source string changes; existing `.xlf` entries for the old wording become stale and will retranslate via the normal Weblate pipeline.
- Value is in seconds on the wire because the help text reads in seconds; matches the unit operators see in `production.yaml` (`'10 seconds'`).