### PR TITLE
fix: avoid unnecessary S3 download when local file still exists during object storage migration

### DIFF
--- a/server/core/lib/video-path-manager.ts
+++ b/server/core/lib/video-path-manager.ts
@@ -15,7 +15,7 @@ import {
   MVideoWithFile
 } from '@server/types/models/index.js'
 import { Mutex } from 'async-mutex'
-import { remove } from 'fs-extra/esm'
+import { pathExists, remove } from 'fs-extra/esm'
 import { extname, join } from 'path'
 import { makeHLSFileAvailable, makeWebVideoFileAvailable } from './object-storage/index.js'
 import { getHLSDirectory, getHLSResolutionPlaylistFilename } from './paths.js'
@@ -66,9 +66,12 @@ class VideoPathManager {
     const createMethods: MakeAvailableCreateMethod[] = []
 
     for (const videoFile of videoFiles) {
-      if (videoFile.storage === FileStorage.FILE_SYSTEM) {
+      const localPath = this.getFSVideoFileOutputPath(videoFile.getVideoOrStreamingPlaylist(), videoFile)
+      const localExists = videoFile.storage === FileStorage.FILE_SYSTEM || await pathExists(localPath)
+
+      if (localExists) {
         createMethods.push({
-          method: () => this.getFSVideoFileOutputPath(videoFile.getVideoOrStreamingPlaylist(), videoFile),
+          method: () => localPath,
           clean: false
         })
 
@@ -117,12 +120,14 @@ class VideoPathManager {
 
   async makeAvailableResolutionPlaylistFile<T> (videoFile: MVideoFileStreamingPlaylistVideo, cb: MakeAvailableCB<T>) {
     const filename = getHLSResolutionPlaylistFilename(videoFile.filename)
+    const localPath = join(getHLSDirectory(videoFile.getVideo()), filename)
+    const localExists = videoFile.storage === FileStorage.FILE_SYSTEM || await pathExists(localPath)
 
-    if (videoFile.storage === FileStorage.FILE_SYSTEM) {
+    if (localExists) {
       return this.makeAvailableFactory({
         createMethods: [
           {
-            method: () => join(getHLSDirectory(videoFile.getVideo()), filename),
+            method: () => localPath,
             clean: false
           }
         ],


### PR DESCRIPTION
## Problem

When migrating video files to object storage, there is an unnecessary S3 round-trip for **every migrated file**.

The sequence in `moveHLSFiles` (and the web-video equivalent) is:

1. Upload local file → S3 ✅
2. Call `onVideoFileMoved()` which sets `file.storage = OBJECT_STORAGE` in the DB
3. Call `updateTorrentMetadata()` which calls `makeAvailableVideoFile()` / `makeAvailableResolutionPlaylistFile()`
4. Those methods check `file.storage === FILE_SYSTEM` — it's now `OBJECT_STORAGE`, so they **download the file back from S3** even though the local file has not been deleted yet

This causes every migration job to download the file it just uploaded, doubling the time per file and saturating the network link unnecessarily.

Observed impact on a production instance migrating ~20 000 videos to an S3-compatible store in the same datacenter (1–2 ms RTT, 56 MB/s upload): throughput went from ~2 videos/min to ~15 videos/min after patching the compiled JS.

## Fix

Before falling through to the S3 download, check whether the local file actually exists on disk with `pathExists`. If it does, use it directly — regardless of the `storage` field value.

This is applied to both `makeAvailableVideoFiles` and `makeAvailableResolutionPlaylistFile`.

## Why not reorder the DB update?

Moving the `file.storage` update to after `updateTorrentMetadata()` would also work, but it is a more invasive change touching the migration state machine. The `pathExists` guard is a minimal, safe fix: it only changes behavior when the local file exists and `storage` says otherwise (i.e. exactly during migration), and it adds at most one `stat` syscall per file in normal operation when the file is already on object storage.