### PR TITLE
Add ability to customize the video redundancy timeout

### DIFF
--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -1143,6 +1143,11 @@
               "type": "string",
               "default": "1 hour"
             },
+            "timeout": {
+              "description": "Maximum duration of a video mirror, mainly useful for big videos on slow connections",
+              "type": "string",
+              "default": "3 hours"
+            },
             "strategies": {
               "description": "Just uncomment strategies you want",
               "type": [

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -358,6 +358,7 @@ trending:
 redundancy:
   videos:
     check_interval: '1 hour' # How often you want to check new videos to cache
+    timeout: '3 hours' # Maximum duration of a video mirror, mainly useful for big videos on slow connections
     strategies: # Just uncomment strategies you want
 #      -
 #        size: '10GB'

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -356,6 +356,7 @@ trending:
 redundancy:
   videos:
     check_interval: '1 hour' # How often you want to check new videos to cache
+    timeout: '3 hours' # Maximum duration of a video mirror, mainly useful for big videos on slow connections
     strategies: # Just uncomment strategies you want
 #      -
 #        size: '10GB'

--- a/server/core/initializers/checker-before-init.ts
+++ b/server/core/initializers/checker-before-init.ts
@@ -91,6 +91,7 @@ export function checkMissedConfig () {
     'signup.filters.cidr.blacklist',
     'redundancy.videos.strategies',
     'redundancy.videos.check_interval',
+    'redundancy.videos.timeout',
     'transcoding.enabled',
     'transcoding.original_file.keep',
     'transcoding.threads',

--- a/server/core/initializers/config.ts
+++ b/server/core/initializers/config.ts
@@ -580,6 +580,7 @@ const CONFIG = {
   REDUNDANCY: {
     VIDEOS: {
       CHECK_INTERVAL: parseDurationToMs(config.get<string>('redundancy.videos.check_interval')),
+      TIMEOUT: parseDurationToMs(config.get<string>('redundancy.videos.timeout')),
       STRATEGIES: buildVideosRedundancy(config.get<any[]>('redundancy.videos.strategies'))
     }
   },

--- a/server/core/initializers/constants.ts
+++ b/server/core/initializers/constants.ts
@@ -309,7 +309,7 @@ export const JOB_TTL: { [id in JobType]: number } = {
   'actor-keys': 60000 * 20, // 20 minutes
   'videos-stats': undefined, // Unlimited
   'activitypub-refresher': 60000 * 10, // 10 minutes
-  'video-redundancy': 1000 * 3600 * 3, // 3 hours
+  'video-redundancy': CONFIG.REDUNDANCY.VIDEOS.TIMEOUT,
   'video-live-ending': 1000 * 60 * 10, // 10 minutes
   'generate-video-storyboard': 1000 * 3600 * 6, // 6 hours
   'manage-video-torrent': 1000 * 3600 * 3, // 3 hours
@@ -358,6 +358,7 @@ export const JOB_REMOVAL_OPTIONS = {
 }
 
 export const VIDEO_IMPORT_TIMEOUT = Math.floor(JOB_TTL['video-import'] * 0.9)
+export const VIDEO_REDUNDANCY_TIMEOUT = Math.floor(JOB_TTL['video-redundancy'] * 0.9)
 
 export const RUNNER_JOBS = {
   MAX_FAILURES: 5,

--- a/server/core/lib/schedulers/videos-redundancy-scheduler.ts
+++ b/server/core/lib/schedulers/videos-redundancy-scheduler.ts
@@ -12,7 +12,7 @@ import {
 import { join } from 'path'
 import { createLogger } from '../../helpers/logger.js'
 import { CONFIG } from '../../initializers/config.js'
-import { DIRECTORIES, REDUNDANCY, VIDEO_IMPORT_TIMEOUT } from '../../initializers/constants.js'
+import { DIRECTORIES, REDUNDANCY, VIDEO_REDUNDANCY_TIMEOUT } from '../../initializers/constants.js'
 import { VideoRedundancyModel } from '../../models/redundancy/video-redundancy.js'
 import { sendCreateCacheFile, sendUpdateCacheFile } from '../activitypub/send/index.js'
 import { getLocalVideoCacheStreamingPlaylistActivityPubUrl } from '../activitypub/url.js'
@@ -223,7 +223,7 @@ export class VideosRedundancyScheduler extends AbstractScheduler {
 
     const maxSizeKB = this.getTotalFileSizes([ playlist ]) / 1000
     const toleranceKB = maxSizeKB + ((5 * maxSizeKB) / 100) // 5% more tolerance
-    await downloadPlaylistSegments(masterPlaylistUrl, destDirectory, VIDEO_IMPORT_TIMEOUT, toleranceKB)
+    await downloadPlaylistSegments(masterPlaylistUrl, destDirectory, VIDEO_REDUNDANCY_TIMEOUT, toleranceKB)
 
     const createdModel: MVideoRedundancyStreamingPlaylistVideo = await VideoRedundancyModel.create({
       expiresOn,


### PR DESCRIPTION
### Summary

Adds `redundancy.videos.timeout` so a mirror of a large video can be given more time, as you retitled #5519 to ask for.

```yaml
redundancy:
  videos:
    check_interval: '1 hour'
    timeout: '3 hours' # Maximum duration of a video mirror, mainly useful for big videos on slow connections
```

### Why two things had to change

Mirroring was capped twice, and neither cap was configurable:

1. `JOB_TTL['video-redundancy']` was hardcoded to `1000 * 3600 * 3`. This is the cap the reporter hit: their job ran 12:11:46 to 15:11:46, exactly 3 hours, and failed with a bare `Error: Timeout`.
2. `createStreamingPlaylistRedundancy` passed `VIDEO_IMPORT_TIMEOUT` to `downloadPlaylistSegments`, which applies it as a single budget for the whole download rather than per segment. That value is `0.9 * import.videos.timeout`, so the HLS mirror was governed by the *video import* setting: 1.8h at defaults, i.e. tighter than the job TTL.

So raising only one of them would not help, and an admin raising `import.videos.timeout` to make mirroring work would silently change video import behaviour too.

Both now derive from the new option, following the existing `import.videos.timeout` -> `JOB_TTL['video-import']` -> `VIDEO_IMPORT_TIMEOUT` pattern:

```ts
'video-redundancy': CONFIG.REDUNDANCY.VIDEOS.TIMEOUT,
export const VIDEO_REDUNDANCY_TIMEOUT = Math.floor(JOB_TTL['video-redundancy'] * 0.9)
```

### Effect at default config

| | before | after |
| --- | --- | --- |
| `video-redundancy` job TTL | 3.00h, hardcoded | 3.00h, from config |
| HLS download budget | 1.80h, from `import.videos.timeout` | 2.70h, from `redundancy.videos.timeout` |
| `VIDEO_IMPORT_TIMEOUT` | 1.80h | 1.80h, unchanged |

The job TTL default is unchanged. The download budget now sits just under the job TTL instead of being controlled by an unrelated setting, so the download fails with `HLS download timeout.` rather than the job being cancelled first, and both scale together when the option is raised.

I picked `'3 hours'` to keep the job TTL exactly as it is today. That does loosen the effective download budget from 1.8h to 2.7h. `'2 hours'` would track today's real-world behaviour more closely but would shorten the job cap, so I went with the one that matches the intent of the issue. Happy to change it.

### Verification

- `pnpm run validate-config-schema` — OK for `config/default.yaml` and the Docker production config
- `config/config-schema.json` regenerated with `pnpm run generate-config-schema`, not hand-edited
- `tsc -b server/tsconfig.json` — clean
- `oxlint` on the touched files — clean
- Checked at runtime that the values resolve through `CONFIG` into `constants.ts` (`constants.ts` reads `CONFIG` at module load, as it already does for `video-import`), producing the table above
- `redundancy.videos.timeout` registered in `checker-before-init.ts` alongside `redundancy.videos.check_interval`

I did not add an automated test: the behaviour is a multi-hour timeout, so a test would either not exercise it or need the constants stubbed. Happy to add one if you have a preferred shape.

Targeted `develop` since it adds a configuration option; happy to retarget to `release/v8.3.x`.

Closes #5519