### PR TITLE
In v8.1.6, a new checkUnicastOrThrow method was added to youtube-dl-w…

### DIFF
--- a/server/core/helpers/youtube-dl/youtube-dl-wrapper.ts
+++ b/server/core/helpers/youtube-dl/youtube-dl-wrapper.ts
@@ -269,7 +269,7 @@ export class YoutubeDLWrapper {
   }
 
   private async checkUnicastOrThrow (userLanguage: string) {
-    if (!await isResolvingToUnicastOnly(this.url)) {
+    if (!await isResolvingToUnicastOnly(new URL(this.url).hostname)) { 
       throw new YoutubeDlImportError({
         message: t(`URL {targetUrl} is not a unicast URL.`, userLanguage, { targetUrl: this.url }),
         code: YoutubeDlImportErrorCode.NOT_ONLY_UNICAST_URL


### PR DESCRIPTION
In v8.1.6, a new checkUnicastOrThrow method was added to youtube-dl-wrapper.js that passes the full URL to isResolvingToUnicastOnly(), but that function expects just a hostname. It passes it directly to dns.lookup().

## Description

I upgraded 8.1.5 to 8.1.6 and YouTube sync stopped working. In logs I saw that dns is trying to resolve my youtube channel URL instead of hostname. I selected "doesn't update server code, below, because I believe youtube sync is not that. If I am mistaken about the definition please let me know. I applied this small change on my server already. Works.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->