### PR TITLE
fix(client/embed): use correct CSS variable for big play button color

### DIFF
--- a/client/src/standalone/player/src/sass/shared/peertube-skin.scss
+++ b/client/src/standalone/player/src/sass/shared/peertube-skin.scss
@@ -8,8 +8,6 @@ body {
   --pt-player-overlay-bg: rgba(0, 0, 0, 0.6);
   --pt-player-overlay-bg-hover: rgba(255, 255, 255, 0.15);
 
-  --pt-player-big-play-background-color: rgba(0, 0, 0, 0.8);
-
   // Prevent z-index bug with Firefox PiP button
   // See:
   // * https://bugzilla.mozilla.org/show_bug.cgi?id=1742585

--- a/client/src/standalone/videos/embed.ts
+++ b/client/src/standalone/videos/embed.ts
@@ -395,7 +395,7 @@ export class PeerTubeEmbed {
     const body = document.getElementById('custom-css')
 
     if (this.playerOptionsBuilder.hasBigPlayBackgroundColor()) {
-      body.style.setProperty('--pt-player-big-play-background-color', this.playerOptionsBuilder.getBigPlayBackgroundColor())
+      body.style.setProperty('--pt-player-big-play-bg', this.playerOptionsBuilder.getBigPlayBackgroundColor())
     }
 
     if (this.playerOptionsBuilder.hasForegroundColor()) {


### PR DESCRIPTION
## Description

The `bigPlayBackgroundColor` embed URL parameter did not change the big play button's background color, even though the value was being read and applied correctly.

Root cause: `client/src/standalone/videos/embed.ts` (line 398) set the color on a CSS variable named `--pt-player-big-play-background-color`, but the player's stylesheet (`client/src/standalone/player/src/sass/shared/peertube-skin.scss`, line 56) reads a different variable via `pvar()`: `--pt-player-big-play-bg`. Since the two names never matched, the value from the URL param was applied but never actually read by anything.

This PR corrects `embed.ts` to set `--pt-player-big-play-bg` instead, matching the variable defined in `_variables.scss` and `_css-variables.scss` and actually consumed by the stylesheet.

Note: `peertube-skin.scss` (line 11) still declares a default for the now-unused `--pt-player-big-play-background-color` variable. Left untouched here to keep this PR minimal and focused — flagging in case maintainers prefer a follow-up cleanup.

## Related issues

Fixes #7731

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help

Manually verified: `?bigPlayBackgroundColor=red` on an embed URL now correctly tints the big play button, where it previously had no effect.