### PR TITLE
Add TwelveLabs Pegasus transcription engine

### DIFF
--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -2104,7 +2104,7 @@
           "default": false
         },
         "engine": {
-          "description": "Choose engine for local transcription Supported: 'openai-whisper' or 'whisper-ctranslate2'",
+          "description": "Choose engine for transcription Local engines: 'openai-whisper' or 'whisper-ctranslate2' Remote engine: 'twelvelabs' (TwelveLabs Pegasus, requires the TWELVELABS_API_KEY env variable - https://twelvelabs.io)",
           "type": "string",
           "default": "whisper-ctranslate2"
         },

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -816,8 +816,9 @@ video_transcription:
   # Enable automatic transcription of videos
   enabled: false
 
-  # Choose engine for local transcription
-  # Supported: 'openai-whisper' or 'whisper-ctranslate2'
+  # Choose engine for transcription
+  # Local engines: 'openai-whisper' or 'whisper-ctranslate2'
+  # Remote engine: 'twelvelabs' (TwelveLabs Pegasus, requires the TWELVELABS_API_KEY env variable - https://twelvelabs.io)
   engine: 'whisper-ctranslate2'
 
   # You can set a custom engine path for local transcription

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -826,8 +826,9 @@ video_transcription:
   # Enable automatic transcription of videos
   enabled: false
 
-  # Choose engine for local transcription
-  # Supported: 'openai-whisper' or 'whisper-ctranslate2'
+  # Choose engine for transcription
+  # Local engines: 'openai-whisper' or 'whisper-ctranslate2'
+  # Remote engine: 'twelvelabs' (TwelveLabs Pegasus, requires the TWELVELABS_API_KEY env variable - https://twelvelabs.io)
   engine: 'whisper-ctranslate2'
 
   # You can set a custom engine path for local transcription

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "sql-formatter": "^15.8.2",
     "srt-to-vtt": "^1.1.3",
     "tslib": "^2.8.1",
+    "twelvelabs-js": "^1.2.8",
     "uuid": "^14.0.1",
     "validator": "^13.15.35",
     "webfinger.js": "3.0.4",

--- a/packages/tests/src/transcription/transcriber-factory.spec.ts
+++ b/packages/tests/src/transcription/transcriber-factory.spec.ts
@@ -2,7 +2,7 @@ import { TranscriptionEngineName, transcriberFactory } from '@peertube/peertube-
 import { createConsoleLogger } from '@tests/shared/common.js'
 
 describe('Transcriber factory', function () {
-  const transcribers: TranscriptionEngineName[] = [ 'openai-whisper', 'whisper-ctranslate2' ]
+  const transcribers: TranscriptionEngineName[] = [ 'openai-whisper', 'whisper-ctranslate2', 'twelvelabs' ]
 
   describe('Should be able to create a transcriber for each available transcription engine', function () {
 

--- a/packages/tests/src/transcription/twelvelabs/twelvelabs-transcriber.spec.ts
+++ b/packages/tests/src/transcription/twelvelabs/twelvelabs-transcriber.spec.ts
@@ -1,0 +1,96 @@
+/* oxlint-disable @typescript-eslint/no-unused-expressions */
+import { buildAbsoluteFixturePath } from '@peertube/peertube-node-utils'
+import { TranscriptFile, TranscriptionModel, TwelveLabsTranscriber } from '@peertube/peertube-transcription'
+import { createConsoleLogger } from '@tests/shared/common.js'
+import { expect } from 'chai'
+import { ensureDir, remove } from 'fs-extra/esm'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+describe('TwelveLabs Pegasus transcriber', function () {
+  const tmpDirectory = join(tmpdir(), 'peertube-transcription')
+  const transcriptDirectory = join(tmpDirectory, 'transcriber', 'twelvelabs')
+  const shortVideoPath = buildAbsoluteFixturePath('transcription/videos/the_last_man_on_earth.mp4')
+
+  const transcriber = new TwelveLabsTranscriber({
+    engine: {
+      name: 'twelvelabs',
+      type: 'api',
+      supportedModelFormats: [],
+      languageDetection: true,
+      version: 'pegasus1.5'
+    },
+    logger: createConsoleLogger()
+  })
+
+  before(async function () {
+    await ensureDir(transcriptDirectory)
+  })
+
+  // No-network unit test: the engine must refuse the unsupported srt/txt formats
+  it('Should reject unsupported transcript formats', async function () {
+    let errored = false
+
+    try {
+      await transcriber.transcribe({
+        mediaFilePath: shortVideoPath,
+        model: new TranscriptionModel('pegasus1.5'),
+        format: 'srt',
+        transcriptDirectory
+      })
+    } catch (err) {
+      errored = true
+      expect(err.message).to.contain('vtt')
+    }
+
+    expect(errored).to.be.true
+  })
+
+  // No-network unit test: without an API key the engine must fail fast with a clear message
+  it('Should require the TWELVELABS_API_KEY environment variable', async function () {
+    const previous = process.env.TWELVELABS_API_KEY
+    delete process.env.TWELVELABS_API_KEY
+
+    let errored = false
+    try {
+      await transcriber.transcribe({
+        mediaFilePath: shortVideoPath,
+        model: new TranscriptionModel('pegasus1.5'),
+        format: 'vtt',
+        transcriptDirectory
+      })
+    } catch (err) {
+      errored = true
+      expect(err.message).to.contain('TWELVELABS_API_KEY')
+    } finally {
+      if (previous) process.env.TWELVELABS_API_KEY = previous
+    }
+
+    expect(errored).to.be.true
+  })
+
+  // Integration smoke test, only runs when a real API key is provided
+  it('Should transcribe a video to WebVTT using Pegasus', async function () {
+    if (!process.env.TWELVELABS_API_KEY) this.skip()
+
+    this.timeout(10 * 60 * 1000)
+
+    const transcript = await transcriber.transcribe({
+      mediaFilePath: shortVideoPath,
+      model: new TranscriptionModel('pegasus1.5'),
+      format: 'vtt',
+      transcriptDirectory,
+      language: 'en'
+    })
+
+    expect(transcript).to.be.instanceOf(TranscriptFile)
+    expect(transcript.format).to.equal('vtt')
+
+    const content = String(await transcript.read())
+    expect(content).to.contain('WEBVTT')
+  })
+
+  after(async function () {
+    await remove(transcriptDirectory)
+  })
+})

--- a/packages/transcription/src/index.ts
+++ b/packages/transcription/src/index.ts
@@ -1,4 +1,5 @@
 import { TranscriberFactory } from './transcriber-factory.js'
+import { twelvelabsEngines } from './twelvelabs/index.js'
 import { engines } from './whisper/index.js'
 
 export * from './abstract-transcriber.js'
@@ -8,5 +9,6 @@ export * from './transcription-engine.js'
 export * from './transcription-model.js'
 export * from './transcription-run.js'
 export * from './whisper/index.js'
+export * from './twelvelabs/index.js'
 
-export const transcriberFactory = new TranscriberFactory(engines)
+export const transcriberFactory = new TranscriberFactory([ ...engines, ...twelvelabsEngines ])

--- a/packages/transcription/src/transcriber-factory.ts
+++ b/packages/transcription/src/transcriber-factory.ts
@@ -1,5 +1,6 @@
 import { SimpleLogger } from '@peertube/peertube-models'
 import { TranscriptionEngine, TranscriptionEngineName } from './transcription-engine.js'
+import { TwelveLabsTranscriber } from './twelvelabs/index.js'
 import { Ctranslate2Transcriber, OpenaiTranscriber } from './whisper/index.js'
 
 export class TranscriberFactory {
@@ -30,6 +31,9 @@ export class TranscriberFactory {
 
       case 'whisper-ctranslate2':
         return new Ctranslate2Transcriber(transcriberArgs)
+
+      case 'twelvelabs':
+        return new TwelveLabsTranscriber(transcriberArgs)
 
       default:
         throw new Error(`Unimplemented engine ${engineName}`)

--- a/packages/transcription/src/transcription-engine.ts
+++ b/packages/transcription/src/transcription-engine.ts
@@ -1,13 +1,18 @@
 import { ModelFormat } from './transcription-model.js'
 
-export type TranscriptionEngineName = 'openai-whisper' | 'whisper-ctranslate2'
+export type TranscriptionEngineName = 'openai-whisper' | 'whisper-ctranslate2' | 'twelvelabs'
 
 export interface TranscriptionEngine {
   name: TranscriptionEngineName
   description?: string
   language?: string
-  type: 'binary'
-  command: string
+
+  // 'binary' engines run a local command, 'api' engines call a remote provider
+  type: 'binary' | 'api'
+
+  // Only set for 'binary' engines
+  command?: string
+
   version: string
   license?: string
   forgeURL?: string

--- a/packages/transcription/src/twelvelabs/engines.ts
+++ b/packages/transcription/src/twelvelabs/engines.ts
@@ -1,0 +1,14 @@
+import { TranscriptionEngine } from '../transcription-engine.js'
+
+export const twelvelabsEngines: TranscriptionEngine[] = [
+  {
+    name: 'twelvelabs',
+    description: 'Remote transcription using the TwelveLabs Pegasus video understanding model',
+    type: 'api',
+    forgeURL: 'https://github.com/twelvelabs-io/twelvelabs-js',
+    license: 'Proprietary',
+    supportedModelFormats: [],
+    languageDetection: true,
+    version: 'pegasus1.5'
+  }
+]

--- a/packages/transcription/src/twelvelabs/index.ts
+++ b/packages/transcription/src/twelvelabs/index.ts
@@ -1,0 +1,2 @@
+export * from './engines.js'
+export * from './twelvelabs-transcriber.js'

--- a/packages/transcription/src/twelvelabs/twelvelabs-transcriber.ts
+++ b/packages/transcription/src/twelvelabs/twelvelabs-transcriber.ts
@@ -1,0 +1,154 @@
+import { buildSUUID } from '@peertube/peertube-node-utils'
+import { join, parse } from 'node:path'
+import { AbstractTranscriber, TranscribeArgs } from '../abstract-transcriber.js'
+import { TranscriptFile } from '../transcript-file.js'
+import { TranscriptionModel } from '../transcription-model.js'
+
+// Pegasus generates text from the audio/video content. We constrain it to emit a valid WebVTT
+// transcript so PeerTube can store the result exactly like the output of a local Whisper engine.
+const VTT_PROMPT = [
+  'Transcribe the spoken audio of this video verbatim into a valid WebVTT subtitle file.',
+  'Output ONLY the WebVTT content, nothing else.',
+  'Start with the line "WEBVTT".',
+  'Split the transcript into short cues. Each cue must have a timestamp line in the format',
+  '"HH:MM:SS.mmm --> HH:MM:SS.mmm" followed by the spoken text on the next line, then a blank line.',
+  'Timestamps must reflect when the words are spoken in the video.',
+  'Do not add speaker labels, comments, styling or markdown code fences.'
+].join(' ')
+
+/**
+ * Remote transcriber backed by TwelveLabs Pegasus (https://twelvelabs.io).
+ *
+ * Unlike the Whisper engines, this engine does not run a local binary: it uploads the media file
+ * to the TwelveLabs platform and asks the Pegasus video-understanding model to produce a WebVTT
+ * transcript. It is fully opt-in and only used when `video_transcription.engine` is set to
+ * `twelvelabs`.
+ *
+ * The API key is read from the `TWELVELABS_API_KEY` environment variable so the secret never has
+ * to live in PeerTube's configuration files.
+ */
+export class TwelveLabsTranscriber extends AbstractTranscriber {
+
+  // The TwelveLabs engine handles every model server-side, so it does not depend on a local model file
+  supports (_model: TranscriptionModel) {
+    return true
+  }
+
+  async transcribe ({
+    mediaFilePath,
+    language,
+    format,
+    transcriptDirectory,
+    runId = buildSUUID(),
+    signal
+  }: TranscribeArgs): Promise<TranscriptFile> {
+    if (format !== 'vtt') {
+      throw new Error(`The "twelvelabs" transcription engine only supports the "vtt" format (received "${format}").`)
+    }
+
+    const client = await this.buildClient()
+
+    this.createRun(runId)
+    this.startRun()
+
+    try {
+      this.logger.debug(`Uploading ${mediaFilePath} to TwelveLabs`, { runId })
+      const { assetId } = await client.multipartUpload.uploadFile(mediaFilePath, { fileType: 'video' })
+
+      this.logger.debug(`Creating TwelveLabs Pegasus analysis task for asset ${assetId}`, { runId })
+      const { taskId } = await client.analyzeAsync.tasks.create({
+        modelName: 'pegasus1.5',
+        video: { type: 'asset_id', assetId },
+        prompt: VTT_PROMPT,
+        temperature: 0
+      })
+
+      const vtt = await this.waitForTranscript(client, taskId, signal)
+
+      const outputPath = join(transcriptDirectory, `${parse(mediaFilePath).name}.vtt`)
+
+      return TranscriptFile.write({
+        path: outputPath,
+        content: this.sanitizeVTT(vtt),
+        language: language || 'en',
+        format: 'vtt'
+      })
+    } finally {
+      this.stopRun()
+    }
+  }
+
+  // The platform installs/hosts the model, nothing to install locally
+  install () {
+    return Promise.resolve()
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private async waitForTranscript (client: TwelveLabsClient, taskId: string, signal?: AbortSignal) {
+    // Poll until the asynchronous analysis task completes
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (signal?.aborted) throw new Error('TwelveLabs transcription aborted')
+
+      const task = await client.analyzeAsync.tasks.retrieve(taskId)
+
+      if (task.status === 'ready') {
+        const data = task.result?.data
+        if (!data) throw new Error(`TwelveLabs task ${taskId} is ready but returned no data`)
+
+        return data
+      }
+
+      if (task.status === 'failed') {
+        throw new Error(`TwelveLabs transcription task ${taskId} failed: ${task.error?.message || 'unknown error'}`)
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 5000))
+    }
+  }
+
+  // Pegasus is instructed to return raw WebVTT, but defensively strip markdown code fences if present
+  private sanitizeVTT (content: string) {
+    const trimmed = content.trim().replace(/^```[a-z]*\n?/i, '').replace(/```$/, '').trim()
+
+    return trimmed.startsWith('WEBVTT')
+      ? trimmed
+      : `WEBVTT\n\n${trimmed}`
+  }
+
+  private async buildClient (): Promise<TwelveLabsClient> {
+    const apiKey = process.env.TWELVELABS_API_KEY
+    if (!apiKey) {
+      throw new Error('The "twelvelabs" transcription engine requires the TWELVELABS_API_KEY environment variable to be set.')
+    }
+
+    // Lazy import so PeerTube does not need the optional dependency unless this engine is used
+    const { TwelveLabs } = await import('twelvelabs-js')
+
+    return new TwelveLabs({ apiKey }) as unknown as TwelveLabsClient
+  }
+}
+
+// Minimal structural type of the parts of the TwelveLabs SDK we use, so the optional dependency
+// does not have to be resolved at type-check time.
+interface TwelveLabsClient {
+  multipartUpload: {
+    uploadFile (filePath: string, options?: { fileType?: string }): Promise<{ assetId: string }>
+  }
+  analyzeAsync: {
+    tasks: {
+      create (request: {
+        modelName: string
+        video: { type: 'asset_id', assetId: string }
+        prompt: string
+        temperature?: number
+      }): Promise<{ taskId: string }>
+      retrieve (taskId: string): Promise<{
+        status: string
+        result?: { data?: string }
+        error?: { message?: string }
+      }>
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+      twelvelabs-js:
+        specifier: ^1.2.8
+        version: 1.2.8
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
@@ -7028,6 +7031,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@4.1.0:
+    resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
+    engines: {node: '>= 18'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -7035,6 +7042,10 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  formdata-node@6.0.3:
+    resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
+    engines: {node: '>= 18'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -8888,6 +8899,15 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -11020,6 +11040,9 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -11121,6 +11144,9 @@ packages:
   tv4@1.3.0:
     resolution: {integrity: sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==}
     engines: {node: '>= 0.8.0'}
+
+  twelvelabs-js@1.2.8:
+    resolution: {integrity: sha512-LFOIp0zUA1YmOGW2Q8ugav81ln0XTsyPpLki4iCGiJFfsnWx9by47FUbLf2g08EfNwZp8n0G44cTtqjPGn5mSw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -11374,6 +11400,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -11675,6 +11704,9 @@ packages:
   webfinger.js@3.0.4:
     resolution: {integrity: sha512-5c15N1n4qCm/jGJjUt32mBdPVlSugLbAztIDNBpuDfukGz2E9NhmXPfLikayn2p3kcgEZsI/UOdOwVpxOr8qJA==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -11702,6 +11734,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -18943,6 +18978,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@4.1.0: {}
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -18958,6 +18995,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  formdata-node@6.0.3: {}
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -21010,6 +21049,10 @@ snapshots:
       semver: 6.3.1
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -23714,6 +23757,8 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tr46@0.0.3: {}
+
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -23827,6 +23872,18 @@ snapshots:
       safe-buffer: 5.2.1
 
   tv4@1.3.0: {}
+
+  twelvelabs-js@1.2.8:
+    dependencies:
+      form-data: 4.0.6
+      form-data-encoder: 4.1.0
+      formdata-node: 6.0.3
+      node-fetch: 2.7.0
+      qs: 6.15.2
+      readable-stream: 4.7.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - encoding
 
   type-check@0.4.0:
     dependencies:
@@ -24026,6 +24083,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-join@4.0.1: {}
 
   url-parse@1.5.10:
     dependencies:
@@ -24363,6 +24422,8 @@ snapshots:
 
   webfinger.js@3.0.4: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -24432,6 +24493,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Description

This PR adds an opt-in **TwelveLabs Pegasus** transcription engine to `@peertube/peertube-transcription`, alongside the existing local Whisper engines.

PeerTube can already auto-transcribe videos with `openai-whisper` / `whisper-ctranslate2`, but those require running a local model (and ideally a GPU). This adds a remote alternative for admins who'd rather offload transcription: when `video_transcription.engine` is set to `twelvelabs`, PeerTube uploads the extracted audio/video to the TwelveLabs platform and asks the Pegasus video-understanding model to return a WebVTT transcript, which is stored exactly like Whisper output. No model download or local inference needed.

What it adds:
- A new `'api'` engine type (the existing ones are `'binary'`), and a `TwelveLabsTranscriber` implementing the same `AbstractTranscriber` contract (`transcribe()` → `TranscriptFile`, no-op `install()`).
- Registration in the engine list + `TranscriberFactory`, so it's selected the same way as the other engines.
- Config docs in `default.yaml` / `production.yaml.example` (regenerated `config-schema.json`).
- The `twelvelabs-js` SDK dependency.

**Opt-in / non-breaking:** the default engine is unchanged (`whisper-ctranslate2`). Nothing changes unless an admin explicitly sets `engine: 'twelvelabs'`. The API key is read from the `TWELVELABS_API_KEY` environment variable so the secret never lives in PeerTube's config files; if it's missing the engine fails fast with a clear message.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

> Note: the contributing guide suggests discussing features in an issue first. I'm opening this directly as a concrete, tested proposal — happy to move the discussion to an issue or adjust the approach (config plumbing for the key, format handling, etc.) based on maintainer preference.

## Related issues

None yet — opening as a proposal.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite

Added `packages/tests/src/transcription/twelvelabs/twelvelabs-transcriber.spec.ts`:
- No-network unit tests: unsupported-format rejection and the `TWELVELABS_API_KEY` guard (run in CI without a key).
- An integration smoke test that's skipped unless `TWELVELABS_API_KEY` is set.

Locally:
- `tsc -b packages/transcription` builds clean.
- `oxlint` passes on the changed files.
- The factory + unit specs pass (smoke test pending without a key).
- The integration smoke test passes end-to-end against the real API: it uploaded the `the_last_man_on_earth.mp4` fixture, ran Pegasus 1.5, and got back a valid `WEBVTT` transcript in ~14s.
