### PR TITLE
fix: avoid infinite re-migration loop for captions already on object storage

### DIFF
--- a/server/core/lib/move-storage/shared/move-video.ts
+++ b/server/core/lib/move-storage/shared/move-video.ts
@@ -119,7 +119,7 @@ export async function filterVideoResourcesToBeMoved (videoArg: MVideo, targetSto
       if (c.storage !== targetStorage) return true
 
       if (hls) {
-        if (targetStorage === FileStorage.OBJECT_STORAGE) return !c.m3u8Filename || !c.m3u8Url
+        if (targetStorage === FileStorage.OBJECT_STORAGE) return !c.m3u8Filename || (!c.isLocal() && !c.m3u8Url)
         else if (targetStorage === FileStorage.FILE_SYSTEM) return !c.m3u8Filename || c.m3u8Url
       }
 


### PR DESCRIPTION
## Problem

When migrating videos to object storage, `filterVideoResourcesToBeMoved` checks `!c.m3u8Url` to decide whether a caption needs its HLS m3u8 file migrated. This creates an infinite loop:

- For **local** captions, `m3u8Url` is **never stored** in the database — it is computed dynamically in `getM3U8Url()` when `isLocal()` is true and storage is `OBJECT_STORAGE`
- This means every caption with `storage = OBJECT_STORAGE` and `m3u8Filename` set still returns `!c.m3u8Url === true`
- So `moveCaptionFiles` is called repeatedly for captions that are already fully migrated
- Each call re-uploads the m3u8 file and triggers `updateHLSMasterOnCaptionChange`, which calls `updateMasterHLSPlaylist` — this downloads all video files from S3 just to run ffprobe for codec detection
- With tens of thousands of captions, this floods the job queue and saturates storage I/O indefinitely

## Fix

Restrict the `!c.m3u8Url` check to **non-local** (federated) captions, for which `m3u8Url` is the remote server's URL that must be cleared during migration to the filesystem. For local captions, `m3u8Filename` being set is the correct signal that the m3u8 was successfully uploaded.

```ts
// Before
if (targetStorage === FileStorage.OBJECT_STORAGE) return !c.m3u8Filename || !c.m3u8Url

// After
if (targetStorage === FileStorage.OBJECT_STORAGE) return !c.m3u8Filename || (!c.isLocal() && !c.m3u8Url)
```

## Impact

On instances with many captioned videos, the migration job queue could accumulate tens of thousands of redundant jobs (one per caption per script invocation), each triggering full HLS master playlist rebuilds with S3 downloads. This severely degrades migration throughput and server performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)