### PR TITLE
Add ability to disable video embed

### DIFF
--- a/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/common/video-edit.model.ts
@@ -14,6 +14,7 @@ import {
   VideoDetails,
   VideoEmbedPrivacy,
   VideoEmbedPrivacyPolicy,
+  VideoEmbedPrivacyPolicyType,
   VideoEmbedPrivacyUpdate,
   VideoImportCreate,
   VideoPrivacy,
@@ -81,7 +82,7 @@ type StudioForm = {
 type PlayerSettingsForm = PlayerVideoSettingsUpdate
 
 type EmbedPrivacyForm = {
-  videoPrivacyEmbedEnableAllowlist?: boolean
+  videoPrivacyEmbedPolicy?: VideoEmbedPrivacyPolicyType
   videoPrivacyEmbedAllowlistDomains?: string
 }
 
@@ -960,24 +961,24 @@ export class VideoEdit {
 
   loadFromEmbedPrivacyForm (value: EmbedPrivacyForm) {
     this.embedPrivacy = {
-      policy: value.videoPrivacyEmbedEnableAllowlist
-        ? VideoEmbedPrivacyPolicy.ALLOWLIST
-        : VideoEmbedPrivacyPolicy.ALL_ALLOWED,
+      policy: value.videoPrivacyEmbedPolicy ?? VideoEmbedPrivacyPolicy.ALL_ALLOWED,
 
-      domains: splitAndGetNotEmpty(value.videoPrivacyEmbedAllowlistDomains)
+      domains: value.videoPrivacyEmbedPolicy === VideoEmbedPrivacyPolicy.ALLOWLIST
+        ? splitAndGetNotEmpty(value.videoPrivacyEmbedAllowlistDomains)
+        : []
     }
   }
 
   toEmbedPrivacyFormPatch (): Required<EmbedPrivacyForm> {
     if (!this.embedPrivacy) {
       return {
-        videoPrivacyEmbedEnableAllowlist: false,
+        videoPrivacyEmbedPolicy: VideoEmbedPrivacyPolicy.ALL_ALLOWED,
         videoPrivacyEmbedAllowlistDomains: ''
       }
     }
 
     return {
-      videoPrivacyEmbedEnableAllowlist: this.embedPrivacy.policy === VideoEmbedPrivacyPolicy.ALLOWLIST,
+      videoPrivacyEmbedPolicy: this.embedPrivacy.policy,
       videoPrivacyEmbedAllowlistDomains: this.embedPrivacy.domains.join('\n')
     }
   }

--- a/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.html
+++ b/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.html
@@ -49,39 +49,38 @@
 
     <div>
       <div class="form-group">
-        <my-peertube-checkbox inputName="videoPrivacyEmbedEnableAllowlist" formControlName="videoPrivacyEmbedEnableAllowlist">
-          <ng-template ptTemplate="label">
-            <ng-container i18n>Restrict embed to the following domains</ng-container>
-          </ng-template>
+        <my-select-radio
+          i18n-label label="Embed" [items]="embedPrivacyPolicies" inputId="videoPrivacyEmbedPolicy"
+          formControlName="videoPrivacyEmbedPolicy"
+        ></my-select-radio>
+      </div>
 
-          <ng-container ngProjectAs="extra">
-            <div class="form-group">
-              <label i18n for="videoPrivacyEmbedAllowlistDomains">Allowed domains</label>
-              <div class="form-group-description">1 domain (without "https://") per line</div>
+      @if (form.value.videoPrivacyEmbedPolicy === VideoEmbedPrivacyPolicy.ALLOWLIST) {
+        <div class="form-group">
+          <label i18n for="videoPrivacyEmbedAllowlistDomains">Allowed domains</label>
+          <div class="form-group-description">1 domain (without "https://") per line</div>
 
-              <textarea
-                placeholder="example.com"
-                formControlName="videoPrivacyEmbedAllowlistDomains"
-                type="text"
-                id="videoPrivacyEmbedAllowlistDomains"
-                name="videoPrivacyEmbedAllowlistDomains"
-                class="form-control"
-                [ngClass]="{ 'input-error': formErrors['videoPrivacyEmbedAllowlistDomains'] }"
-              ></textarea>
+          <textarea
+            placeholder="example.com"
+            formControlName="videoPrivacyEmbedAllowlistDomains"
+            type="text"
+            id="videoPrivacyEmbedAllowlistDomains"
+            name="videoPrivacyEmbedAllowlistDomains"
+            class="form-control"
+            [ngClass]="{ 'input-error': formErrors['videoPrivacyEmbedAllowlistDomains'] }"
+          ></textarea>
 
-              @if (formErrors.videoPrivacyEmbedAllowlistDomains) {
-                <div class="form-error" role="alert">
-                  {{ formErrors.videoPrivacyEmbedAllowlistDomains }}
+          @if (formErrors.videoPrivacyEmbedAllowlistDomains) {
+            <div class="form-error" role="alert">
+              {{ formErrors.videoPrivacyEmbedAllowlistDomains }}
 
-                  @if (form.controls['videoPrivacyEmbedAllowlistDomains'].errors.validHosts) {
-                    <div>{{ form.controls['videoPrivacyEmbedAllowlistDomains'].errors.validHosts.value }}</div>
-                  }
-                </div>
+              @if (form.controls['videoPrivacyEmbedAllowlistDomains'].errors.validHosts) {
+                <div>{{ form.controls['videoPrivacyEmbedAllowlistDomains'].errors.validHosts.value }}</div>
               }
             </div>
-          </ng-container>
-        </my-peertube-checkbox>
-      </div>
+          }
+        </div>
+      }
     </div>
   </div>
 </form>

--- a/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.ts
+++ b/client/src/app/+videos-publish-manage/shared-manage/moderation/video-moderation.component.ts
@@ -6,7 +6,7 @@ import { ServerService } from '@app/core'
 import { BuildFormArgument } from '@app/shared/form-validators/form-validator.model'
 import { VIDEO_NSFW_SUMMARY_VALIDATOR } from '@app/shared/form-validators/video-validators'
 import { FormReactiveErrors, FormReactiveService, FormReactiveMessages } from '@app/shared/shared-forms/form-reactive.service'
-import { HTMLServerConfig, VideoCommentPolicyType, ConstantLabel } from '@peertube/peertube-models'
+import { HTMLServerConfig, VideoCommentPolicyType, VideoEmbedPrivacyPolicy, VideoEmbedPrivacyPolicyType, ConstantLabel } from '@peertube/peertube-models'
 import debug from 'debug'
 import { Subscription } from 'rxjs'
 import { PeertubeCheckboxComponent } from '../../../shared/shared-forms/peertube-checkbox.component'
@@ -27,7 +27,7 @@ type Form = {
 
   commentPolicies: FormControl<VideoCommentPolicyType>
 
-  videoPrivacyEmbedEnableAllowlist: FormControl<boolean>
+  videoPrivacyEmbedPolicy: FormControl<VideoEmbedPrivacyPolicyType>
   videoPrivacyEmbedAllowlistDomains: FormControl<string>
 }
 
@@ -50,6 +50,8 @@ type Form = {
   ]
 })
 export class VideoModerationComponent implements OnInit, OnDestroy {
+  protected readonly VideoEmbedPrivacyPolicy = VideoEmbedPrivacyPolicy
+
   private formReactiveService = inject(FormReactiveService)
   private serverService = inject(ServerService)
   private manageController = inject(VideoManageController)
@@ -59,6 +61,7 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
   validationMessages: FormReactiveMessages = {}
 
   commentPolicies: ConstantLabel<VideoCommentPolicyType>[] = []
+  embedPrivacyPolicies: ConstantLabel<VideoEmbedPrivacyPolicyType>[] = []
   serverConfig: HTMLServerConfig
 
   private updatedSub: Subscription
@@ -70,6 +73,9 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
 
     this.serverService.getCommentPolicies()
       .subscribe(res => this.commentPolicies = res)
+
+    this.serverService.getEmbedPrivacyPolicies()
+      .subscribe(res => this.embedPrivacyPolicies = res)
   }
 
   ngOnDestroy () {
@@ -86,7 +92,7 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
       nsfwFlagViolent: null,
       nsfwFlagSex: null,
       nsfwSummary: VIDEO_NSFW_SUMMARY_VALIDATOR,
-      videoPrivacyEmbedEnableAllowlist: null,
+      videoPrivacyEmbedPolicy: null,
       videoPrivacyEmbedAllowlistDomains: UNIQUE_HOSTS_VALIDATOR
     }
 
@@ -117,7 +123,7 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
     })
 
     this.updateNSFWControls(videoEdit.toCommonFormPatch().nsfw)
-    this.updateAllowedDomainsControls(videoEdit.toEmbedPrivacyFormPatch().videoPrivacyEmbedEnableAllowlist)
+    this.updateAllowedDomainsControls(videoEdit.toEmbedPrivacyFormPatch().videoPrivacyEmbedPolicy)
 
     this.trackControlsChange()
   }
@@ -127,9 +133,9 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
       .valueChanges
       .subscribe(newNSFW => this.updateNSFWControls(newNSFW))
 
-    this.form.controls.videoPrivacyEmbedEnableAllowlist
+    this.form.controls.videoPrivacyEmbedPolicy
       .valueChanges
-      .subscribe(newEnableAllowlist => this.updateAllowedDomainsControls(newEnableAllowlist))
+      .subscribe(newPolicy => this.updateAllowedDomainsControls(newPolicy))
   }
 
   private updateNSFWControls (nsfw: boolean) {
@@ -152,12 +158,12 @@ export class VideoModerationComponent implements OnInit, OnDestroy {
     }
   }
 
-  private updateAllowedDomainsControls (enableAllowlist: boolean) {
+  private updateAllowedDomainsControls (policy: VideoEmbedPrivacyPolicyType) {
     const controls = [
       this.form.controls.videoPrivacyEmbedAllowlistDomains
     ]
 
-    if (!enableAllowlist) {
+    if (policy !== VideoEmbedPrivacyPolicy.ALLOWLIST) {
       for (const control of controls) {
         control.disable()
       }

--- a/client/src/app/core/server/server.service.ts
+++ b/client/src/app/core/server/server.service.ts
@@ -7,6 +7,8 @@ import {
   ServerConfig,
   ServerStats,
   VideoCommentPolicy,
+  VideoEmbedPrivacyPolicy,
+  VideoEmbedPrivacyPolicyType,
   ConstantLabel,
   VideoLicenceType,
   VideoPlaylistPrivacyType,
@@ -129,6 +131,23 @@ export class ServerService {
       {
         id: VideoCommentPolicy.REQUIRES_APPROVAL,
         label: $localize`Any new comment requires approval`
+      }
+    ])
+  }
+
+  getEmbedPrivacyPolicies (): Observable<ConstantLabel<VideoEmbedPrivacyPolicyType>[]> {
+    return of([
+      {
+        id: VideoEmbedPrivacyPolicy.ALL_ALLOWED,
+        label: $localize`Anyone can embed this video`
+      },
+      {
+        id: VideoEmbedPrivacyPolicy.ALLOWLIST,
+        label: $localize`Only allowed domains can embed this video`
+      },
+      {
+        id: VideoEmbedPrivacyPolicy.DISABLED,
+        label: $localize`Nobody can embed this video`
       }
     ])
   }

--- a/client/src/app/shared/shared-main/video/video-details.model.ts
+++ b/client/src/app/shared/shared-main/video/video-details.model.ts
@@ -75,6 +75,10 @@ export class VideoDetails extends Video implements VideoDetailsServerModel {
     return this.embedPrivacyPolicy.id !== VideoEmbedPrivacyPolicy.ALL_ALLOWED
   }
 
+  hasEmbedDisabled () {
+    return this.embedPrivacyPolicy.id === VideoEmbedPrivacyPolicy.DISABLED
+  }
+
   // Try to find the best video file to download
   // It builds an array and prioritizes web videos that play on more third-party players.
   getFilesForDownload () {

--- a/client/src/app/shared/shared-share-modal/share-video.component.html
+++ b/client/src/app/shared/shared-share-modal/share-video.component.html
@@ -19,6 +19,20 @@
     <my-alert i18n type="primary">
       This video is password protected, please note that recipients will require the corresponding password to access the content.
     </my-alert>
+  } @else if (video().hasEmbedDisabled()) {
+    <my-alert type="primary">
+      <div i18n>
+        The owner of this video disabled embedding, so it can only be shared using the direct link or the QR code.
+      </div>
+
+      <a
+        i18n
+        class="peertube-button-link secondary-button mt-3"
+        [routerLink]="[ '/videos/', 'manage', video().shortUUID, 'moderation' ]"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Update embed privacy</a>
+    </my-alert>
   } @else if (video().hasEmbedRestrictions() && isInEmbedTab()) {
     <my-alert type="primary">
       <div i18n>
@@ -65,34 +79,36 @@
       </ng-template>
     </ng-container>
 
-    <ng-container ngbNavItem="embed">
-      <a ngbNavLink i18n>Embed</a>
+    @if (!video().hasEmbedDisabled()) {
+      <ng-container ngbNavItem="embed">
+        <a ngbNavLink i18n>Embed</a>
 
-      <ng-template ngbNavContent>
-        <div class="nav-content">
-          <my-input-text
-            inputId="video-embed-url"
-            i18n-ariaLabel
-            ariaLabel="Video embed URL"
-            [value]="customizations().onlyEmbedUrl ? videoEmbedUrl : videoEmbedHTML"
-            (ngModelChange)="onUpdate()"
-            [withToggle]="false"
-            [withCopy]="true"
-            [show]="true"
-            [readonly]="true"
-          ></my-input-text>
+        <ng-template ngbNavContent>
+          <div class="nav-content">
+            <my-input-text
+              inputId="video-embed-url"
+              i18n-ariaLabel
+              ariaLabel="Video embed URL"
+              [value]="customizations().onlyEmbedUrl ? videoEmbedUrl : videoEmbedHTML"
+              (ngModelChange)="onUpdate()"
+              [withToggle]="false"
+              [withCopy]="true"
+              [show]="true"
+              [readonly]="true"
+            ></my-input-text>
 
-          @if (notSecure()) {
-            <my-alert i18n type="warning" class="mt-3">
-              The url is not secured (no HTTPS), so the embed video won't work on HTTPS websites (web browsers block non secured HTTP requests on HTTPS
-              websites).
-            </my-alert>
-          }
+            @if (notSecure()) {
+              <my-alert i18n type="warning" class="mt-3">
+                The url is not secured (no HTTPS), so the embed video won't work on HTTPS websites (web browsers block non secured HTTP requests on HTTPS
+                websites).
+              </my-alert>
+            }
 
-          <div class="embed" [innerHTML]="videoEmbedSafeHTML"></div>
-        </div>
-      </ng-template>
-    </ng-container>
+            <div class="embed" [innerHTML]="videoEmbedSafeHTML"></div>
+          </div>
+        </ng-template>
+      </ng-container>
+    }
   </div>
 
   <div [ngbNavOutlet]="nav"></div>

--- a/client/src/standalone/videos/embed.ts
+++ b/client/src/standalone/videos/embed.ts
@@ -303,7 +303,11 @@ export class PeerTubeEmbed {
     ])
 
     if (allowed !== true) {
-      throw new Error('This video is not allowed to be embedded on this domain.')
+      throw new Error(
+        video.embedPrivacyPolicy.id === VideoEmbedPrivacyPolicy.DISABLED
+          ? 'Embedding is disabled for this video.'
+          : 'This video is not allowed to be embedded on this domain.'
+      )
     }
 
     const playlist = this.playlistTracker

--- a/packages/models/src/videos/embed-privacy/video-embed-privacy-policy.enum.ts
+++ b/packages/models/src/videos/embed-privacy/video-embed-privacy-policy.enum.ts
@@ -3,7 +3,9 @@ export const VideoEmbedPrivacyPolicy = {
   ALLOWLIST: 2,
 
   // Federated server imposes restrictions on the embed
-  REMOTE_RESTRICTIONS: 3
+  REMOTE_RESTRICTIONS: 3,
+
+  DISABLED: 4
 } as const
 
 export type VideoEmbedPrivacyPolicyType = typeof VideoEmbedPrivacyPolicy[keyof typeof VideoEmbedPrivacyPolicy]

--- a/packages/tests/src/api/check-params/video-embed-privacy.ts
+++ b/packages/tests/src/api/check-params/video-embed-privacy.ts
@@ -233,12 +233,32 @@ describe('Test video embed privacy validator', function () {
       })
     })
 
+    it('Should fail with domains when disabling embed', async function () {
+      await server.videoEmbedPrivacy.update({
+        videoId: video.id,
+        policy: VideoEmbedPrivacyPolicy.DISABLED,
+        domains: [ 'example.com' ],
+        expectedStatus: HttpStatusCode.BAD_REQUEST_400
+      })
+    })
+
     it('Should succeed with correct params', async function () {
       const policy = VideoEmbedPrivacyPolicy.ALLOWLIST
       const domains = [ 'example.com' ]
 
       for (const token of [ server.accessToken, ownerAccessToken, editorAccessToken ]) {
         await server.videoEmbedPrivacy.update({ videoId: video.id, token, policy, domains })
+      }
+    })
+
+    it('Should succeed disabling embed with no domains', async function () {
+      for (const token of [ server.accessToken, ownerAccessToken, editorAccessToken ]) {
+        await server.videoEmbedPrivacy.update({
+          videoId: video.id,
+          token,
+          policy: VideoEmbedPrivacyPolicy.DISABLED,
+          domains: []
+        })
       }
     })
   })

--- a/packages/tests/src/api/videos/video-embed-privacy.ts
+++ b/packages/tests/src/api/videos/video-embed-privacy.ts
@@ -156,6 +156,53 @@ describe('Test video embed privacy', function () {
     }
   })
 
+  it('Should disable video embed', async function () {
+    await servers[0].videoEmbedPrivacy.update({
+      videoId,
+      policy: VideoEmbedPrivacyPolicy.DISABLED,
+      domains: []
+    })
+
+    const policy = { id: VideoEmbedPrivacyPolicy.DISABLED, label: 'Disabled' }
+
+    {
+      const body = await servers[0].videoEmbedPrivacy.get({ videoId })
+      expect(body).to.deep.equal({ policy, domains: [] } satisfies VideoEmbedPrivacy)
+    }
+
+    {
+      const video = await servers[0].videos.get({ id: videoId })
+      expect(video.embedPrivacyPolicy).to.deep.equal(policy)
+    }
+  })
+
+  it('Should never allow embed when disabled, even on the origin instance or for the owner', async function () {
+    // Called with the default (owner/admin) token: unlike allowlist, manage rights don't bypass a disabled policy
+    {
+      const result = await servers[0].videoEmbedPrivacy.isDomainAllowed({ videoId, domain: 'toto.example.com' })
+      expect(result).to.deep.equal({ domainAllowed: false, userBypassAllowed: false })
+    }
+
+    // The "same instance" shortcut must not bypass a disabled policy either
+    {
+      const result = await servers[0].videoEmbedPrivacy.isDomainAllowed({ videoId, domain: servers[0].host })
+      expect(result).to.deep.equal({ domainAllowed: false, userBypassAllowed: false })
+    }
+
+    // Anonymous requests are blocked too
+    {
+      const result = await servers[0].videoEmbedPrivacy.isDomainAllowed({ videoId, domain: 'toto.example.com', token: null })
+      expect(result).to.deep.equal({ domainAllowed: false, userBypassAllowed: false })
+    }
+  })
+
+  it('Should have federated the disabled video embed policy', async function () {
+    await waitJobs(servers)
+
+    const video = await servers[1].videos.get({ id: videoId })
+    expect(video.embedPrivacyPolicy.id).to.equal(VideoEmbedPrivacyPolicy.REMOTE_RESTRICTIONS)
+  })
+
   after(async function () {
     await cleanupTests(servers)
   })

--- a/scripts/i18n/create-custom-files.ts
+++ b/scripts/i18n/create-custom-files.ts
@@ -143,6 +143,7 @@ Object.values(VIDEO_CATEGORIES)
     'Unavailable video',
     'Audio only',
     'Unknown',
+    'Embedding is disabled for this video.',
     'This video is not allowed to be embedded on this domain.'
   ])
   .forEach(v => {

--- a/server/core/controllers/api/videos/embed-privacy.ts
+++ b/server/core/controllers/api/videos/embed-privacy.ts
@@ -76,9 +76,11 @@ async function isVideoEmbedOnDomainAllowed (req: express.Request, res: express.R
   const video = res.locals.videoWithBlacklist
   const isOnInstance = req.query.domain === WEBSERVER.HOST
 
-  const domainAllowed = video.embedPrivacyPolicy === VideoEmbedPrivacyPolicy.ALL_ALLOWED || isOnInstance
-    ? true
-    : await VideoEmbedPrivacyDomainModel.isDomainAllowed(video.id, req.query.domain)
+  const domainAllowed = video.embedPrivacyPolicy === VideoEmbedPrivacyPolicy.DISABLED
+    ? false
+    : video.embedPrivacyPolicy === VideoEmbedPrivacyPolicy.ALL_ALLOWED || isOnInstance
+      ? true
+      : await VideoEmbedPrivacyDomainModel.isDomainAllowed(video.id, req.query.domain)
 
   const user = getAuthUser(res)
 
@@ -86,7 +88,7 @@ async function isVideoEmbedOnDomainAllowed (req: express.Request, res: express.R
     ? null
     : false
 
-  if (domainAllowed === false && user) {
+  if (domainAllowed === false && user && video.embedPrivacyPolicy !== VideoEmbedPrivacyPolicy.DISABLED) {
     userBypassAllowed = await checkCanManageVideo({
       user,
       video: await VideoModel.loadWithRights(video.id),

--- a/server/core/controllers/api/videos/embed-privacy.ts
+++ b/server/core/controllers/api/videos/embed-privacy.ts
@@ -76,11 +76,15 @@ async function isVideoEmbedOnDomainAllowed (req: express.Request, res: express.R
   const video = res.locals.videoWithBlacklist
   const isOnInstance = req.query.domain === WEBSERVER.HOST
 
-  const domainAllowed = video.embedPrivacyPolicy === VideoEmbedPrivacyPolicy.DISABLED
-    ? false
-    : video.embedPrivacyPolicy === VideoEmbedPrivacyPolicy.ALL_ALLOWED || isOnInstance
-      ? true
-      : await VideoEmbedPrivacyDomainModel.isDomainAllowed(video.id, req.query.domain)
+  let domainAllowed: boolean
+
+  if (video.embedPrivacyPolicy === VideoEmbedPrivacyPolicy.DISABLED) {
+    domainAllowed = false
+  } else if (video.embedPrivacyPolicy === VideoEmbedPrivacyPolicy.ALL_ALLOWED || isOnInstance) {
+    domainAllowed = true
+  } else {
+    domainAllowed = await VideoEmbedPrivacyDomainModel.isDomainAllowed(video.id, req.query.domain)
+  }
 
   const user = getAuthUser(res)
 

--- a/server/core/initializers/constants.ts
+++ b/server/core/initializers/constants.ts
@@ -766,7 +766,8 @@ export const VIDEO_CHANNEL_ACTIVITY_TARGETS: { [id in VideoChannelActivityTarget
 export const VIDEO_EMBED_PRIVACY_POLICIES: { [id in VideoEmbedPrivacyPolicyType]: string } = {
   [VideoEmbedPrivacyPolicy.ALL_ALLOWED]: 'All allowed',
   [VideoEmbedPrivacyPolicy.ALLOWLIST]: 'Allowlist',
-  [VideoEmbedPrivacyPolicy.REMOTE_RESTRICTIONS]: 'Remote restrictions'
+  [VideoEmbedPrivacyPolicy.REMOTE_RESTRICTIONS]: 'Remote restrictions',
+  [VideoEmbedPrivacyPolicy.DISABLED]: 'Disabled'
 }
 
 export const CHANGE_OWNERSHIP_STATES: { [id in ChangeOwnershipStateType]: string } = {

--- a/server/core/middlewares/validators/videos/video-embed-privacy.ts
+++ b/server/core/middlewares/validators/videos/video-embed-privacy.ts
@@ -69,9 +69,12 @@ export const updateVideoEmbedPrivacyValidator = [
     ) return
 
     const body: VideoEmbedPrivacyUpdate = req.body
-    if (body.policy === VideoEmbedPrivacyPolicy.ALL_ALLOWED && body.domains.length !== 0) {
+    if (
+      (body.policy === VideoEmbedPrivacyPolicy.ALL_ALLOWED || body.policy === VideoEmbedPrivacyPolicy.DISABLED) &&
+      body.domains.length !== 0
+    ) {
       return res.fail({
-        message: req.t('Domains should be empty when policy is in "all allowed" mode')
+        message: req.t('Domains should be empty when policy is in "all allowed" or "disabled" mode')
       })
     }
 

--- a/support/doc/api/openapi.yaml
+++ b/support/doc/api/openapi.yaml
@@ -14375,11 +14375,13 @@ components:
         - 1
         - 2
         - 3
+        - 4<
       description: >
         The video embed privacy level:
           - `1` All allowed: anyone can embed the video
           - `2` Allowlist: only the domains in the allowlist can embed the video
           - `3` Remote restrictions: the remote instance has restrictions on where the video can be embedded
+          - `4` Nobody can embed this video
 
     PlayerTheme:
       type: string


### PR DESCRIPTION
## Description

Video owners could only restrict embedding to an allowlist of domains, with no way to disable it entirely. This adds a `DISABLED` value to the existing `VideoEmbedPrivacyPolicy` enum (no migration needed, reuses the current allowlist infrastructure).

When set, embedding is blocked everywhere, including on the origin instance and for the video owner/editor, with no bypass. The "Embed" tab is hidden from the share modal (URL and QR code sharing stay available), and the moderation form's allowlist checkbox becomes a 3-option policy selector (anyone / allowlist / nobody).

## Related issues

Fix #7690 

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite