### PR TITLE
Add null guard for channelItem in VideoCustomizationComponent.ngOnInit to prevent crash when the video's channel is not 

### DIFF
--- a/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/customization/video-customization.component.ts
@@ -70,7 +70,9 @@ export class VideoCustomizationComponent implements OnInit, OnDestroy {
     this.videoEdit = videoEdit
 
     const channelItem = userChannels.find(c => c.id === videoEdit.toCommonFormPatch().channelId)
-    this.videoChannel = { name: channelItem.name, displayName: channelItem.label }
+    if (channelItem) {
+      this.videoChannel = { name: channelItem.name, displayName: channelItem.label }
+    }
 
     this.buildForm()
   }


### PR DESCRIPTION
Fixes #7660.

Add null guard for channelItem in VideoCustomizationComponent.ngOnInit to prevent crash when the video's channel is not in the user's channel list. The component assumes `userChannels.find(...)` always returns a channel, but when an admin/moderator edits a video belonging to another user's channel, `channelItem` is `undefined`. This causes a TypeError when accessing `.name` and `.label`, aborting `ngOnInit` before `buildForm()` runs, leading to infinite loading. The sibling component `video-main-info.component.ts` already guards such lookups. Adding a simple null check prevents the crash and allows the form to be built.

I ran the available lightweight check for the frontend change.