### PR TITLE
Document rates_limit enabled option in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
  * Add explicit Redis socket configuration in `redis.socket` to provide the redis socket path
  * Add `user.allow_cross_provider_auth` configuration to support multiple auth plugins for the same PeerTube user [#7655](https://github.com/Chocobozzz/PeerTube/pull/7655)
  * Add opt-in configuration to automatically add the username and HTTP request id as tags in the log file: `log.tag_requests`
+ * Add `enabled` configuration to every `rates_limit` section, so a specific rate limiter can be disabled [#6089](https://github.com/Chocobozzz/PeerTube/issues/6089)
 
 ### Plugins/Themes/Embed API
 


### PR DESCRIPTION
### Summary

The per-section `enabled` flag for rate limiters landed in 8.3 but is not listed in the release notes, so admins hitting the problem have no way to discover it.

This adds a single line to the `Configuration` section of the v8.3.0-rc.1 changelog.

### Context

`rates_limit.*.enabled` resolves #6089, where an admin could not fully disable rate limiting: since express-rate-limit v7 a `max` of `0` blocks every request instead of disabling the limiter, so the only workaround was a large `max` on a short `window`.

`buildRateLimiter` now short-circuits to a pass-through middleware when the flag is false:

https://github.com/Chocobozzz/PeerTube/blob/develop/server/core/middlewares/rate-limiter.ts#L22-L24

All 15 rate limiters pass the flag through, and every section has it in `config/production.yaml.example`.