### PR TITLE
Recommendations policy

### DIFF
--- a/client/src/app/+video-watch/shared/recommendations/video-recommendation.service.ts
+++ b/client/src/app/+video-watch/shared/recommendations/video-recommendation.service.ts
@@ -5,7 +5,7 @@ import { Video } from '@app/shared/shared-main/video/video.model'
 import { VideoService } from '@app/shared/shared-main/video/video.service'
 import { AdvancedSearch } from '@app/shared/shared-search/advanced-search.model'
 import { SearchService } from '@app/shared/shared-search/search.service'
-import { HTMLServerConfig } from '@peertube/peertube-models'
+import { HTMLServerConfig, VideoRecommendationPolicy } from '@peertube/peertube-models'
 import { Observable, of } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 
@@ -59,11 +59,16 @@ export class VideoRecommendationService {
     return this.userService.getAnonymousOrLoggedUser()
       .pipe(
         switchMap(user => {
-          const defaultSubscription = this.videos.listVideos({
+          const defaultSubscription = this.videos.listRecommendationVideos({
             skipCount: true,
             videoPagination: pagination,
-            sort: '-publishedAt'
+            sort: '-publishedAt',
+            currentVideo
           }).pipe(map(v => v.data))
+
+          if (currentVideo.recommendationPolicy.id !== VideoRecommendationPolicy.ANY_VIDEOS) {
+            return defaultSubscription
+          }
 
           const searchIndexConfig = this.config.search.searchIndex
           if (searchIndexConfig.enabled === true && searchIndexConfig.disableLocalSearch === true) {

--- a/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
@@ -124,6 +124,7 @@ type UpdateFromAPIOptions = {
     | 'waitTranscoding'
     | 'support'
     | 'commentsPolicy'
+    | 'recommendationPolicy'
     | 'downloadEnabled'
     | 'pluginData'
     | 'scheduledUpdate'
@@ -404,6 +405,7 @@ export class VideoEdit {
         waitTranscoding: video.waitTranscoding ?? null,
         support: video.support ?? '',
         commentsPolicy: video.commentsPolicy?.id ?? null,
+        recommendationPolicy: video.recommendationPolicy?.id ?? null,
 
         downloadEnabled: video.downloadEnabled ?? null,
 
@@ -558,6 +560,7 @@ export class VideoEdit {
     if (values.waitTranscoding !== undefined) this.common.waitTranscoding = values.waitTranscoding
     if (values.support !== undefined) this.common.support = values.support
     if (values.commentsPolicy !== undefined) this.common.commentsPolicy = values.commentsPolicy
+    if (values.recommendationPolicy !== undefined) this.common.recommendationPolicy = values.recommendationPolicy
     if (values.downloadEnabled !== undefined) this.common.downloadEnabled = values.downloadEnabled
     if (values.thumbnailfile !== undefined) this.common.thumbnailfile = values.thumbnailfile
     if (values.pluginData !== undefined) this.common.pluginData = values.pluginData
@@ -643,6 +646,7 @@ export class VideoEdit {
       nsfwSummary: this.common.nsfwSummary,
 
       commentsPolicy: this.common.commentsPolicy,
+      recommendationPolicy: this.common.recommendationPolicy,
       waitTranscoding: this.common.waitTranscoding,
       channelId: this.common.channelId,
       privacy: this.common.privacy,
@@ -712,6 +716,7 @@ export class VideoEdit {
       nsfwSummary: this.common.nsfwSummary || null,
       waitTranscoding: this.common.waitTranscoding,
       commentsPolicy: this.common.commentsPolicy,
+      recommendationPolicy: this.common.recommendationPolicy,
       downloadEnabled: this.common.downloadEnabled,
       thumbnailfile: this.common.thumbnailfile,
       scheduleUpdate: this.common.scheduleUpdate || null,

--- a/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.html
@@ -45,6 +45,14 @@
           </div>
         </my-select-radio>
       </div>
+
+      <div class="form-group">
+        <my-select-radio i18n-label label="Recommendation policy" [items]="recommendationPolicies" inputId="recommendationPolicy" formControlName="recommendationPolicy">
+          <div class="form-group-description" i18n>
+            Control which videos appear in recommendations for this video
+          </div>
+        </my-select-radio>
+      </div>
     </div>
 
     <div>

--- a/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.ts
@@ -6,7 +6,7 @@ import { ServerService } from '@app/core'
 import { BuildFormArgument } from '@app/shared/form-validators/form-validator.model'
 import { VIDEO_NSFW_SUMMARY_VALIDATOR } from '@app/shared/form-validators/video-validators'
 import { FormReactiveErrors, FormReactiveService, FormReactiveMessages } from '@app/shared/shared-forms/form-reactive.service'
-import { HTMLServerConfig, VideoCommentPolicyType, ConstantLabel } from '@peertube/peertube-models'
+import { HTMLServerConfig, VideoCommentPolicyType, VideoRecommendationPolicyType, ConstantLabel } from '@peertube/peertube-models'
 import debug from 'debug'
 import { Subscription } from 'rxjs'
 import { PeertubeCheckboxComponent } from '../../../shared/shared-forms/peertube-checkbox.component'
@@ -26,6 +26,7 @@ type Form = {
   nsfwSummary: FormControl<string>
 
   commentPolicies: FormControl<VideoCommentPolicyType>
+  recommendationPolicies: FormControl<VideoRecommendationPolicyType>
 
   videoPrivacyEmbedEnableAllowlist: FormControl<boolean>
   videoPrivacyEmbedAllowlistDomains: FormControl<string>
@@ -58,6 +59,8 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
   validationMessages: FormReactiveMessages = {}
 
   commentPolicies: ConstantLabel<VideoCommentPolicyType>[] = []
+  recommendationPolicies: ConstantLabel<VideoRecommendationPolicyType>[] = []
+
   serverConfig: HTMLServerConfig
 
   private updatedSub: Subscription
@@ -69,6 +72,9 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
 
     this.serverService.getCommentPolicies()
       .subscribe(res => this.commentPolicies = res)
+
+    this.serverService.getRecommendationPolicies()
+      .subscribe(res => this.recommendationPolicies = res)
   }
 
   ngOnDestroy () {
@@ -81,6 +87,7 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
     const defaultValues = { ...videoEdit.toCommonFormPatch(), ...videoEdit.toEmbedPrivacyFormPatch() }
     const obj: BuildFormArgument = {
       commentsPolicy: null,
+      recommendationPolicy: null,
       nsfw: null,
       nsfwFlagViolent: null,
       nsfwFlagSex: null,

--- a/client/src/app/core/server/server.service.ts
+++ b/client/src/app/core/server/server.service.ts
@@ -7,6 +7,7 @@ import {
   ServerConfig,
   ServerStats,
   VideoCommentPolicy,
+  VideoRecommendationPolicy,
   ConstantLabel,
   VideoLicenceType,
   VideoPlaylistPrivacyType,
@@ -129,6 +130,27 @@ export class ServerService {
       {
         id: VideoCommentPolicy.REQUIRES_APPROVAL,
         label: $localize`Any new comment requires approval`
+      }
+    ])
+  }
+
+  getRecommendationPolicies () {
+    return of([
+      {
+        id: VideoRecommendationPolicy.ANY_VIDEOS,
+        label: $localize`Allow any videos in recommendations`
+      },
+      {
+        id: VideoRecommendationPolicy.ONLY_LOCAL_VIDEOS,
+        label: $localize`Only allow instance-local videos in recommendations`
+      },
+      {
+        id: VideoRecommendationPolicy.ONLY_CHANNEL_VIDEOS,
+        label: $localize`Only allow same channel videos in recommendations`
+      },
+      {
+        id: VideoRecommendationPolicy.ONLY_OWNER_VIDEOS,
+        label: $localize`Only allow owner videos in recommendations`
       }
     ])
   }

--- a/client/src/app/shared/shared-main/video/video-details.model.ts
+++ b/client/src/app/shared/shared-main/video/video-details.model.ts
@@ -3,6 +3,7 @@ import { VideoChannel } from '@app/shared/shared-main/channel/video-channel.mode
 import {
   ConstantLabel,
   VideoCommentPolicyType,
+  VideoRecommendationPolicyType,
   VideoDetails as VideoDetailsServerModel,
   VideoEmbedPrivacyPolicy,
   VideoEmbedPrivacyPolicyType,
@@ -22,6 +23,7 @@ export class VideoDetails extends Video implements VideoDetailsServerModel {
   downloadEnabled: boolean
 
   commentsPolicy: ConstantLabel<VideoCommentPolicyType>
+  recommendationPolicy: ConstantLabel<VideoRecommendationPolicyType>
 
   likesPercent: number
   dislikesPercent: number
@@ -48,6 +50,7 @@ export class VideoDetails extends Video implements VideoDetailsServerModel {
     this.support = hash.support
     this.commentsPolicy = hash.commentsPolicy
     this.downloadEnabled = hash.downloadEnabled
+    this.recommendationPolicy = hash.recommendationPolicy
 
     this.inputFileUpdatedAt = hash.inputFileUpdatedAt
 

--- a/client/src/app/shared/shared-main/video/video.service.ts
+++ b/client/src/app/shared/shared-main/video/video.service.ts
@@ -164,6 +164,14 @@ export class VideoService {
       )
   }
 
+  listRecommendationVideos (
+    options: VideoListParams & {
+      currentVideo: Pick<Video, 'uuid'>
+    }
+  ): Observable<ResultList<Video>> {
+    return this.listVideos({ ...options, currentVideo: options.currentVideo })
+  }
+
   listAccountVideos (
     options: VideoListParams & {
       account: Pick<Account, 'nameWithHost'>
@@ -183,16 +191,19 @@ export class VideoService {
   listVideos (
     optionsArg: VideoListParams & {
       videoChannel?: Pick<VideoChannel, 'nameWithHost'>
+      currentVideo?: Pick<Video, 'uuid'>
       account?: Pick<Account, 'nameWithHost'>
     }
   ): Observable<ResultList<Video>> {
-    const { account, videoChannel, ...options } = optionsArg
+    const { account, videoChannel, currentVideo, ...options } = optionsArg
 
     let params = new HttpParams()
     params = this.buildVideoListParams({ params, ...options })
 
     let url: string
-    if (videoChannel) {
+    if (currentVideo) {
+      url = VideoService.BASE_VIDEO_URL + '/' + currentVideo.uuid + '/recommendations'
+    } else if (videoChannel) {
       url = VideoChannelService.BASE_VIDEO_CHANNEL_URL + videoChannel.nameWithHost + '/videos'
     } else if (account) {
       url = AccountService.BASE_ACCOUNT_URL + account.nameWithHost + '/videos'

--- a/packages/models/src/videos/index.ts
+++ b/packages/models/src/videos/index.ts
@@ -32,6 +32,7 @@ export * from './video-rate.type.js'
 export * from './video-schedule-update.model.js'
 export * from './video-sort-field.type.js'
 export * from './video-state.enum.js'
+export * from './video-recommendation-policies.enum.js'
 export * from './video-source.model.js'
 
 export * from './video-streaming-playlist.model.js'

--- a/packages/models/src/videos/video-create-update-common.model.ts
+++ b/packages/models/src/videos/video-create-update-common.model.ts
@@ -1,4 +1,5 @@
 import { VideoCommentPolicyType } from './comment/video-comment-policy.enum.js'
+import { VideoRecommendationPolicyType } from './video-recommendation-policies.enum.js'
 import { VideoPrivacyType } from './video-privacy.enum.js'
 import { VideoScheduleUpdate } from './video-schedule-update.model.js'
 
@@ -30,4 +31,6 @@ export interface VideoCreateUpdateCommon {
   scheduleUpdate?: VideoScheduleUpdate
   originallyPublishedAt?: Date | string
   videoPasswords?: string[]
+
+  recommendationPolicy?: VideoRecommendationPolicyType
 }

--- a/packages/models/src/videos/video-recommendation-policies.enum.ts
+++ b/packages/models/src/videos/video-recommendation-policies.enum.ts
@@ -1,0 +1,8 @@
+export const VideoRecommendationPolicy = {
+  ANY_VIDEOS: 1,
+  ONLY_LOCAL_VIDEOS: 2,
+  ONLY_OWNER_VIDEOS: 3,
+  ONLY_CHANNEL_VIDEOS: 4
+} as const
+
+export type VideoRecommendationPolicyType = typeof VideoRecommendationPolicy[keyof typeof VideoRecommendationPolicy]

--- a/packages/models/src/videos/video.model.ts
+++ b/packages/models/src/videos/video.model.ts
@@ -1,6 +1,7 @@
 import { Account, AccountSummary } from '../actors/index.js'
 import { VideoChannel, VideoChannelSummary } from './channel/video-channel.model.js'
 import { VideoCommentPolicyType } from './comment/video-comment-policy.enum.js'
+import { VideoRecommendationPolicyType } from './video-recommendation-policies.enum.js'
 import { VideoEmbedPrivacyPolicyType } from './embed-privacy/video-embed-privacy-policy.enum.js'
 import { VideoFile } from './file/index.js'
 import { LiveVideoScheduleEdit } from './live/live-video-schedule.model.js'
@@ -87,6 +88,8 @@ export interface Video extends Partial<VideoAdditionalAttributes> {
   }
 
   pluginData?: any
+
+  recommendationPolicy?: ConstantLabel<VideoRecommendationPolicyType>
 }
 
 // Not included by default, needs query params
@@ -117,6 +120,11 @@ export interface VideoDetails extends Video {
   channel: VideoChannel
   account: Account
   tags: string[]
+
+  recommendationPolicy: {
+    id: VideoRecommendationPolicyType
+    label: string
+  }
 
   commentsPolicy: {
     id: VideoCommentPolicyType

--- a/packages/server-commands/src/videos/videos-command.ts
+++ b/packages/server-commands/src/videos/videos-command.ts
@@ -266,6 +266,25 @@ export class VideosCommand extends AbstractCommand {
   }
 
   // ---------------------------------------------------------------------------
+  listRecommendations (
+    options: OverrideCommandOptions & VideosCommonQuery & {
+      id: number | string
+    }
+  ) {
+    const path = '/api/v1/videos/' + options.id + '/recommendations'
+
+    const query = this.buildListQuery(options)
+
+    return this.getRequestBody<ResultList<Video>>({
+      ...options,
+
+      path,
+      query: { sort: 'name', ...query },
+      implicitToken: false,
+      defaultExpectedStatus: HttpStatusCode.OK_200
+    })
+  }
+
 
   list (options: OverrideCommandOptions & VideosCommonQuery = {}) {
     const path = '/api/v1/videos'

--- a/packages/tests/src/api/videos/video-recommendation-policy.ts
+++ b/packages/tests/src/api/videos/video-recommendation-policy.ts
@@ -1,0 +1,87 @@
+import { VideoRecommendationPolicy } from '@peertube/peertube-models'
+import {
+  cleanupTests,
+  createSingleServer,
+  PeerTubeServer,
+  setAccessTokensToServers,
+  waitJobs
+} from '@peertube/peertube-server-commands'
+import { expect } from 'chai'
+
+describe('Video recommendation policy (server-side)', function () {
+  let server: PeerTubeServer
+  let videoA: any
+
+  before(async function () {
+    this.timeout(30000)
+
+    server = await createSingleServer(1, {})
+    await setAccessTokensToServers([ server ])
+
+    // Create 2 videos in same channel
+    videoA = await server.videos.upload({ attributes: { name: 'VideoA' } })
+    // Fetch video details
+    videoA = await server.videos.get({ id: videoA.id })
+
+    await server.videos.upload({ attributes: { name: 'VideoB' } })
+
+    // Create another channel + video
+    const channel = await server.channels.create({ attributes: { displayName: 'Other channel', name: 'other' } })
+    await server.videos.upload({
+      attributes: { name: 'VideoC', channelId: channel.id }
+    })
+
+    // Create another user + video
+    const token = await server.users.generateUserAndToken('user2')
+    await server.videos.upload({
+      token,
+      attributes: { name: 'VideoD' }
+    })
+
+    await waitJobs(server)
+  })
+
+  it('only-channel-videos: should only return videos from same channel', async function () {
+    await server.videos.update({ id: videoA.id, attributes: { recommendationPolicy: VideoRecommendationPolicy.ONLY_CHANNEL_VIDEOS } })
+
+    const res = await server.videos.listRecommendations({ id: videoA.uuid })
+
+    const videos = res.data
+    expect(videos.length).to.be.greaterThan(0)
+    expect(videos.every(v => v.channel.id === videoA.channel.id)).to.equal(true)
+  })
+
+  it('only-owner-videos: should only return videos from same owner', async function () {
+    await server.videos.update({ id: videoA.id, attributes: { recommendationPolicy: VideoRecommendationPolicy.ONLY_OWNER_VIDEOS } })
+
+    const res = await server.videos.listRecommendations({ id: videoA.uuid })
+
+    const videos = res.data
+    expect(videos.length).to.be.greaterThan(0)
+    expect(videos.every(v => v.account.id === videoA.account.id)).to.equal(true)
+  })
+
+  it('only-local-videos: should only return local videos', async function () {
+    await server.videos.update({ id: videoA.id, attributes: { recommendationPolicy: VideoRecommendationPolicy.ONLY_LOCAL_VIDEOS } })
+
+    const res = await server.videos.listRecommendations({ id: videoA.uuid })
+
+    const videos = res.data
+    expect(videos.every(v => v.isLocal === true)).to.equal(true)
+  })
+
+  it('any-videos: should allow mixed results', async function () {
+    await server.videos.update({ id: videoA.id, attributes: { recommendationPolicy: VideoRecommendationPolicy.ANY_VIDEOS } })
+
+    const res = await server.videos.listRecommendations({ id: videoA.uuid })
+
+    const videos = res.data
+    const hasDifferentChannel = videos.some(v => v.channel.id !== videoA.channel.id)
+
+    expect(hasDifferentChannel).to.equal(true)
+  })
+
+  after(async function () {
+    await cleanupTests([ server ])
+  })
+})

--- a/server/core/controllers/api/accounts.ts
+++ b/server/core/controllers/api/accounts.ts
@@ -243,6 +243,7 @@ async function listAccountVideos (req: express.Request, res: express.Response) {
     displayOnlyForFollower,
     accountId: account.id,
     user: res.locals.oauth ? res.locals.oauth.token.User : undefined,
+    currentVideoUuid: undefined,
     countVideos
   }, 'filter:api.accounts.videos.list.params')
 

--- a/server/core/controllers/api/overviews.ts
+++ b/server/core/controllers/api/overviews.ts
@@ -122,6 +122,7 @@ async function getVideos (
     },
     user: res.locals.oauth ? res.locals.oauth.token.User : undefined,
     countVideos: false,
+    currentVideoUuid: undefined,
 
     ...where
   }, 'filter:api.overviews.videos.list.params')

--- a/server/core/controllers/api/users/me.ts
+++ b/server/core/controllers/api/users/me.ts
@@ -165,6 +165,7 @@ async function listMyVideos (req: express.Request, res: express.Response) {
       videoChannelId: res.locals.videoChannel?.id,
       channelNameOneOf: req.query.channelNameOneOf,
       includeCollaborations: req.query.includeCollaborations || false,
+      currentVideoUuid: undefined,
 
       countVideos,
 

--- a/server/core/controllers/api/users/my-subscriptions.ts
+++ b/server/core/controllers/api/users/my-subscriptions.ts
@@ -171,6 +171,7 @@ async function getUserSubscriptionVideos (req: express.Request, res: express.Res
       orLocalVideos: false
     },
     user,
+    currentVideoUuid: undefined,
     countVideos
   }, 'filter:api.user.me.subscription-videos.list.params')
 

--- a/server/core/controllers/api/video-channels/index.ts
+++ b/server/core/controllers/api/video-channels/index.ts
@@ -407,6 +407,7 @@ async function listVideoChannelVideos (req: express.Request, res: express.Respon
     displayOnlyForFollower,
     videoChannelId: videoChannelInstance.id,
     user: res.locals.oauth ? res.locals.oauth.token.User : undefined,
+    currentVideoUuid: undefined,
     countVideos
   }, 'filter:api.video-channels.videos.list.params')
 

--- a/server/core/controllers/api/videos/index.ts
+++ b/server/core/controllers/api/videos/index.ts
@@ -101,6 +101,20 @@ videosRouter.get(
 )
 
 videosRouter.get(
+  '/:id/recommendations',
+  openapiOperationDoc({ operationId: 'getVideoRecommendations' }),
+  paginationValidator,
+  videosSortValidator,
+  setDefaultVideosSort,
+  setDefaultPagination,
+  optionalAuthenticate,
+  commonVideosFiltersValidatorFactory(),
+  asyncMiddleware(videoGetValidatorFactory('for-api')),
+  asyncMiddleware(checkVideoFollowConstraints),
+  asyncMiddleware(listVideos)
+)
+
+videosRouter.get(
   '/:id',
   openapiOperationDoc({ operationId: 'getVideo' }),
   optionalAuthenticate,
@@ -174,6 +188,7 @@ async function listVideos (req: express.Request, res: express.Response) {
       actorId: serverActor.id,
       orLocalVideos: true
     },
+    currentVideoUuid: res.locals?.videoAPI?.uuid,
     user: res.locals.oauth ? res.locals.oauth.token.User : undefined,
     countVideos
   }, 'filter:api.videos.list.params')

--- a/server/core/controllers/api/videos/update.ts
+++ b/server/core/controllers/api/videos/update.ts
@@ -94,7 +94,8 @@ async function updateVideo (req: express.Request, res: express.Response) {
         'waitTranscoding',
         'support',
         'description',
-        'downloadEnabled'
+        'downloadEnabled',
+        'recommendationPolicy'
       ]
 
       for (const key of keysToUpdate) {

--- a/server/core/controllers/feeds/shared/video-feed-utils.ts
+++ b/server/core/controllers/feeds/shared/video-feed-utils.ts
@@ -36,6 +36,7 @@ export async function getVideosForFeeds (options: {
       },
       hasFiles: true,
       countVideos: false,
+      currentVideoUuid: undefined,
 
       privacyOneOf: options.allowUnlisted
         ? [ VideoPrivacy.PUBLIC, VideoPrivacy.UNLISTED ]

--- a/server/core/controllers/sitemap.ts
+++ b/server/core/controllers/sitemap.ts
@@ -89,6 +89,7 @@ async function getSitemapLocalVideoUrls () {
       },
       isLocal: true,
       countVideos: false,
+      currentVideoUuid: undefined,
       include: VideoInclude.FILES | VideoInclude.TAGS
     })
 

--- a/server/core/helpers/custom-validators/videos.ts
+++ b/server/core/helpers/custom-validators/videos.ts
@@ -12,7 +12,8 @@ import {
   VIDEO_LIVE,
   VIDEO_PRIVACIES,
   VIDEO_RATE_TYPES,
-  VIDEO_STATES
+  VIDEO_STATES,
+  VIDEO_RECOMMENDATION_POLICY
 } from '../../initializers/constants.js'
 import { exists, isArray, isDateValid, isFileValid } from './misc.js'
 
@@ -49,6 +50,10 @@ export function isVideoDescriptionValid (value: string) {
 
 export function isVideoCommentsPolicyValid (value: any) {
   return value === null || VIDEO_COMMENTS_POLICY[value] !== undefined
+}
+
+export function isRecommendationPolicyValid (value: any) {
+  return value === null || VIDEO_RECOMMENDATION_POLICY[value] !== undefined
 }
 
 export function isVideoSupportValid (value: string) {

--- a/server/core/initializers/constants.ts
+++ b/server/core/initializers/constants.ts
@@ -47,7 +47,9 @@ import {
   VideoRateType,
   VideoResolution,
   VideoState,
-  VideoStateType
+  VideoStateType,
+  VideoRecommendationPolicy,
+  VideoRecommendationPolicyType
 } from '@peertube/peertube-models'
 import { isTestInstance, isTestOrDevInstance, root } from '@peertube/peertube-node-utils'
 import { RepeatOptions } from 'bullmq'
@@ -62,7 +64,7 @@ import { CONFIG, registerConfigChangedHandler } from './config.js'
 
 // ---------------------------------------------------------------------------
 
-export const LAST_MIGRATION_VERSION = 1040
+export const LAST_MIGRATION_VERSION = 1041
 
 // ---------------------------------------------------------------------------
 
@@ -636,6 +638,13 @@ export const VIDEO_PRIVACIES: { [id in VideoPrivacyType]: string } = {
   [VideoPrivacy.PRIVATE]: 'Private',
   [VideoPrivacy.INTERNAL]: 'Internal',
   [VideoPrivacy.PASSWORD_PROTECTED]: 'Password protected'
+}
+
+export const VIDEO_RECOMMENDATION_POLICY: { [id in VideoRecommendationPolicyType]: string } = {
+  [VideoRecommendationPolicy.ONLY_OWNER_VIDEOS]: "Only owner videos",
+  [VideoRecommendationPolicy.ONLY_CHANNEL_VIDEOS]: "Only same channel videos",
+  [VideoRecommendationPolicy.ONLY_LOCAL_VIDEOS]: "Only instance local videos",
+  [VideoRecommendationPolicy.ANY_VIDEOS]: "Any videos (instance administrator choice)",
 }
 
 export const VIDEO_STATES: { [id in VideoStateType]: string } = {

--- a/server/core/initializers/migrations/1041-video-recommendation-policy.ts
+++ b/server/core/initializers/migrations/1041-video-recommendation-policy.ts
@@ -1,0 +1,13 @@
+import * as Sequelize from 'sequelize'
+
+export async function up (queryInterface: Sequelize.QueryInterface) {
+  await queryInterface.addColumn('video', 'recommendationPolicy', {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: 1 // ANY_VIDEOS
+  })
+}
+
+export async function down (queryInterface: Sequelize.QueryInterface) {
+  await queryInterface.removeColumn('video', 'recommendationPolicy')
+}

--- a/server/core/middlewares/validators/videos/videos.ts
+++ b/server/core/middlewares/validators/videos/videos.ts
@@ -38,6 +38,7 @@ import {
   isValidPasswordProtectedPrivacy,
   isVideoCategoryValid,
   isVideoCommentsPolicyValid,
+  isRecommendationPolicyValid,
   isVideoDescriptionValid,
   isVideoImageValid,
   isVideoIncludeValid,
@@ -491,7 +492,11 @@ export function getCommonVideoEditAttributes () {
     body('scheduleUpdate.privacy')
       .optional()
       .customSanitizer(toIntOrNull)
-      .custom(isScheduleVideoUpdatePrivacyValid)
+      .custom(isScheduleVideoUpdatePrivacyValid),
+
+    body('recommendationPolicy')
+      .optional()
+      .custom(isRecommendationPolicyValid),
   ] as (ValidationChain | ExpressPromiseHandler)[]
 }
 
@@ -549,6 +554,10 @@ export const commonVideosFiltersValidatorFactory = (options: {
       .optional()
       .customSanitizer(toBooleanOrNull)
       .custom(isBooleanValid).withMessage('Should have a valid isLocal boolean'),
+
+    query('currentVideoUuid')
+      .optional()
+      .isUUID(),
     query('hasHLSFiles')
       .optional()
       .customSanitizer(toBooleanOrNull)

--- a/server/core/models/redundancy/video-redundancy.ts
+++ b/server/core/models/redundancy/video-redundancy.ts
@@ -459,6 +459,7 @@ export class VideoRedundancyModel extends SequelizeModel<VideoRedundancyModel> {
       sort,
       nsfw: null,
       displayOnlyForFollower: null,
+      currentVideoUuid: undefined,
 
       include: VideoInclude.FILES | VideoInclude.BLACKLISTED | VideoInclude.NOT_PUBLISHED_STATE | VideoInclude.BLOCKED_OWNER,
       privacyOneOf: getAllPrivacies(),

--- a/server/core/models/user/user-video-history.ts
+++ b/server/core/models/user/user-video-history.ts
@@ -68,6 +68,7 @@ export class UserVideoHistoryModel extends SequelizeModel<UserVideoHistoryModel>
       sort: '-"userVideoHistory"."updatedAt"',
       nsfw: null, // All
       displayOnlyForFollower: null,
+      currentVideoUuid: undefined,
       user,
       historyOfUser: user
     })

--- a/server/core/models/video/formatter/video-api-format.ts
+++ b/server/core/models/video/formatter/video-api-format.ts
@@ -18,6 +18,7 @@ import { isArray } from '../../../helpers/custom-validators/misc.js'
 import {
   VIDEO_CATEGORIES,
   VIDEO_COMMENTS_POLICY,
+  VIDEO_RECOMMENDATION_POLICY,
   VIDEO_EMBED_PRIVACY_POLICIES,
   VIDEO_LANGUAGES,
   VIDEO_LICENCES,
@@ -198,6 +199,11 @@ export function videoModelToFormattedDetailsJSON (video: MVideoFormattableDetail
     embedPrivacyPolicy: {
       id: video.embedPrivacyPolicy,
       label: VIDEO_EMBED_PRIVACY_POLICIES[video.embedPrivacyPolicy]
+    },
+
+    recommendationPolicy: {
+      id: video.recommendationPolicy,
+      label: VIDEO_RECOMMENDATION_POLICY[video.recommendationPolicy]
     }
   }
 

--- a/server/core/models/video/sql/video/shared/video-table-attributes.ts
+++ b/server/core/models/video/sql/video/shared/video-table-attributes.ts
@@ -305,6 +305,7 @@ export class VideoTableAttributes {
       'aspectRatio',
       'url',
       'commentsPolicy',
+      'recommendationPolicy',
       'downloadEnabled',
       'embedPrivacyPolicy',
       'waitTranscoding',

--- a/server/core/models/video/sql/video/videos-id-list-query-builder.ts
+++ b/server/core/models/video/sql/video/videos-id-list-query-builder.ts
@@ -110,6 +110,7 @@ export type BuildVideosListQueryOptions = {
   redundancyStrategy?: string
   includeRedundancy?: boolean
   localRedundancy?: boolean
+  currentVideoUuid?: string
 }
 
 type SortDirection = 'ASC' | 'DESC'

--- a/server/core/models/video/video.ts
+++ b/server/core/models/video/video.ts
@@ -14,10 +14,12 @@ import {
   VideoObject,
   VideoPrivacy,
   VideoRateType,
+  VideoRecommendationPolicy,
   VideoState,
   VideoStreamingPlaylistType,
   VideoSummary,
   type VideoCommentPolicyType,
+  type VideoRecommendationPolicyType,
   type VideoEmbedPrivacyPolicyType,
   type VideoPrivacyType,
   type VideoStateType
@@ -582,6 +584,11 @@ export class VideoModel extends SequelizeModel<VideoModel> {
   @AllowNull(false)
   @Column
   declare embedPrivacyPolicy: VideoEmbedPrivacyPolicyType
+
+  @AllowNull(false)
+  @Default(VideoRecommendationPolicy.ANY_VIDEOS)
+  @Column
+  declare recommendationPolicy: VideoRecommendationPolicyType
 
   @AllowNull(false)
   @Column
@@ -1159,6 +1166,7 @@ export class VideoModel extends SequelizeModel<VideoModel> {
         | 'includeRedundancy'
         | 'localRedundancy'
         | 'tableAttributes'
+        | 'currentVideoUuid'
       >
   ) {
     if (options.skipPrivateIncludeCheck !== true) {
@@ -1167,6 +1175,36 @@ export class VideoModel extends SequelizeModel<VideoModel> {
     }
 
     const serverActor = await getServerActor()
+
+    // Apply recommendation filtering based on current video
+    if (options.currentVideoUuid) {
+      const current = await VideoModel.findOne({
+        attributes: [ 'id', 'channelId', 'recommendationPolicy' ],
+        where: { uuid: options.currentVideoUuid },
+        include: [ {
+          association: 'VideoChannel',
+          attributes: [ 'id' ],
+          include: [ {
+            association: 'Account',
+            attributes: [ 'id' ]
+          } ]
+        } ]
+      })
+
+      if (current) {
+        switch (current.recommendationPolicy) {
+          case VideoRecommendationPolicy.ONLY_OWNER_VIDEOS:
+            options.accountId = current.VideoChannel?.Account?.id
+            break
+          case VideoRecommendationPolicy.ONLY_CHANNEL_VIDEOS:
+            options.videoChannelId = current.channelId
+            break
+          case VideoRecommendationPolicy.ONLY_LOCAL_VIDEOS:
+            options.isLocal = true
+            break
+        }
+      }
+    }
 
     const queryOptions = {
       ...pick(options, [


### PR DESCRIPTION
## Description

This commit adds a new option attached to a video, that allows to chose  which kind of recommendation will appear below it in the viewer.  It currently allows four setups:
 - Any video (same as currently)
 - Local videos only
 - Owner videos only
 - Same channel videos only
    
This allows the user who owns the video to restrict the recommendations associated to his videos.

AI disclaimer: Tests were written in big part with AI help. It also sketched me a draft of the feature implementation but no line of this draft remain in this PR, it helped mostly with providing indications and relevant code locations since I’m not familiar with the project.

## Related issues

https://github.com/Chocobozzz/PeerTube/issues/1600

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots

<img width="688" height="225" alt="2026-05-28_15_52_42" src="https://github.com/user-attachments/assets/dc2ec167-0052-4634-950b-abcd8e9e9895" />
