### PR TITLE
Fix docker timeout on stop

### DIFF
--- a/support/docker/production/Dockerfile
+++ b/support/docker/production/Dockerfile
@@ -58,5 +58,7 @@ ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 # Expose API, RTMP and RTMPS ports
 EXPOSE 9000 1935 1936
 
+STOPSIGNAL SIGINT
+
 # Run the application
 CMD [ "node", "dist/server" ]


### PR DESCRIPTION
## Description

The docker container of peertube doesn't stop properly and instead timeouts. as discussed in #7391 it is caused by the wrong signal being sent to the container. This commit changes the STOPSIGNAL in the Dockerfile.

## Related issues

#7391 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
