### PR TITLE
allow others to download original file

### DIFF
--- a/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
@@ -1151,6 +1151,10 @@ export class VideoEdit {
     return !this.metadata.isLive && this.metadata.state === VideoState.PUBLISHED
   }
 
+  isNew () {
+    return this.isNewVideo
+  }
+
   private updateAfterChange () {
     this.videoAttributes = {
       id: this.metadata.id,

--- a/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
@@ -125,6 +125,7 @@ type UpdateFromAPIOptions = {
     | 'support'
     | 'commentsPolicy'
     | 'downloadEnabled'
+    | 'downloadOriginalFileEnabled'
     | 'pluginData'
     | 'scheduledUpdate'
     | 'originallyPublishedAt'
@@ -318,6 +319,7 @@ export class VideoEdit {
 
     this.common.privacy = serverDefaults.publish.privacy
     this.common.downloadEnabled = serverDefaults.publish.downloadEnabled
+    this.common.downloadOriginalFileEnabled = serverDefaults.publish.downloadOriginalFileEnabled
     this.common.licence = serverDefaults.publish.licence
     this.common.commentsPolicy = serverDefaults.publish.commentsPolicy
     this.common.nsfw = this.serverConfig.instance.isNSFW
@@ -406,6 +408,7 @@ export class VideoEdit {
         commentsPolicy: video.commentsPolicy?.id ?? null,
 
         downloadEnabled: video.downloadEnabled ?? null,
+        downloadOriginalFileEnabled: video.downloadOriginalFileEnabled ?? null,
 
         pluginData: video.pluginData ?? {},
 
@@ -559,6 +562,7 @@ export class VideoEdit {
     if (values.support !== undefined) this.common.support = values.support
     if (values.commentsPolicy !== undefined) this.common.commentsPolicy = values.commentsPolicy
     if (values.downloadEnabled !== undefined) this.common.downloadEnabled = values.downloadEnabled
+    if (values.downloadOriginalFileEnabled !== undefined) this.common.downloadOriginalFileEnabled = values.downloadOriginalFileEnabled
     if (values.thumbnailfile !== undefined) this.common.thumbnailfile = values.thumbnailfile
     if (values.pluginData !== undefined) this.common.pluginData = values.pluginData
 
@@ -656,6 +660,7 @@ export class VideoEdit {
         : null,
 
       downloadEnabled: this.common.downloadEnabled,
+      downloadOriginalFileEnabled: this.common.downloadOriginalFileEnabled,
 
       originallyPublishedAt: this.common.originallyPublishedAt
         ? new Date(this.common.originallyPublishedAt)
@@ -713,6 +718,7 @@ export class VideoEdit {
       waitTranscoding: this.common.waitTranscoding,
       commentsPolicy: this.common.commentsPolicy,
       downloadEnabled: this.common.downloadEnabled,
+      downloadOriginalFileEnabled: this.common.downloadOriginalFileEnabled,
       thumbnailfile: this.common.thumbnailfile,
       scheduleUpdate: this.common.scheduleUpdate || null,
       originallyPublishedAt: this.common.originallyPublishedAt || null

--- a/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.html
@@ -59,6 +59,10 @@
       </div>
 
       <my-peertube-checkbox inputName="downloadEnabled" formControlName="downloadEnabled" i18n-labelText labelText="Enable download"></my-peertube-checkbox>
+
+      @if (form.get('downloadEnabled').value) {
+        <my-peertube-checkbox inputName="downloadOriginalFileEnabled" formControlName="downloadOriginalFileEnabled" i18n-labelText labelText="Allow downloading the original file"></my-peertube-checkbox>
+      }
     </div>
 
   </div>

--- a/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.html
@@ -58,11 +58,17 @@
         </my-select-player-theme>
       </div>
 
-      <my-peertube-checkbox inputName="downloadEnabled" formControlName="downloadEnabled" i18n-labelText labelText="Enable download"></my-peertube-checkbox>
-
-      @if (form.get('downloadEnabled').value) {
-        <my-peertube-checkbox inputName="downloadOriginalFileEnabled" formControlName="downloadOriginalFileEnabled" i18n-labelText labelText="Allow downloading the original file"></my-peertube-checkbox>
-      }
+      <my-peertube-checkbox inputName="downloadEnabled" formControlName="downloadEnabled" i18n-labelText labelText="Enable download">
+        @if (hasOriginalFileToDownload()) {
+          <ng-container ngProjectAs="extra">
+            <my-peertube-checkbox
+              inputName="downloadOriginalFileEnabled"
+              formControlName="downloadOriginalFileEnabled"
+              i18n-labelText labelText="Allow downloading the original file"
+            ></my-peertube-checkbox>
+          </ng-container>
+        }
+      </my-peertube-checkbox>
     </div>
 
   </div>

--- a/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.ts
@@ -98,6 +98,11 @@ export class VideoCustomizationComponent implements OnInit, OnDestroy {
     this.formErrors = formErrors
     this.validationMessages = validationMessages
 
+    // Original file download is only relevant when download is enabled: keep the option visible but disabled otherwise
+    const downloadEnabledControl = this.form.get('downloadEnabled')
+    this.updateDownloadOriginalFileState(downloadEnabledControl.value)
+    downloadEnabledControl.valueChanges.subscribe(enabled => this.updateDownloadOriginalFileState(enabled))
+
     this.form.valueChanges.subscribe(() => {
       this.manageController.setFormError($localize`Customization`, 'customization', this.formErrors)
 
@@ -128,6 +133,28 @@ export class VideoCustomizationComponent implements OnInit, OnDestroy {
 
   hasPublicationDate () {
     return !!this.form.value.originallyPublishedAt
+  }
+
+  hasOriginalFileToDownload () {
+    // On upload there is no source yet, so rely on the instance config to know if the original file will be kept
+    if (this.videoEdit.isNew()) {
+      return this.serverConfig.transcoding.originalFile.keep
+    }
+
+    // On update, the option only makes sense if the video actually has an original source file
+    return !!this.videoEdit.getVideoSource()?.fileDownloadUrl
+  }
+
+  private updateDownloadOriginalFileState (downloadEnabled: boolean) {
+    const control = this.form.get('downloadOriginalFileEnabled')
+
+    if (downloadEnabled) {
+      control.enable({ emitEvent: false })
+    } else {
+      // Keep the form value consistent so we never submit downloadOriginalFileEnabled=true with downloadEnabled=false
+      control.setValue(false)
+      control.disable({ emitEvent: false })
+    }
   }
 
   resetField (name: string) {

--- a/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.ts
@@ -18,6 +18,7 @@ const debugLogger = debug('peertube:video-manage')
 
 type Form = {
   downloadEnabled: FormControl<boolean>
+  downloadOriginalFileEnabled: FormControl<boolean>
   originallyPublishedAt: FormControl<Date>
 
   playerSettings: FormGroup<{
@@ -80,6 +81,7 @@ export class VideoCustomizationComponent implements OnInit, OnDestroy {
 
     const obj: BuildFormArgumentTyped<Form> = {
       downloadEnabled: null,
+      downloadOriginalFileEnabled: null,
       originallyPublishedAt: VIDEO_ORIGINALLY_PUBLISHED_AT_VALIDATOR,
       playerSettings: {
         theme: null

--- a/client/src/app/shared/shared-main/video/video-details.model.ts
+++ b/client/src/app/shared/shared-main/video/video-details.model.ts
@@ -20,6 +20,7 @@ export class VideoDetails extends Video implements VideoDetailsServerModel {
 
   support: string
   downloadEnabled: boolean
+  downloadOriginalFileEnabled: boolean
 
   commentsPolicy: ConstantLabel<VideoCommentPolicyType>
 
@@ -48,6 +49,7 @@ export class VideoDetails extends Video implements VideoDetailsServerModel {
     this.support = hash.support
     this.commentsPolicy = hash.commentsPolicy
     this.downloadEnabled = hash.downloadEnabled
+    this.downloadOriginalFileEnabled = hash.downloadOriginalFileEnabled
 
     this.inputFileUpdatedAt = hash.inputFileUpdatedAt
 

--- a/client/src/app/shared/shared-video-miniature/download/video-download.component.ts
+++ b/client/src/app/shared/shared-video-miniature/download/video-download.component.ts
@@ -99,8 +99,14 @@ export class VideoDownloadComponent {
 
     const user = this.authService.getUser()
     // User that can update the video can also get the original video file
-    if (!this.video.isUpdatableBy(user)) return of(undefined)
+    if (this.video.isUpdatableBy(user)) return this.getSourceObs()
+    // Uploader can allow downloading the original file
+    if (this.video.downloadOriginalFileEnabled) return this.getSourceObs()
 
+    return of(undefined)
+  }
+
+  private getSourceObs () {
     return this.videoService.getSource(this.video.id)
       .pipe(catchError(err => {
         logger.error('Cannot get source file', err)

--- a/client/src/app/shared/shared-video-miniature/download/video-files-download.component.html
+++ b/client/src/app/shared/shared-video-miniature/download/video-files-download.component.html
@@ -20,7 +20,9 @@
     <ng-container ngbNavItem="original">
       <a ngbNavLink>
         <ng-container i18n>Original file</ng-container>
-        <my-global-icon i18n-ngbTooltip ngbTooltip="Other users cannot download the original file" iconName="shield"></my-global-icon>
+        @if (!video().downloadOriginalFileEnabled) {
+          <my-global-icon i18n-ngbTooltip ngbTooltip="Other users cannot download the original file" iconName="shield"></my-global-icon>
+        }
       </a>
       <ng-template ngbNavContent>
         <ng-template [ngTemplateOutlet]="rootNavContent"></ng-template>

--- a/client/src/app/shared/shared-video-miniature/download/video-generate-download.component.html
+++ b/client/src/app/shared/shared-video-miniature/download/video-generate-download.component.html
@@ -6,7 +6,9 @@
       <label for="original-file">
         <strong i18n>Original file</strong>
         <span class="muted">{{ originalVideoFile().size | bytes: 1 }} | {{ originalVideoFile().width }}x{{ originalVideoFile().height }}</span>
-        <my-global-icon i18n-ngbTooltip ngbTooltip="Other users cannot download the original file" iconName="shield"></my-global-icon>
+        @if (!video().downloadOriginalFileEnabled) {
+          <my-global-icon i18n-ngbTooltip ngbTooltip="Other users cannot download the original file" iconName="shield"></my-global-icon>
+        }
       </label>
     </div>
   }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1227,6 +1227,8 @@ defaults:
   publish:
     download_enabled: true
 
+    download_original_file_enabled: false
+
     # enabled = 1, disabled = 2, requires_approval = 3
     comments_policy: 1
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -1237,6 +1237,10 @@ defaults:
   publish:
     download_enabled: true
 
+    # Allow download of the original uploaded file
+    # Requires download_enabled to be true
+    download_original_file_enabled: true
+
     # enabled = 1, disabled = 2, requires_approval = 3
     comments_policy: 1
 

--- a/packages/models/src/server/server-config.model.ts
+++ b/packages/models/src/server/server-config.model.ts
@@ -92,6 +92,7 @@ export interface ServerConfig {
   defaults: {
     publish: {
       downloadEnabled: boolean
+      downloadOriginalFileEnabled: boolean
 
       commentsPolicy: VideoCommentPolicyType
 

--- a/packages/models/src/server/server-config.model.ts
+++ b/packages/models/src/server/server-config.model.ts
@@ -236,6 +236,10 @@ export interface ServerConfig {
       enabled: boolean
     }
 
+    originalFile: {
+      keep: boolean
+    }
+
     enabledResolutions: number[]
 
     profile: string

--- a/packages/models/src/videos/video-create-update-common.model.ts
+++ b/packages/models/src/videos/video-create-update-common.model.ts
@@ -15,6 +15,7 @@ export interface VideoCreateUpdateCommon {
   commentsPolicy?: VideoCommentPolicyType
 
   downloadEnabled?: boolean
+  downloadOriginalFileEnabled?: boolean
 
   nsfw?: boolean
   nsfwSummary?: string

--- a/packages/models/src/videos/video.model.ts
+++ b/packages/models/src/videos/video.model.ts
@@ -124,6 +124,7 @@ export interface VideoDetails extends Video {
   }
 
   downloadEnabled: boolean
+  downloadOriginalFileEnabled: boolean
 
   // Not optional in details (unlike in parent Video)
   waitTranscoding: boolean

--- a/packages/tests/src/api/videos/video-source.ts
+++ b/packages/tests/src/api/videos/video-source.ts
@@ -204,6 +204,64 @@ describe('Test video source management', function () {
     })
   })
 
+  describe('Original file public download', function () {
+    let videoUUID: string
+
+    before(async function () {
+      this.timeout(60000)
+
+      await servers[0].config.keepSourceFile()
+
+      const { uuid } = await servers[0].videos.upload({
+        attributes: { name: 'downloadable original', fixture: 'video_short.webm' },
+        mode: 'resumable'
+      })
+      videoUUID = uuid
+
+      await waitJobs(servers)
+    })
+
+    it('Should default downloadOriginalFileEnabled to false', async function () {
+      const video = await servers[0].videos.get({ id: videoUUID })
+
+      expect(video.downloadOriginalFileEnabled).to.be.false
+    })
+
+    it('Should forbid a non-owner from fetching the source when disabled', async function () {
+      await servers[0].videos.getSource({ id: videoUUID, token: userToken, expectedStatus: HttpStatusCode.FORBIDDEN_403 })
+    })
+
+    it('Should let the owner enable downloadOriginalFileEnabled', async function () {
+      await servers[0].videos.update({ id: videoUUID, attributes: { downloadOriginalFileEnabled: true } })
+
+      const video = await servers[0].videos.get({ id: videoUUID })
+      expect(video.downloadOriginalFileEnabled).to.be.true
+    })
+
+    it('Should let a non-owner fetch the source once enabled', async function () {
+      const source = await servers[0].videos.getSource({ id: videoUUID, token: userToken })
+
+      expect(source.fileDownloadUrl).to.exist
+    })
+
+    it('Should let a non-owner download the original file once enabled', async function () {
+      const source = await servers[0].videos.getSource({ id: videoUUID, token: userToken })
+
+      await makeRawRequest({ url: source.fileDownloadUrl, token: userToken, expectedStatus: HttpStatusCode.OK_200 })
+    })
+
+    it('Should forbid access again after the owner disables downloadOriginalFileEnabled', async function () {
+      await servers[0].videos.update({ id: videoUUID, attributes: { downloadOriginalFileEnabled: false } })
+
+      await servers[0].videos.getSource({ id: videoUUID, token: userToken, expectedStatus: HttpStatusCode.FORBIDDEN_403 })
+    })
+
+    after(async function () {
+      await servers[0].videos.remove({ id: videoUUID })
+      await waitJobs(servers)
+    })
+  })
+
   describe('Updating video source', function () {
     describe('Filesystem', function () {
       it('Should replace a video file with transcoding disabled', async function () {

--- a/server/core/controllers/api/videos/update.ts
+++ b/server/core/controllers/api/videos/update.ts
@@ -94,7 +94,8 @@ async function updateVideo (req: express.Request, res: express.Response) {
         'waitTranscoding',
         'support',
         'description',
-        'downloadEnabled'
+        'downloadEnabled',
+        'downloadOriginalFileEnabled'
       ]
 
       for (const key of keysToUpdate) {

--- a/server/core/initializers/checker-after-init.ts
+++ b/server/core/initializers/checker-after-init.ts
@@ -56,6 +56,7 @@ function checkConfig () {
   checkVideoStudioConfig()
   checkThumbnailsConfig()
   checkBrowseVideosConfig()
+  checkDownloadConfig()
 }
 
 // We get db by param to not import it in this file (import orders)
@@ -394,4 +395,10 @@ function checkBrowseVideosConfig () {
 
   const scopeError = getBrowseVideosDefaultScopeError(CONFIG.CLIENT.BROWSE_VIDEOS.DEFAULT_SCOPE)
   if (scopeError) throw new Error(scopeError)
+}
+
+function checkDownloadConfig () {
+  if (CONFIG.DEFAULTS.PUBLISH.DOWNLOAD_ORIGINAL_FILE_ENABLED && !CONFIG.DEFAULTS.PUBLISH.DOWNLOAD_ENABLED) {
+    throw new Error('defaults.publish.download_enabled must be true if defaults.publish.download_original_file_enabled is true')
+  }
 }

--- a/server/core/initializers/checker-before-init.ts
+++ b/server/core/initializers/checker-before-init.ts
@@ -133,6 +133,7 @@ export function checkMissedConfig () {
     'client.menu.login.redirect_on_single_external_auth',
     'client.header.hide_instance_name',
     'defaults.publish.download_enabled',
+    'defaults.publish.download_original_file_enabled',
     'defaults.publish.comments_policy',
     'defaults.publish.privacy',
     'defaults.publish.licence',

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -212,6 +212,9 @@ const CONFIG = {
       get DOWNLOAD_ENABLED () {
         return config.get<boolean>('defaults.publish.download_enabled')
       },
+      get DOWNLOAD_ORIGINAL_FILE_ENABLED () {
+        return config.get<boolean>('defaults.publish.download_original_file_enabled')
+      },
       get COMMENTS_POLICY () {
         return config.get<VideoCommentPolicyType>('defaults.publish.comments_policy')
       },

--- a/server/core/initializers/migrations/1035-video-download-original-file.ts
+++ b/server/core/initializers/migrations/1035-video-download-original-file.ts
@@ -1,0 +1,24 @@
+import * as Sequelize from 'sequelize'
+
+async function up (utils: {
+  transaction: Sequelize.Transaction
+  queryInterface: Sequelize.QueryInterface
+  sequelize: Sequelize.Sequelize
+}): Promise<void> {
+  const { transaction } = utils
+
+  await utils.queryInterface.addColumn('video', 'downloadOriginalFileEnabled', {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  }, { transaction })
+}
+
+function down (options) {
+  throw new Error('Not implemented.')
+}
+
+export {
+  down,
+  up
+}

--- a/server/core/lib/server-config-manager.ts
+++ b/server/core/lib/server-config-manager.ts
@@ -101,6 +101,7 @@ class ServerConfigManager {
       defaults: {
         publish: {
           downloadEnabled: CONFIG.DEFAULTS.PUBLISH.DOWNLOAD_ENABLED,
+          downloadOriginalFileEnabled: CONFIG.DEFAULTS.PUBLISH.DOWNLOAD_ORIGINAL_FILE_ENABLED,
 
           commentsPolicy: CONFIG.DEFAULTS.PUBLISH.COMMENTS_POLICY,
 

--- a/server/core/lib/server-config-manager.ts
+++ b/server/core/lib/server-config-manager.ts
@@ -219,6 +219,9 @@ class ServerConfigManager {
         web_videos: {
           enabled: CONFIG.TRANSCODING.ENABLED && CONFIG.TRANSCODING.WEB_VIDEOS.ENABLED
         },
+        originalFile: {
+          keep: CONFIG.TRANSCODING.ORIGINAL_FILE.KEEP
+        },
         enabledResolutions: this.getEnabledResolutions('vod'),
         profile: CONFIG.TRANSCODING.PROFILE,
         availableProfiles: VideoTranscodingProfilesManager.Instance.getAvailableProfiles('vod')

--- a/server/core/middlewares/validators/shared/videos.ts
+++ b/server/core/middlewares/validators/shared/videos.ts
@@ -277,6 +277,10 @@ export async function checkCanAccessVideoSourceFile (options: {
     return true
   }
 
+  if (video.downloadOriginalFileEnabled === true) {
+    return true
+  }
+
   res.sendStatus(HttpStatusCode.FORBIDDEN_403)
   return false
 }

--- a/server/core/middlewares/validators/shared/videos.ts
+++ b/server/core/middlewares/validators/shared/videos.ts
@@ -277,7 +277,7 @@ export async function checkCanAccessVideoSourceFile (options: {
     return true
   }
 
-  if (video.downloadOriginalFileEnabled === true) {
+  if (video.downloadEnabled === true && video.downloadOriginalFileEnabled === true) {
     return true
   }
 

--- a/server/core/middlewares/validators/videos/video-source.ts
+++ b/server/core/middlewares/validators/videos/video-source.ts
@@ -24,8 +24,17 @@ export const videoSourceGetLatestValidator = [
     const video = res.locals.videoWithRights
 
     const user = res.locals.oauth.token.User
-    if (!await checkCanManageVideo({ user, video, right: UserRight.UPDATE_ANY_VIDEO, req, res, checkIsLocal: true, checkIsOwner: false })) {
-      return
+
+    // Allow access if the user can manage the video OR if the uploader enabled original file downloads
+    const canManage = await checkCanManageVideo({
+      user, video, right: UserRight.UPDATE_ANY_VIDEO, req, res: null, checkIsLocal: true, checkIsOwner: false
+    })
+
+    if (!canManage && !video.downloadOriginalFileEnabled) {
+      return res.fail({
+        status: HttpStatusCode.FORBIDDEN_403,
+        message: req.t('You do not have the right to access this video source')
+      })
     }
 
     res.locals.videoSource = await VideoSourceModel.loadLatest(video.id)

--- a/server/core/middlewares/validators/videos/videos.ts
+++ b/server/core/middlewares/validators/videos/videos.ts
@@ -478,6 +478,10 @@ export function getCommonVideoEditAttributes () {
       .optional()
       .customSanitizer(toBooleanOrNull)
       .custom(isBooleanValid).withMessage('Should have downloadEnabled boolean'),
+    body('downloadOriginalFileEnabled')
+      .optional()
+      .customSanitizer(toBooleanOrNull)
+      .custom(isBooleanValid).withMessage('Should have downloadOriginalFileEnabled boolean'),
     body('originallyPublishedAt')
       .optional()
       .customSanitizer(toValueOrNull)

--- a/server/core/middlewares/validators/videos/videos.ts
+++ b/server/core/middlewares/validators/videos/videos.ts
@@ -481,7 +481,15 @@ export function getCommonVideoEditAttributes () {
     body('downloadOriginalFileEnabled')
       .optional()
       .customSanitizer(toBooleanOrNull)
-      .custom(isBooleanValid).withMessage('Should have downloadOriginalFileEnabled boolean'),
+      .custom(isBooleanValid).withMessage('Should have downloadOriginalFileEnabled boolean')
+      .bail()
+      .custom((value, { req }) => {
+        if (value === true && req.body.downloadEnabled === false) {
+          throw new Error('downloadOriginalFileEnabled cannot be enabled when downloadEnabled is disabled')
+        }
+
+        return true
+      }),
     body('originallyPublishedAt')
       .optional()
       .customSanitizer(toValueOrNull)

--- a/server/core/models/video/formatter/video-api-format.ts
+++ b/server/core/models/video/formatter/video-api-format.ts
@@ -184,6 +184,7 @@ export function videoModelToFormattedDetailsJSON (video: MVideoFormattableDetail
     },
 
     downloadEnabled: video.downloadEnabled,
+    downloadOriginalFileEnabled: video.downloadOriginalFileEnabled,
     waitTranscoding: video.waitTranscoding,
 
     inputFileUpdatedAt: video.inputFileUpdatedAt,

--- a/server/core/models/video/sql/video/shared/video-table-attributes.ts
+++ b/server/core/models/video/sql/video/shared/video-table-attributes.ts
@@ -306,6 +306,7 @@ export class VideoTableAttributes {
       'url',
       'commentsPolicy',
       'downloadEnabled',
+      'downloadOriginalFileEnabled',
       'embedPrivacyPolicy',
       'waitTranscoding',
       'state',

--- a/server/core/models/video/video.ts
+++ b/server/core/models/video/video.ts
@@ -580,6 +580,11 @@ export class VideoModel extends SequelizeModel<VideoModel> {
   declare downloadEnabled: boolean
 
   @AllowNull(false)
+  @Default(false)
+  @Column
+  declare downloadOriginalFileEnabled: boolean
+
+  @AllowNull(false)
   @Column
   declare embedPrivacyPolicy: VideoEmbedPrivacyPolicyType
 

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -3573,6 +3573,9 @@ paths:
                 downloadEnabled:
                   description: Enable or disable downloading for this video
                   type: boolean
+                downloadOriginalFileEnabled:
+                  description: "**PeerTube >= 8.3** Enable or disable downloading the original file for this video (requires downloadEnabled)"
+                  type: boolean
                 originallyPublishedAt:
                   description: Date when the content was originally published
                   type: string
@@ -4145,6 +4148,9 @@ paths:
                   $ref: '#/components/schemas/VideoCommentsPolicySet'
                 downloadEnabled:
                   description: Enable or disable downloading for the replay of this live video
+                  type: boolean
+                downloadOriginalFileEnabled:
+                  description: "**PeerTube >= 8.3** Enable or disable downloading the original file for this video (requires downloadEnabled)"
                   type: boolean
                 schedules:
                   type: array
@@ -10308,6 +10314,9 @@ components:
               $ref: '#/components/schemas/VideoCommentsPolicyConstant'
             downloadEnabled:
               type: boolean
+            downloadOriginalFileEnabled:
+              type: boolean
+              description: "**PeerTube >= 8.3** Whether the original file can be downloaded"
             inputFileUpdatedAt:
               type: string
               format: date-time
@@ -11759,6 +11768,8 @@ components:
               properties:
                 downloadEnabled:
                   type: boolean
+                downloadOriginalFileEnabled:
+                  type: boolean
                 commentsPolicy:
                   $ref: '#/components/schemas/VideoCommentsPolicySet'
                 privacy:
@@ -11943,6 +11954,9 @@ components:
           $ref: '#/components/schemas/VideoCommentsPolicySet'
         downloadEnabled:
           description: Enable or disable downloading for this video
+          type: boolean
+        downloadOriginalFileEnabled:
+          description: "**PeerTube >= 8.3** Enable or disable downloading the original file for this video (requires downloadEnabled)"
           type: boolean
         originallyPublishedAt:
           description: Date when the content was originally published


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, with motivation and context -->
if keep original file is enabled and the uploader enables it for the video

## Related issues

fix #6698

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<!-- delete if not relevant -->
