### PR TITLE
Enabled 2fa for LDAP users

### DIFF
--- a/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
+++ b/client/src/app/+my-account/my-account-settings/my-account-settings.component.html
@@ -65,16 +65,14 @@
   </div>
 }
 
-@if (user.pluginAuth === null) {
-  <div class="pt-two-cols mt-5"> <!-- two factor auth grid -->
-    <div class="title-col">
-      <h2 i18n>TWO-FACTOR AUTHENTICATION</h2>
-    </div>
-    <div class="content-col">
-      <my-account-two-factor-button [user]="user"></my-account-two-factor-button>
-    </div>
+<div class="pt-two-cols mt-5"> <!-- two factor auth grid -->
+  <div class="title-col">
+    <h2 i18n>TWO-FACTOR AUTHENTICATION</h2>
   </div>
-}
+  <div class="content-col">
+    <my-account-two-factor-button [user]="user"></my-account-two-factor-button>
+  </div>
+</div>
 
 <div class="pt-two-cols mt-5">
   <div class="title-col">

--- a/client/src/app/+my-account/my-account-settings/my-account-two-factor/my-account-two-factor-button.component.ts
+++ b/client/src/app/+my-account/my-account-settings/my-account-two-factor/my-account-two-factor-button.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject, input, ChangeDetectionStrategy } from '@angular/core'
 import { AuthService, ConfirmService, Notifier, User } from '@app/core'
 import { TwoFactorService } from '@app/shared/shared-users/two-factor.service'
+import { ServerErrorCode } from '@peertube/peertube-models'
 import { ButtonComponent } from '../../../shared/shared-main/buttons/button.component'
 
 @Component({
@@ -39,7 +40,13 @@ export class MyAccountTwoFactorButtonComponent implements OnInit {
           this.notifier.success($localize`Two factor authentication disabled`)
         },
 
-        error: err => this.notifier.handleError(err)
+        error: err => {
+          if (err.body?.code === ServerErrorCode.CURRENT_PASSWORD_IS_INVALID) {
+            return this.notifier.error($localize`Please check your password and try again.`, $localize`Password not recognized`)
+          }
+
+          return this.notifier.handleError(err)
+        }
       })
   }
 }

--- a/client/src/app/+my-account/my-account-settings/my-account-two-factor/my-account-two-factor.component.ts
+++ b/client/src/app/+my-account/my-account-settings/my-account-two-factor/my-account-two-factor.component.ts
@@ -5,6 +5,8 @@ import { AuthService, Notifier, User } from '@app/core'
 import { USER_EXISTING_PASSWORD_VALIDATOR, USER_OTP_TOKEN_VALIDATOR } from '@app/shared/form-validators/user-validators'
 import { FormReactiveService } from '@app/shared/shared-forms/form-reactive.service'
 import { TwoFactorService } from '@app/shared/shared-users/two-factor.service'
+import { ServerErrorCode } from '@peertube/peertube-models'
+import { PeerTubeHTTPError } from '@root-helpers/errors'
 import { QRCodeComponent } from 'angularx-qrcode'
 import { InputTextComponent } from '../../../shared/shared-forms/input-text.component'
 
@@ -62,7 +64,7 @@ export class MyAccountTwoFactorComponent implements OnInit {
         this.step = 'confirm'
       },
 
-      error: err => this.notifier.handleError(err)
+      error: err => this.handleRequestError(err)
     })
   }
 
@@ -91,6 +93,14 @@ export class MyAccountTwoFactorComponent implements OnInit {
 
     this.formPassword = form
     this.formErrorsPassword = formErrors
+  }
+
+  private handleRequestError (err: PeerTubeHTTPError) {
+    if (err.body?.code === ServerErrorCode.CURRENT_PASSWORD_IS_INVALID) {
+      return this.notifier.error($localize`Please check your password and try again.`, $localize`Password not recognized`)
+    }
+
+    return this.notifier.handleError(err)
   }
 
   private buildOTPForm () {

--- a/packages/tests/src/external-plugins/auth-ldap.ts
+++ b/packages/tests/src/external-plugins/auth-ldap.ts
@@ -1,13 +1,14 @@
 /* oxlint-disable @typescript-eslint/no-unused-expressions,@typescript-eslint/require-await */
 
 import { HttpStatusCode, UserRole } from '@peertube/peertube-models'
-import { cleanupTests, createSingleServer, PeerTubeServer, setAccessTokensToServers } from '@peertube/peertube-server-commands'
+import { cleanupTests, createSingleServer, PeerTubeServer, setAccessTokensToServers, TwoFactorCommand } from '@peertube/peertube-server-commands'
 import { expect } from 'chai'
 
 describe('Official plugin auth-ldap', function () {
   let server: PeerTubeServer
   let accessToken: string
   let userId: number
+  let otpSecret: string
 
   const pluginSettings = {
     'bind-credentials': 'GoodNewsEveryone',
@@ -75,6 +76,45 @@ describe('Official plugin auth-ldap', function () {
     userId = body.id
   })
 
+  it('Should enable two factor authentication with the LDAP password', async function () {
+    await server.twoFactor.request({
+      userId,
+      token: accessToken,
+      currentPassword: 'incorrect password',
+      expectedStatus: HttpStatusCode.FORBIDDEN_403
+    })
+
+    const { otpRequest } = await server.twoFactor.request({ userId, token: accessToken, currentPassword: 'fry' })
+    otpSecret = otpRequest.secret
+
+    await server.twoFactor.confirmRequest({
+      userId,
+      token: accessToken,
+      requestToken: otpRequest.requestToken,
+      otpToken: TwoFactorCommand.buildOTP({ secret: otpSecret }).generate()
+    })
+  })
+
+  it('Should require a valid OTP token when logging in with LDAP', async function () {
+    await server.login.login({
+      user: { username: 'fry', password: 'fry' },
+      expectedStatus: HttpStatusCode.UNAUTHORIZED_401
+    })
+
+    await server.login.login({
+      user: { username: 'fry', password: 'fry' },
+      otpToken: '123456',
+      expectedStatus: HttpStatusCode.BAD_REQUEST_400
+    })
+
+    const { access_token } = await server.login.login({
+      user: { username: 'fry', password: 'fry' },
+      otpToken: TwoFactorCommand.buildOTP({ secret: otpSecret }).generate()
+    })
+
+    accessToken = access_token
+  })
+
   it('Should upload a video', async function () {
     await server.videos.upload({ token: accessToken, attributes: { name: 'my super video' } })
   })
@@ -90,6 +130,22 @@ describe('Official plugin auth-ldap', function () {
 
   it('Should be able to login if the user is unbanned', async function () {
     await server.users.unbanUser({ userId })
+
+    await server.login.login({
+      user: { username: 'fry@planetexpress.com', password: 'fry' },
+      otpToken: TwoFactorCommand.buildOTP({ secret: otpSecret }).generate()
+    })
+  })
+
+  it('Should disable two factor authentication with the LDAP password', async function () {
+    await server.twoFactor.disable({
+      userId,
+      token: accessToken,
+      currentPassword: 'incorrect password',
+      expectedStatus: HttpStatusCode.FORBIDDEN_403
+    })
+
+    await server.twoFactor.disable({ userId, token: accessToken, currentPassword: 'fry' })
 
     await server.login.login({ user: { username: 'fry@planetexpress.com', password: 'fry' } })
   })

--- a/server/core/lib/auth/external-auth.ts
+++ b/server/core/lib/auth/external-auth.ts
@@ -15,6 +15,7 @@ import { generateRandomString } from '@server/helpers/utils.js'
 import { PLUGIN_EXTERNAL_AUTH_TOKEN_LIFETIME } from '@server/initializers/constants.js'
 import { PluginManager } from '@server/lib/plugins/plugin-manager.js'
 import { OAuthTokenModel } from '@server/models/oauth/oauth-token.js'
+import { MUser } from '@server/types/models/user/user.js'
 import {
   RegisterServerAuthenticatedResult,
   RegisterServerAuthPassOptions,
@@ -174,6 +175,26 @@ async function getBypassFromPasswordGrant (username: string, password: string): 
   return undefined
 }
 
+export async function isExternalUserPasswordValid (options: { user: MUser, password: string }) {
+  const { user, password } = options
+
+  const plugin = PluginManager.Instance.getIdAndPassAuths().find(p => p.npmName === user.pluginAuth)
+  if (!plugin) return false
+
+  for (const auth of plugin.idAndPassAuths) {
+    try {
+      const result = await auth.login({ id: user.email, password })
+      if (!result || !isAuthResultValid(plugin.npmName, auth.authName, result)) continue
+
+      if (doesExternalAuthResultMatchUser(user, result)) return true
+    } catch (err) {
+      logger.warn('Cannot reauthenticate user %s with auth method %s of plugin %s.', user.id, auth.authName, plugin.npmName, { err })
+    }
+  }
+
+  return false
+}
+
 function consumeBypassFromExternalAuth (username: string, externalAuthToken: string): BypassLogin {
   const obj = authBypassTokens.get(externalAuthToken)
   if (!obj) throw new Error('Cannot authenticate user with unknown bypass token')
@@ -269,6 +290,12 @@ function buildUserResult (pluginResult: RegisterServerAuthenticatedResult) {
 
     externalId: pluginResult.externalId || undefined
   }
+}
+
+function doesExternalAuthResultMatchUser (user: MUser, result: RegisterServerAuthenticatedResult) {
+  if (user.pluginAuthExternalId) return result.externalId === user.pluginAuthExternalId
+
+  return result.email.toLowerCase() === user.email.toLowerCase()
 }
 
 // ---------------------------------------------------------------------------

--- a/server/core/lib/auth/oauth-user.ts
+++ b/server/core/lib/auth/oauth-user.ts
@@ -51,7 +51,10 @@ export async function getUserOrThrow (options: {
 
     // Continue the password process if handleGetUserBypass returns undefined,
     // which means the user does not belong to the plugin and we should go through a regular login process
-    if (user) return user
+    if (user) {
+      await checkTwoFactorOrThrow(user, oauthHeaders, req)
+      return user
+    }
   }
 
   logger.debug('Getting User (username/email: ' + usernameOrEmail + ', password: ******).')
@@ -104,24 +107,28 @@ export async function getUserOrThrow (options: {
     throw new EmailNotVerifiedError(req.t('User email is not verified.'))
   }
 
-  if (user.otpSecret) {
+  await checkTwoFactorOrThrow(user, oauthHeaders, req)
+
+  await Redis.Instance.deleteLoginFailures(user.id)
+
+  return user
+}
+
+async function checkTwoFactorOrThrow (user: MUserDefault, oauthHeaders: Record<string, string>, req: express.Request) {
+  if (!user.otpSecret) return
+
     if (!oauthHeaders[OTP.HEADER_NAME]) {
       throw new MissingTwoFactorError(req.t('Missing two factor header'))
     }
 
-    if (await isOTPValid({ encryptedSecret: user.otpSecret, token: oauthHeaders[OTP.HEADER_NAME] }) !== true) {
+    if (await isOTPValid({ encryptedSecret: user.otpSecret, token: oauthHeaders[OTP.HEADER_NAME] }) === true) return
+
       if (CONFIG.RATES_LIMIT.LOGIN_LOCKOUT.ENABLED) {
         const failures = await Redis.Instance.addLoginFailure(user.id, req.ip)
         await notifyAccountLockedIfNeeded(user, failures, req.ip)
       }
 
       throw new InvalidTwoFactorError(req.t('Invalid two factor header'))
-    }
-  }
-
-  await Redis.Instance.deleteLoginFailures(user.id)
-
-  return user
 }
 
 // This is the exact failure that just crossed the threshold and locked the account: notify its owner once per lock

--- a/server/core/middlewares/validators/users/users.ts
+++ b/server/core/middlewares/validators/users/users.ts
@@ -2,6 +2,7 @@ import { forceNumber } from '@peertube/peertube-core-utils'
 import { HttpStatusCode, ServerErrorCode, UserRole, UserRoleType, UserUpdateMe } from '@peertube/peertube-models'
 import { isStringArray } from '@server/helpers/custom-validators/search.js'
 import { isNSFWFlagsValid } from '@server/helpers/custom-validators/videos.js'
+import { isExternalUserPasswordValid } from '@server/lib/auth/external-auth.js'
 import { loadReservedActorName } from '@server/lib/local-actor.js'
 import { Hooks } from '@server/lib/plugins/hooks.js'
 import { MUser } from '@server/types/models/user/user.js'
@@ -320,7 +321,7 @@ export const usersUpdateMeValidator = [
       if (await user.isPasswordMatch(body.currentPassword) !== true) {
         return res.fail({
           status: HttpStatusCode.UNAUTHORIZED_401,
-          message: req.t('currentPassword is invalid.'),
+          message: req.t('Current password is incorrect.'),
           type: ServerErrorCode.CURRENT_PASSWORD_IS_INVALID
         })
       }
@@ -471,10 +472,22 @@ export const usersCheckCurrentPasswordFactory = (targetUserIdGetter: (req: expre
         })
       }
 
+      if (user.pluginAuth) {
+        if (await isExternalUserPasswordValid({ user, password: req.body.currentPassword }) !== true) {
+          return res.fail({
+            status: HttpStatusCode.FORBIDDEN_403,
+            message: req.t('Current password is incorrect.'),
+            type: ServerErrorCode.CURRENT_PASSWORD_IS_INVALID
+          })
+        }
+
+        return next()
+      }
+
       if (await user.isPasswordMatch(req.body.currentPassword) !== true) {
         return res.fail({
           status: HttpStatusCode.FORBIDDEN_403,
-          message: 'currentPassword is invalid.',
+          message: req.t('Current password is incorrect.'),
           type: ServerErrorCode.CURRENT_PASSWORD_IS_INVALID
         })
       }


### PR DESCRIPTION
## Description

  This PR allows users authenticated through LDAP to enable and use two-factor authentication.

  Previously, LDAP users could not enable 2FA because PeerTube only validated a locally stored password. This change
  re-authenticates LDAP users through their authentication plugin before enabling or disabling 2FA.

  It also ensures LDAP logins require a valid OTP after 2FA is enabled, and makes the invalid-password message clearer
  in the UI.

## Related issues

NA

## Has this been tested?

<!-- Put an `x` in the box that applies: -->
<!-- Check the unit test guide: https://docs.joinpeertube.org/contribute/getting-started#unit-integration-tests -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots
Short Video demo for the full flow 

https://github.com/user-attachments/assets/7926ac92-9aa1-4515-9a50-373e18a8ba12

Closes #7691 