### PR TITLE
Add Romanian (ro) to supported locales

### DIFF
--- a/packages/core-utils/src/i18n/i18n.ts
+++ b/packages/core-utils/src/i18n/i18n.ts
@@ -32,6 +32,7 @@ export const I18N_LOCALES = {
   'pl-PL': 'Polski',
   'pt-BR': 'Português (Brasil)',
   'pt-PT': 'Português (Portugal)',
+  'ro': 'Română',
   'ru-RU': 'Pусский',
   'sk-SK': 'Slovenčina',
   'sq': 'Shqip',

--- a/packages/core-utils/src/i18n/i18n.ts
+++ b/packages/core-utils/src/i18n/i18n.ts
@@ -67,6 +67,7 @@ const I18N_LOCALE_ALIAS = {
   'nl': 'nl-NL',
   'pl': 'pl-PL',
   'pt': 'pt-BR',
+  'ro-RO': 'ro',
   'ru': 'ru-RU',
   'sk': 'sk-SK',
   'sv': 'sv-SE',


### PR DESCRIPTION
## Description

  Adds Romanian (`ro`) to the supported locales.

  Following the [translation guide](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/translation.md):

  > if you think there are enough translated strings, please create an issue so we add the new locale in PeerTube!

  ### Translation status on Weblate

  - **angular**: 3004/3097 (96.9%) strings, 20653/20775 (99.4%) words — https://weblate.framasoft.org/projects/peertube/angular/ro/
  - **player**: 164/164 (100%)
  - **server**: 240/287 (83.6%)

  ### Changes

  - Add `'ro': 'Română'` to `I18N_LOCALES`
  - Add `'ro-RO': 'ro'` to `I18N_LOCALE_ALIAS` (for browsers sending `Accept-Language: ro-RO`)

  There are 77 fuzzy strings and 55 strings with failing checks (mostly inline placeholder edge cases) on Weblate. Happy to clean those up if
   it's blocking the merge.

  Romanian is spoken by ~20M people. Thanks for PeerTube! 🙂

  ## Has this been tested?

  🙅 no, because this PR does not update server code