### PR TITLE
Add RepoCloud one-click deploy link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ See the [production guide](https://docs.joinpeertube.org/install/any-os), which 
 
 See the [community packages](https://docs.joinpeertube.org/install/unofficial), which cover various platforms (including [YunoHost](https://install-app.yunohost.org/?app=peertube) and [Docker](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/docker.md)).
 
+You can also deploy PeerTube with one click on [RepoCloud](https://repocloud.io/details/PeerTube/):
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/PeerTube/)
+
 :book: Documentation
 ----------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ See the [production guide](https://docs.joinpeertube.org/install/any-os), which 
 
 See the [community packages](https://docs.joinpeertube.org/install/unofficial), which cover various platforms (including [YunoHost](https://install-app.yunohost.org/?app=peertube) and [Docker](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/docker.md)).
 
-You can also deploy PeerTube with one click on [RepoCloud](https://repocloud.io/details/PeerTube/):
-
-[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/PeerTube/)
+You can also deploy PeerTube with one click on [RepoCloud](https://repocloud.io/details/PeerTube/).
 
 :book: Documentation
 ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a one-click deploy link to [RepoCloud](https://repocloud.io/details/PeerTube/) in the "Create your own instance" section of the README.

## Changes

- Added a single line mentioning RepoCloud as a deployment option, alongside the existing production guide, community packages, YunoHost, and Docker references

## Why

RepoCloud offers managed hosting for open-source applications. This gives users an additional one-click option to deploy their own PeerTube instance without manual server setup.

## Notes

- Text link format matches the existing style of the section (inline markdown links within paragraphs)
- No images or buttons added — consistent with the text-only format of the deployment section