### PR TITLE
Document how to reinstall a plugin during development

### DIFF
--- a/support/doc/plugins/guide.md
+++ b/support/doc/plugins/guide.md
@@ -1213,7 +1213,7 @@ You built files are in the `dist/` directory. Check `package.json` to correctly 
 You need to have a local PeerTube instance with an administrator account.
 If you're using dev server on your local computer, test your plugin on `localhost:9000` using `npm run dev` because plugin CSS is not injected in Angular webserver (`localhost:3000`).
 
-Install PeerTube CLI (can be installed on another computer/server than the PeerTube instance):
+Install [PeerTube CLI](https://docs.joinpeertube.org/maintain/tools) (can be installed on another computer/server than the PeerTube instance):
 
 ```bash
 npm install -g @peertube/peertube-cli
@@ -1232,6 +1232,16 @@ If the PeerTube instance is running on another server/computer, you must copy yo
 ```sh
 peertube-cli plugins install --path /your/absolute/plugin-or-theme/path
 ```
+
+`plugins install` copies the directory into the instance plugin storage instead of linking to it,
+so rebuilding your plugin/theme afterwards does not change what the instance runs.
+To load a new build, update the `version` key in your `package.json` and reinstall it:
+
+```sh
+peertube-cli plugins update --path /your/absolute/plugin-or-theme/path
+```
+
+Reusing the same version reinstalls the copy the instance already has, so your changes look like they were ignored.
 
 ### Publish
 


### PR DESCRIPTION
## Description

Fixes #7765.

The plugin development guide tells you to install a local plugin with `peertube-cli plugins install --path …`, but not what to do next time you rebuild it. Re-running the same command reinstalls the plugin the instance already has, so it looks like the new code is being ignored — which is what @matthijskooijman ran into.

The cause is that `installNpmPluginFromDisk` runs `pnpm add file:<path>` (`server/core/lib/plugins/package-manager.ts:28`), which copies the directory into the plugin storage rather than linking to it, and `install()` records `packageJSON.version` on the plugin row. So editing the source has no effect until the plugin is reinstalled under a new version.

`peertube-cli plugins update --path` already exists for exactly this, but the plugin guide never mentions it — the section only documents `install`. This adds that command, explains why rebuilding alone does nothing, and links the CLI tools guide from the section, since the second half of the issue was that the CLI docs were hard to find from here.

No behaviour change, documentation only.

## Related issues

#7765

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this PR does not update server code
- [ ] 🙋 no, because I need help
