### PR TITLE
Add ability to disable audit logs

### DIFF
--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -988,6 +988,17 @@
           },
           "additionalProperties": false
         },
+        "audit": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Log administration and moderation actions in a dedicated audit log file",
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
         "anonymize_ip": {
           "type": "boolean",
           "default": false

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -297,6 +297,9 @@ log:
     max_file_size: 12MB
     max_files: 20
 
+  audit:
+    enabled: true # Log administration and moderation actions in a dedicated audit log file
+
   anonymize_ip: false
 
   # Tag every log line produced while handling a request with a request id, and with the authenticated user's username

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -295,6 +295,9 @@ log:
     max_file_size: 12MB
     max_files: 20
 
+  audit:
+    enabled: true # Log administration and moderation actions in a dedicated audit log file
+
   anonymize_ip: false
 
   # Tag every log line produced while handling a request with a request id, and with the authenticated user's username

--- a/packages/tests/src/api/server/logs.ts
+++ b/packages/tests/src/api/server/logs.ts
@@ -217,6 +217,23 @@ describe('Test logs', function () {
       expect(logsString.includes('video 10')).to.be.true
       expect(logsString.includes('video 11')).to.be.false
     })
+
+    it('Should not log audit entries when the audit log is disabled', async function () {
+      this.timeout(60000)
+
+      await killallServers([ server ])
+
+      await server.run({ log: { audit: { enabled: false } } })
+
+      const now = new Date()
+
+      await server.videos.upload({ attributes: { name: 'video 12' } })
+      await waitJobs([ server ])
+
+      const body = await logsCommand.getAuditLogs({ startDate: now })
+
+      expect(body).to.have.lengthOf(0)
+    })
   })
 
   describe('When creating log from the client', function () {

--- a/server/core/helpers/audit-logger.ts
+++ b/server/core/helpers/audit-logger.ts
@@ -58,6 +58,8 @@ const auditLogger = createLogger({
 })
 
 function auditLoggerWrapper (domain: string, user: string, action: AUDIT_TYPE, entity: EntityAuditView, oldEntity: EntityAuditView = null) {
+  if (CONFIG.LOG.AUDIT.ENABLED !== true) return
+
   let entityInfos: object
 
   if (action === AUDIT_TYPE.UPDATE && oldEntity) {

--- a/server/core/initializers/checker-before-init.ts
+++ b/server/core/initializers/checker-before-init.ts
@@ -56,6 +56,7 @@ export function checkMissedConfig () {
     'log.rotation.enabled',
     'log.rotation.max_file_size',
     'log.rotation.max_files',
+    'log.audit.enabled',
     'log.anonymize_ip',
     'log.tag_requests',
     'log.log_ping_requests',

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -533,6 +533,9 @@ const CONFIG = {
       MAX_FILE_SIZE: bytes.parse(config.get<string>('log.rotation.max_file_size')),
       MAX_FILES: config.get<number>('log.rotation.max_files')
     },
+    AUDIT: {
+      ENABLED: config.get<boolean>('log.audit.enabled')
+    },
     ANONYMIZE_IP: config.get<boolean>('log.anonymize_ip'),
     TAG_REQUESTS: config.get<boolean>('log.tag_requests'),
     LOG_PING_REQUESTS: config.get<boolean>('log.log_ping_requests'),


### PR DESCRIPTION
### Summary

Adds a `log.audit.enabled` configuration option so admins can turn off the audit log, as requested in #2686.

```yaml
log:
  audit:
    enabled: true # Log administration and moderation actions in a dedicated audit log file
```

It mirrors the existing `log.rotation.enabled` shape directly above it in the same section.

### Relation to #6004

@wickloww previously attempted this in #6004, which you closed for inactivity in Feb 2024 saying it could be reopened. I picked up the config-only part of it. Your review there asked for the option to live in the existing `log:` section and to be added to `production.yaml.example` too, so this PR does both. `log.audit.enabled` is also registered in `checker-before-init.ts` alongside the other `log.*` keys, as that PR did.

The one thing I deliberately left out is the admin-panel toggle that #6004 also added. #2686 asks for a config-file option, so this is the smaller change; the runtime toggle can follow separately if you want it.

**One open question from your review of #6004:** you asked for a 403 when audit logs are disabled. This PR only stops audit entries being *written* — reading previously written audit logs still works, so an admin who disables the feature can still consult history. If you would rather the read endpoint 403 as well, say so and I will add it.

### Implementation

The guard is in `auditLoggerWrapper`, the single function that `create`, `update` and `delete` all route through, so none of the 13 `auditLoggerFactory` consumers need to change:

```ts
function auditLoggerWrapper (domain, user, action, entity, oldEntity = null) {
  if (CONFIG.LOG.AUDIT.ENABLED !== true) return
```

`config/config-schema.json` was regenerated with `pnpm run generate-config-schema` rather than edited by hand, since the schema uses `additionalProperties: false`.

### Testing

Added one case to the existing `With the audit log` block in `packages/tests/src/api/server/logs.ts`, following the `Should not log ping/HTTP requests` pattern: restart with the option off, upload a video, assert no audit entry is produced. This is the "check the audit log doesn't contain your upload" half of what you asked for on #6004. It is placed last in that block because it restarts the server with a different config.

Verified locally:

- `pnpm run validate-config-schema` — OK for `config/default.yaml` and the Docker production config
- `tsc -b server/tsconfig.json` and `tsc -b packages/tests/tsconfig.json` — clean
- `oxlint` on the touched files — clean

I did not run the API test suite locally as it needs a live PostgreSQL/Redis/ffmpeg stack.

I targeted `develop` rather than `release/v8.3.x` since this adds a configuration option; happy to retarget if you would rather it went into 8.3.

Closes #2686