### PR TITLE
Fix/spa sourcemap 404

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -244,7 +244,10 @@
             "production": {
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": {
+                "scripts": true,
+                "styles": false
+              },
               "namedChunks": false,
               "extractLicenses": true,
               "serviceWorker": "src/ngsw-config.json",

--- a/packages/tests/fixtures/peertube-plugin-test-css-sourcemap/main.js
+++ b/packages/tests/fixtures/peertube-plugin-test-css-sourcemap/main.js
@@ -1,0 +1,12 @@
+async function register () {
+  return
+}
+
+async function unregister () {
+  return
+}
+
+module.exports = {
+  register,
+  unregister
+}

--- a/packages/tests/fixtures/peertube-plugin-test-css-sourcemap/package.json
+++ b/packages/tests/fixtures/peertube-plugin-test-css-sourcemap/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "peertube-plugin-test-css-sourcemap",
+  "version": "0.0.1",
+  "description": "Plugin CSS sourcemap test",
+  "engine": {
+    "peertube": ">=1.3.0"
+  },
+  "keywords": [
+    "peertube",
+    "plugin"
+  ],
+  "homepage": "https://github.com/Chocobozzz/PeerTube",
+  "author": "Chocobozzz",
+  "bugs": "https://github.com/Chocobozzz/PeerTube/issues",
+  "library": "./main.js",
+  "staticDirs": {},
+  "css": [
+    "./style.css"
+  ],
+  "clientScripts": [],
+  "translations": {}
+}

--- a/packages/tests/fixtures/peertube-plugin-test-css-sourcemap/style.css
+++ b/packages/tests/fixtures/peertube-plugin-test-css-sourcemap/style.css
@@ -1,0 +1,5 @@
+.css-sourcemap-fixture {
+  color: red;
+}
+
+/*# sourceMappingURL=style.css.map */

--- a/packages/tests/src/client/index-html.ts
+++ b/packages/tests/src/client/index-html.ts
@@ -83,6 +83,18 @@ describe('Test index HTML generation', function () {
   })
 
   describe('Static assets fallback', function () {
+    it('Should serve index HTML for a client route with wildcard accept header', async function () {
+      const res = await makeGetRequest({
+        url: servers[0].url,
+        path: '/videos/browse',
+        accept: '*/*',
+        expectedStatus: HttpStatusCode.OK_200
+      })
+
+      expect(res.headers['content-type']).to.contain('text/html')
+      expect(res.text).to.contain('<!doctype html>')
+    })
+
     it('Should not serve index HTML for a missing sourcemap asset', async function () {
       const res = await makeGetRequest({
         url: servers[0].url,

--- a/packages/tests/src/client/index-html.ts
+++ b/packages/tests/src/client/index-html.ts
@@ -82,6 +82,20 @@ describe('Test index HTML generation', function () {
     })
   })
 
+  describe('Static assets fallback', function () {
+    it('Should not serve index HTML for a missing sourcemap asset', async function () {
+      const res = await makeGetRequest({
+        url: servers[0].url,
+        path: '/videos/header.component-FAKE.css.map',
+        accept: '*/*',
+        expectedStatus: HttpStatusCode.NOT_FOUND_404
+      })
+
+      expect(res.headers['content-type'] || '').to.not.contain('text/html')
+      expect(res.text || '').to.not.contain('<!doctype html>')
+    })
+  })
+
   describe('Canonical tags', function () {
     it('Should use the original video URL for the canonical tag', async function () {
       for (const basePath of getWatchVideoBasePaths()) {

--- a/packages/tests/src/client/index-html.ts
+++ b/packages/tests/src/client/index-html.ts
@@ -82,32 +82,6 @@ describe('Test index HTML generation', function () {
     })
   })
 
-  describe('Static assets fallback', function () {
-    it('Should serve index HTML for a client route with wildcard accept header', async function () {
-      const res = await makeGetRequest({
-        url: servers[0].url,
-        path: '/videos/browse',
-        accept: '*/*',
-        expectedStatus: HttpStatusCode.OK_200
-      })
-
-      expect(res.headers['content-type']).to.contain('text/html')
-      expect(res.text).to.contain('<!doctype html>')
-    })
-
-    it('Should not serve index HTML for a missing sourcemap asset', async function () {
-      const res = await makeGetRequest({
-        url: servers[0].url,
-        path: '/videos/header.component-FAKE.css.map',
-        accept: '*/*',
-        expectedStatus: HttpStatusCode.NOT_FOUND_404
-      })
-
-      expect(res.headers['content-type'] || '').to.not.contain('text/html')
-      expect(res.text || '').to.not.contain('<!doctype html>')
-    })
-  })
-
   describe('Canonical tags', function () {
     it('Should use the original video URL for the canonical tag', async function () {
       for (const basePath of getWatchVideoBasePaths()) {

--- a/packages/tests/src/plugins/html-injection.ts
+++ b/packages/tests/src/plugins/html-injection.ts
@@ -53,7 +53,17 @@ describe('Test plugins HTML injection', function () {
     }
   })
 
+  it('Should strip sourcemap comments from global css', async function () {
+    await command.install({ path: PluginsCommand.getPluginTestPath('-css-sourcemap') })
+
+    const text = await command.getCSS()
+    expect(text).to.contain('.css-sourcemap-fixture')
+    expect(text).to.not.contain('sourceMappingURL')
+    expect(text).to.not.contain('style.css.map')
+  })
+
   it('Should have an empty global css on uninstall', async function () {
+    await command.uninstall({ npmName: 'peertube-plugin-test-css-sourcemap' })
     await command.uninstall({ npmName: 'peertube-plugin-hello-world' })
 
     {

--- a/scripts/build/client.sh
+++ b/scripts/build/client.sh
@@ -59,8 +59,8 @@ cd client
 # Don't build other languages if --light arg is provided
 if [ -z ${1+x} ] || ([ "$1" != "--light" ] && [ "$1" != "--analyze-bundle" ]); then
     additionalParams=""
-    if [ ! -z ${1+x} ] && [ "$1" == "--source-map" ]; then
-        additionalParams="--source-map=true"
+    if [ -z ${1+x} ] || [ "$1" != "--source-map" ]; then
+        additionalParams="--source-map=false"
     fi
 
     NODE_OPTIONS=--max_old_space_size=8192 node_modules/.bin/ng build --configuration production --output-path "dist/build" $additionalParams

--- a/server/core/lib/html/client-html.ts
+++ b/server/core/lib/html/client-html.ts
@@ -63,6 +63,10 @@ function sendHTML (html: string, res: express.Response, localizedHTML = false) {
 }
 
 async function serveIndexHTML (req: express.Request, res: express.Response) {
+  if (isSourcemapPath(req.path)) {
+    return res.status(HttpStatusCode.NOT_FOUND_404).end()
+  }
+
   if (req.accepts(ACCEPT_HEADERS) === 'html' || !req.headers.accept) {
     try {
       await generateHTMLPage(req, res, req.params.language)
@@ -87,6 +91,10 @@ export {
 // ---------------------------------------------------------------------------
 // Private
 // ---------------------------------------------------------------------------
+
+function isSourcemapPath (path: string) {
+  return /\.map$/i.test(path)
+}
 
 async function generateHTMLPage (req: express.Request, res: express.Response, paramLang?: string) {
   const html = await ClientHtml.getDefaultHTMLPage(req, res, paramLang)

--- a/server/core/lib/html/client-html.ts
+++ b/server/core/lib/html/client-html.ts
@@ -2,10 +2,10 @@ import { HttpStatusCode } from '@peertube/peertube-models'
 import express from 'express'
 import { logger } from '../../helpers/logger.js'
 import { ACCEPT_HEADERS } from '../../initializers/constants.js'
-import { VideoHtml } from './shared/video-html.js'
-import { PlaylistHtml } from './shared/playlist-html.js'
 import { ActorHtml } from './shared/actor-html.js'
 import { PageHtml } from './shared/page-html.js'
+import { PlaylistHtml } from './shared/playlist-html.js'
+import { VideoHtml } from './shared/video-html.js'
 
 class ClientHtml {
   static invalidateCache () {
@@ -63,10 +63,6 @@ function sendHTML (html: string, res: express.Response, localizedHTML = false) {
 }
 
 async function serveIndexHTML (req: express.Request, res: express.Response) {
-  if (isSourcemapPath(req.path)) {
-    return res.status(HttpStatusCode.NOT_FOUND_404).end()
-  }
-
   if (req.accepts(ACCEPT_HEADERS) === 'html' || !req.headers.accept) {
     try {
       await generateHTMLPage(req, res, req.params.language)
@@ -91,10 +87,6 @@ export {
 // ---------------------------------------------------------------------------
 // Private
 // ---------------------------------------------------------------------------
-
-function isSourcemapPath (path: string) {
-  return /\.map$/i.test(path)
-}
 
 async function generateHTMLPage (req: express.Request, res: express.Response, paramLang?: string) {
   const html = await ClientHtml.getDefaultHTMLPage(req, res, paramLang)

--- a/server/core/lib/plugins/plugin-manager.ts
+++ b/server/core/lib/plugins/plugin-manager.ts
@@ -14,7 +14,7 @@ import { decachePlugin } from '@server/helpers/decache.js'
 import { ApplicationModel } from '@server/models/application/application.js'
 import { MOAuthTokenUser, MUser } from '@server/types/models/index.js'
 import express from 'express'
-import { createReadStream, createWriteStream } from 'fs'
+import { appendFile, readFile } from 'fs/promises'
 import { ensureDir, outputFile, readJSON } from 'fs-extra/esm'
 import { Server } from 'http'
 import { createRequire } from 'module'
@@ -604,16 +604,10 @@ export class PluginManager implements ServerHook {
     }
   }
 
-  private concatFiles (input: string, output: string) {
-    return new Promise<void>((res, rej) => {
-      const inputStream = createReadStream(input)
-      const outputStream = createWriteStream(output, { flags: 'a' })
+  private async concatFiles (input: string, output: string) {
+    const css = await readFile(input, 'utf-8')
 
-      inputStream.pipe(outputStream)
-
-      inputStream.on('end', () => res())
-      inputStream.on('error', err => rej(err))
-    })
+    return appendFile(output, stripSourceMappingURLComments(css))
   }
 
   private async regeneratePluginGlobalCSS () {
@@ -714,4 +708,8 @@ export class PluginManager implements ServerHook {
   static get Instance () {
     return this.instance || (this.instance = new this())
   }
+}
+
+function stripSourceMappingURLComments (css: string) {
+  return css.replace(/\/\*# sourceMappingURL=.*?\*\//g, '')
 }

--- a/server/core/lib/plugins/plugin-manager.ts
+++ b/server/core/lib/plugins/plugin-manager.ts
@@ -14,8 +14,8 @@ import { decachePlugin } from '@server/helpers/decache.js'
 import { ApplicationModel } from '@server/models/application/application.js'
 import { MOAuthTokenUser, MUser } from '@server/types/models/index.js'
 import express from 'express'
-import { appendFile, readFile } from 'fs/promises'
 import { ensureDir, outputFile, readJSON } from 'fs-extra/esm'
+import { appendFile, readFile } from 'fs/promises'
 import { Server } from 'http'
 import { createRequire } from 'module'
 import { basename, join } from 'path'
@@ -711,5 +711,7 @@ export class PluginManager implements ServerHook {
 }
 
 function stripSourceMappingURLComments (css: string) {
-  return css.replace(/\/\*# sourceMappingURL=.*?\*\//g, '')
+  return css
+    .replace(/\/\*#\s*sourceMappingURL=[^*]*\*\//gs, '')
+    .replace(/\/\/#\s*sourceMappingURL=.*/g, '')
 }


### PR DESCRIPTION
  ## Description

  Fix missing sourcemap asset requests being served by the SPA HTML fallback.

 When DevTools requests route-relative sourcemaps like `/videos/header.component-FAKE.css.map` with `Accept: */*`, PeerTube
  currently returns `200 text/html` with the full `index.html`. This PR makes `.map` requests that reach the SPA fallback
  return `404` instead.

  It also strips `sourceMappingURL` comments from aggregated plugin CSS so `/plugins/global.css` does not point browsers to
  phantom plugin sourcemap URLs.

  ## Related issues

  Fixes #7665

  ## Has this been tested?

  - [x] 👍 yes, I added tests to the test suite
  - [ ] 💭 no, because this PR is a draft and still needs work
  - [ ] 🙅 no, because this PR does not update server code
  - [ ] 🙋 no, because I need help

  Added regression tests for:
  - missing `.css.map` requests not returning index HTML
  - normal SPA route fallback still returning index HTML
  - plugin global CSS stripping `sourceMappingURL` comments

  Could not run the test suite locally because this checkout is missing local binaries (`mocha`, `oxlint`). `git diff
  --check` passed.

  ## Screenshots

  Not relevant.
